### PR TITLE
Allow scripts to change font size of config menu

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -134,6 +134,7 @@ namespace Assets.Scripts.Core.Buriko
 		ModDrawCharacter,
 		ModDrawCharacterWithFiltering,
 		ModPlayVoiceLS,
-		ModPlayMovie
+		ModPlayMovie,
+		ModSetConfigFontSize
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2149,6 +2149,8 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODPlayVoiceLS();
 			case BurikoOperations.ModPlayMovie:
 				return OperationMODPlayMovie();
+			case BurikoOperations.ModSetConfigFontSize:
+				return OperationMODSetConfigFontSize();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;
@@ -2491,6 +2493,14 @@ namespace Assets.Scripts.Core.Buriko
 			string moviename = ReadVariable().StringValue();
 			GameSystem.Instance.PushStateObject(new StateMovie(moviename));
 			gameSystem.ExecuteActions();
+			return BurikoVariable.Null;
+		}
+
+		private BurikoVariable OperationMODSetConfigFontSize()
+		{
+			SetOperationType("MODSetConfigFontSize");
+			int size = ReadVariable().IntValue();
+			GameSystem.Instance.ConfigMenuFontSize = size;
 			return BurikoVariable.Null;
 		}
 	}

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -164,6 +164,8 @@ namespace Assets.Scripts.Core
 
 		public float AspectRatio;
 
+		public float ConfigMenuFontSize = 0;
+
 		public static GameSystem Instance => _instance ?? (_instance = GameObject.Find("_GameSystem").GetComponent<GameSystem>());
 
 		public GameState GameState

--- a/Assets.Scripts.UI.Config/ConfigManager.cs
+++ b/Assets.Scripts.UI.Config/ConfigManager.cs
@@ -56,6 +56,13 @@ namespace Assets.Scripts.UI.Config
 			GameSystem.Instance.MainUIController.FadeOut(0.3f, isBlocking: false);
 			GameSystem.Instance.SceneController.HideFace(0.3f);
 			GameSystem.Instance.ExecuteActions();
+			if (GameSystem.Instance.ConfigMenuFontSize > 0)
+			{
+				foreach (TextRefresher text in Panel.GetComponentsInChildren<TextRefresher>())
+				{
+					text.SetFontSize(GameSystem.Instance.ConfigMenuFontSize);
+				}
+			}
 		}
 
 		public void Open(int screen, bool msgWindow)

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -163,6 +163,7 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModDrawCharacterWithFiltering", new OpType(BurikoOperations.ModDrawCharacterWithFiltering, "iisssiiibiiiiiiib"));
 			paramLookup.Add("ModPlayVoiceLS", new OpType(BurikoOperations.ModPlayVoiceLS, "iisib"));
 			paramLookup.Add("ModPlayMovie", new OpType(BurikoOperations.ModPlayMovie, "s"));
+			paramLookup.Add("ModSetConfigFontSize", new OpType(BurikoOperations.ModSetConfigFontSize, "i"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/TextRefresher.cs
+++ b/TextRefresher.cs
@@ -23,6 +23,13 @@ public class TextRefresher : MonoBehaviour
 		if (textMesh != null)
 		{
 			textMesh.text = ((!language) ? Japanese : English);
+			// Game places the main menu at y +2, which puts them a bit too high in their boxes.
+			if (System.Math.Abs(textMesh.transform.localPosition.y - 2f) < 0.1)
+			{
+				Vector3 localPosition = textMesh.transform.localPosition;
+				localPosition.y = 1f;
+				textMesh.transform.localPosition = localPosition;
+			}
 		}
 		else
 		{
@@ -58,5 +65,11 @@ public class TextRefresher : MonoBehaviour
 			language = GameSystem.Instance.UseEnglishText;
 			UpdateText();
 		}
+	}
+
+	public void SetFontSize(float size)
+	{
+		if (textMesh == null) { return; }
+		textMesh.fontSize = size;
 	}
 }


### PR DESCRIPTION
If a new font or language causes the text of one of the config buttons to go outside of its border, you can now call ModSetConfigFontSize in init.txt to shrink the font.  Onikakushi default is 18.

@enumag I think this and the Onikakushi history font fix PR is the last change we need to allow easy customization of the `msgothic_2` font