### PR TITLE
Backport history font selection fix

### DIFF
--- a/Assets.Scripts.Core.History/HistoryTextButton.cs
+++ b/Assets.Scripts.Core.History/HistoryTextButton.cs
@@ -10,6 +10,15 @@ namespace Assets.Scripts.Core.History
 
 		private TextMeshPro textMesh;
 
+		public TextMeshPro GetTextMesh()
+		{
+			if (textMesh == null)
+			{
+				textMesh = GetComponent<TextMeshPro>();
+			}
+			return textMesh;
+		}
+
 		private void OnHover(bool isHover)
 		{
 		}

--- a/Assets.Scripts.Core.History/HistoryWindow.cs
+++ b/Assets.Scripts.Core.History/HistoryWindow.cs
@@ -109,9 +109,11 @@ namespace Assets.Scripts.Core.History
 			lastStep = Slider.numberOfSteps;
 			stepsize = 1f / (float)lastStep;
 			textButtons = new HistoryTextButton[5];
+			TextMeshProFont currentFont = GameSystem.Instance.MainUIController.GetCurrentFont();
 			for (int i = 0; i < 5; i++)
 			{
 				textButtons[i] = Labels[i].gameObject.GetComponent<HistoryTextButton>();
+				textButtons[i].GetTextMesh().font = currentFont;
 			}
 			FillText();
 			HistoryTextButton[] array = textButtons;

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -320,6 +320,21 @@ namespace Assets.Scripts.UI
 			textContainer.margins.Set((float)left, (float)top, (float)right, (float)bottom);
 		}
 
+		public TextMeshProFont GetEnglishFont()
+		{
+			return Resources.Load<TextMeshProFont>(FontList[altFontId]);
+		}
+
+		public TextMeshProFont GetJapaneseFont()
+		{
+			return Resources.Load<TextMeshProFont>(FontList[0]);
+		}
+
+		public TextMeshProFont GetCurrentFont()
+		{
+			return TextWindow.font;
+		}
+
 		public void ChangeFontId(int id)
 		{
 			altFontId = id;


### PR DESCRIPTION
Games after Onikakushi select the correct font for the text history view based on the language of the text, while Onikakushi always selects the English font.  By backporting this, we no longer have to make sure that the English font has the full set of kanji that the Japanese script uses.