### PR TITLE
Allow custom chapter jumps in JSON

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -233,6 +233,7 @@
     <Compile Include="MOD.Scripts.Core.State\StateMovie.cs" />
     <Compile Include="MOD.Scripts.Core.TextWindow\MODTextController.cs" />
     <Compile Include="MOD.Scripts.Core\MODSystem.cs" />
+    <Compile Include="MOD.Scripts.UI.ChapterJump\MODChapterJumpController.cs" />
     <Compile Include="MOD.Scripts.UI.Tips\MODTipsController.cs" />
     <Compile Include="MOD.Scripts.UI\MODMainUIController.cs" />
     <Compile Include="Newtonsoft.Json.Bson\BsonArray.cs" />

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -48,6 +48,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GFlag_GameClear", 1);
 			variableReference.Add("GQsaveNum", 2);
 			variableReference.Add("GOnikakushiDay", 3);
+			variableReference.Add("GHighestChapter", 3); // For consistency between chapters
 			variableReference.Add("GMessageSpeed", 10);
 			variableReference.Add("GAutoSpeed", 11);
 			variableReference.Add("GAutoAdvSpeed", 12);
@@ -101,6 +102,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GMOD_DEBUG_MODE", 521);
 			variableReference.Add("GLipSync", 522);
 			variableReference.Add("GVideoOpening", 523);
+			// 601 - 609 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);
 			SetGlobalFlag("GAutoAdvSpeed", 50);
@@ -198,20 +200,40 @@ namespace Assets.Scripts.Core.Buriko
 			}
 		}
 
-		public void SetGlobalFlag(string flagname, int val)
+		public void SetGlobalFlag(int key, int val)
 		{
-			if (!variableReference.TryGetValue(flagname, out int value))
+			if (!globalFlags.ContainsKey(key))
 			{
-				throw new Exception("Unable to set flag with the name " + flagname + ", flag not found.");
-			}
-			if (!globalFlags.ContainsKey(value))
-			{
-				globalFlags.Add(value, val);
+				globalFlags.Add(key, val);
 			}
 			else
 			{
-				globalFlags[value] = val;
+				globalFlags[key] = val;
 			}
+		}
+
+		public void SetGlobalFlag(string flagname, int val)
+		{
+			if (!variableReference.TryGetValue(flagname, out int key))
+			{
+				throw new Exception("Unable to set flag with the name " + flagname + ", flag not found.");
+			}
+			SetGlobalFlag(key, val);
+		}
+
+		public void SetHighestChapterFlag(int arcNumber, int number)
+		{
+			if (arcNumber < 0 || arcNumber >= 10)
+			{
+				throw new Exception("Attempted to set highest chapter for chapter " + arcNumber + ", only 0-9 are allowed.");
+			}
+			if (arcNumber == 0)
+			{
+				SetGlobalFlag("GHighestChapter", number);
+				return;
+			}
+			int target = arcNumber + 600;
+			SetGlobalFlag(target, number);
 		}
 
 		public bool IsFlag(string name)
@@ -232,17 +254,41 @@ namespace Assets.Scripts.Core.Buriko
 			return new BurikoVariable(flags[value]);
 		}
 
+		private BurikoVariable GetGlobalFlag(int key)
+		{
+			if (!globalFlags.ContainsKey(key))
+			{
+				return new BurikoVariable(0);
+			}
+			return new BurikoVariable(globalFlags[key]);
+		}
+
 		public BurikoVariable GetGlobalFlag(string flagname)
 		{
 			if (!variableReference.TryGetValue(flagname, out int value))
 			{
 				throw new Exception("Unable to get global flag with the name " + flagname + ", flag not found.");
 			}
-			if (!globalFlags.ContainsKey(value))
+			return GetGlobalFlag(value);
+		}
+
+		public BurikoVariable GetHighestChapterFlag(int arcNumber)
+		{
+			if (arcNumber < 0 || arcNumber >= 10)
 			{
-				return new BurikoVariable(0);
+				throw new Exception("Attempted to set highest chapter for chapter " + arcNumber + ", only 0-9 are allowed.");
 			}
-			return new BurikoVariable(globalFlags[value]);
+			if (arcNumber == 0)
+			{
+				return GetGlobalFlag("GHighestChapter");
+			}
+			int target = arcNumber + 600;
+			return GetGlobalFlag(target);
+		}
+
+		public int[] GetHighestChapterFlags()
+		{
+			return Enumerable.Range(0, 10).Select( arc => GetHighestChapterFlag(arc).IntValue() ).ToArray();
 		}
 
 		public void MarkLineAsRead(string scriptname, int line)

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -102,7 +102,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GMOD_DEBUG_MODE", 521);
 			variableReference.Add("GLipSync", 522);
 			variableReference.Add("GVideoOpening", 523);
-			// 601 - 609 used for additional chapter progress info
+			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);
 			SetGlobalFlag("GAutoAdvSpeed", 50);
@@ -232,7 +232,7 @@ namespace Assets.Scripts.Core.Buriko
 				SetGlobalFlag("GHighestChapter", number);
 				return;
 			}
-			int target = arcNumber + 600;
+			int target = arcNumber + 610;
 			SetGlobalFlag(target, number);
 		}
 
@@ -282,7 +282,7 @@ namespace Assets.Scripts.Core.Buriko
 			{
 				return GetGlobalFlag("GHighestChapter");
 			}
-			int target = arcNumber + 600;
+			int target = arcNumber + 610;
 			return GetGlobalFlag(target);
 		}
 

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -136,6 +136,8 @@ namespace Assets.Scripts.Core.Buriko
 		ModPlayVoiceLS,
 		ModPlayMovie,
 		ModSetConfigFontSize,
-		ModSetChapterJumpFontSize
+		ModSetChapterJumpFontSize,
+		ModSetHighestChapterFlag,
+		ModGetHighestChapterFlag
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2153,6 +2153,10 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODSetConfigFontSize();
 			case BurikoOperations.ModSetChapterJumpFontSize:
 				return OperationMODSetChapterJumpFontSize();
+			case BurikoOperations.ModSetHighestChapterFlag:
+				return OperationMODSetHighestChapterFlag();
+			case BurikoOperations.ModGetHighestChapterFlag:
+				return OperationMODGetHighestChapterFlag();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;
@@ -2513,6 +2517,22 @@ namespace Assets.Scripts.Core.Buriko
 			int english = ReadVariable().IntValue();
 			GameSystem.Instance.SetChapterJumpFontSize(japanese, english);
 			return BurikoVariable.Null;
+		}
+
+		private BurikoVariable OperationMODSetHighestChapterFlag()
+		{
+			SetOperationType("MODSetHighestChapterFlag");
+			int key = ReadVariable().IntValue();
+			int value = ReadVariable().IntValue();
+			BurikoMemory.Instance.SetHighestChapterFlag(key, value);
+			return BurikoVariable.Null;
+		}
+
+		private BurikoVariable OperationMODGetHighestChapterFlag()
+		{
+			SetOperationType("MODGetHighestChapterFlag");
+			int key = ReadVariable().IntValue();
+			return BurikoMemory.Instance.GetHighestChapterFlag(key);
 		}
 	}
 }

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpButton.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpButton.cs
@@ -83,6 +83,11 @@ namespace Assets.Scripts.UI.ChapterJump
 			}
 		}
 
+		public void UpdateTextAndActive()
+		{
+			Start();
+		}
+
 		public bool IsChapterButton => name != "Return";
 
 		public void SetFontSize(float size)

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpButton.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpButton.cs
@@ -3,6 +3,7 @@ using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
 using TMPro;
 using UnityEngine;
+using static MOD.Scripts.UI.ChapterJump.MODChapterJumpController;
 
 namespace Assets.Scripts.UI.ChapterJump
 {
@@ -21,6 +22,9 @@ namespace Assets.Scripts.UI.ChapterJump
 		public int ChapterNumber;
 
 		public string BlockName;
+
+		private int ArcNumber = 0;
+		private string FileName = null;
 
 		private TextMeshPro _text = null;
 		public TextMeshPro Text
@@ -53,7 +57,14 @@ namespace Assets.Scripts.UI.ChapterJump
 					stateChapterJump.RequestLeave();
 					if (!(base.name == "Return"))
 					{
-						BurikoScriptSystem.Instance.JumpToBlock(BlockName);
+						if (FileName != null)
+						{
+							BurikoScriptSystem.Instance.JumpToScript(scriptname: FileName, blockname: BlockName);
+						}
+						else
+						{
+							BurikoScriptSystem.Instance.JumpToBlock(BlockName);
+						}
 					}
 				}
 			}
@@ -77,9 +88,11 @@ namespace Assets.Scripts.UI.ChapterJump
 		private void Start()
 		{
 			Text.text = GameSystem.Instance.ChooseJapaneseEnglish(japanese: Japanese, english: English);
-			if (!(base.name == "Return") && !BurikoMemory.Instance.GetGlobalFlag("GFlag_GameClear").BoolValue() && BurikoMemory.Instance.GetGlobalFlag("GOnikakushiDay").IntValue() < ChapterNumber)
+			if (!(base.name == "Return")
+			    && !BurikoMemory.Instance.GetGlobalFlag("GFlag_GameClear").BoolValue()
+			    && BurikoMemory.Instance.GetHighestChapterFlag(ArcNumber).IntValue() < ChapterNumber)
 			{
-				base.gameObject.SetActive(value: false);
+				base.gameObject.SetActive(false);
 			}
 		}
 
@@ -97,6 +110,17 @@ namespace Assets.Scripts.UI.ChapterJump
 
 		private void LateUpdate()
 		{
+		}
+
+		public void UpdateFromChapterJumpEntry(ChapterJumpEntry entry)
+		{
+			English = entry.English;
+			Japanese = entry.Japanese;
+			ChapterNumber = entry.ChapterNumber;
+			BlockName = entry.BlockName;
+			FileName = entry.FileName;
+			ArcNumber = entry.ArcNumber;
+			UpdateTextAndActive();
 		}
 	}
 }

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
@@ -58,16 +58,18 @@ namespace Assets.Scripts.UI.ChapterJump
 				List<ChapterJumpButton> newButtons = new List<ChapterJumpButton>();
 				foreach (var entry in MODChapterJumpController.ChapterJumpsOrNull)
 				{
+
 					var newButtonObject = Instantiate(baseButton.gameObject);
 					newButtonObject.transform.SetParent(baseButton.gameObject.transform.parent, worldPositionStays: false);
 					newButtonObject.transform.localPosition = position;
 					ChapterJumpButton newButton = newButtonObject.GetComponent<ChapterJumpButton>();
 
-					newButton.English = entry.English;
-					newButton.Japanese = entry.Japanese;
-					newButton.ChapterNumber = entry.ChapterNumber;
-					newButton.BlockName = entry.BlockName;
-					newButton.UpdateTextAndActive();
+					newButton.UpdateFromChapterJumpEntry(entry);
+					if (!newButton.isActiveAndEnabled)
+					{
+						Destroy(newButton);
+						continue;
+					}
 
 					newButtons.Add(newButton);
 

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
@@ -54,6 +54,11 @@ namespace Assets.Scripts.UI.ChapterJump
 			if (MODChapterJumpController.ChapterJumpsOrNull != null)
 			{
 				var baseButton = JumpButtons[0];
+
+				// Copied from Onikakushi
+				// Himatsubushi has less options so they moved the object down further, which messes up positioning
+				baseButton.transform.parent.localPosition = new Vector3(-215.0f, 223.0f, 0.0f);
+
 				var position = new Vector3(0, 0, 0);
 				List<ChapterJumpButton> newButtons = new List<ChapterJumpButton>();
 				foreach (var entry in MODChapterJumpController.ChapterJumpsOrNull)

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
@@ -98,13 +98,14 @@ namespace Assets.Scripts.UI.ChapterJump
 			var tipsManager = gameSystem.TipsPrefab.GetComponent<Tips.TipsManager>();
 
 			// Steal buttons from tips manager
-			var leftButton = Instantiate(tipsManager.PageLeft);
+			var leftButton = Instantiate(tipsManager.PageLeft.gameObject);
 			leftButton.transform.SetParent(returnButton.gameObject.transform.parent, worldPositionStays: false);
 			PageLeft = leftButton.GetComponent<UIButton>();
-			var rightButton = Instantiate(tipsManager.PageRight);
+			var rightButton = Instantiate(tipsManager.PageRight.gameObject);
 			rightButton.transform.SetParent(returnButton.gameObject.transform.parent, worldPositionStays: false);
 			PageRight = rightButton.GetComponent<UIButton>();
-			var pageNumberText = Instantiate(tipsManager.tipsPageText);
+			var pageNumberText = Instantiate(returnButton.gameObject);
+			Destroy(pageNumberText.GetComponent<ChapterJumpButton>());
 			pageNumberText.transform.SetParent(returnButton.gameObject.transform.parent, worldPositionStays: false);
 			PageNumberText = pageNumberText.GetComponent<TextMeshPro>();
 

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 using MOD.Scripts.UI.ChapterJump;
+using TMPro;
 
 namespace Assets.Scripts.UI.ChapterJump
 {
@@ -17,6 +18,15 @@ namespace Assets.Scripts.UI.ChapterJump
 		public List<ChapterJumpButton> JumpButtons;
 
 		public bool isActive = true;
+
+		private List<List<ChapterJumpButton>> allButtons;
+		private int currentPage = 0;
+		private int NumPages => allButtons.Count();
+		private List<ChapterJumpButton> CurrentButtons => allButtons[currentPage];
+		private UIButton PageLeft;
+		private UIButton PageRight;
+		private TextMeshPro PageNumberText;
+		private ChapterJumpButton returnButton;
 
 		private bool relayoutDone = false;
 		private static readonly float windowStartPos = 0;
@@ -33,10 +43,20 @@ namespace Assets.Scripts.UI.ChapterJump
 		private static readonly float minYPos = -330;
 		private static readonly float ySpacing = 30;
 
-		private void PopulateJumpButtonList() 
+		private void PopulateJumpButtonList()
 		{
-			// For some reason `JumpButtons` is empty on load and nothing seems to populate it
-			JumpButtons = GetComponentsInChildren<ChapterJumpButton>().Where( button => button.IsChapterButton ).ToList();
+			var childComponents = GetComponentsInChildren<ChapterJumpButton>();
+			if (allButtons == null)
+			{
+				allButtons = new List<List<ChapterJumpButton>>
+				{
+					childComponents.Where( button => button.IsChapterButton ).ToList()
+				};
+			}
+			JumpButtons = allButtons.SelectMany( x => x ).ToList();
+
+			returnButton = childComponents.Where( button => button.name == "Return" ).First();
+
 			/*
 			foreach (var button in JumpButtons)
 			{
@@ -49,10 +69,72 @@ namespace Assets.Scripts.UI.ChapterJump
 			*/
 		}
 
+		/// <summary>
+		/// Switches pages
+		/// Run with 0 movement if you change the button list to properly the buttons on the current page
+		/// </summary>
+		/// <param name="movement">The number of pages to move forward (negative will move backward)</param>
+		private void UpdatePage(int movement)
+		{
+			currentPage = Math.Max(Math.Min(currentPage + movement, NumPages - 1), 0);
+			if (PageLeft != null)
+			{
+				PageLeft.enabled = (currentPage != 0);
+				PageRight.enabled = (currentPage != NumPages - 1);
+				PageNumberText.text = (currentPage + 1) + "/" + NumPages;
+			}
+			JumpButtons.ForEach( button => button.gameObject.SetActive(false) );
+			CurrentButtons.ForEach( button => button.gameObject.SetActive(true) );
+			RelayoutButtons();
+		}
+
+		/// <summary>
+		/// Steals page button objects from the tips screen and sets them up here
+		/// </summary>
+		private void SetupPageButtons()
+		{
+			if (NumPages <= 1) { return; }
+			var gameSystem = GameSystem.Instance;
+			var tipsManager = gameSystem.TipsPrefab.GetComponent<Tips.TipsManager>();
+
+			// Steal buttons from tips manager
+			var leftButton = Instantiate(tipsManager.PageLeft);
+			leftButton.transform.SetParent(returnButton.gameObject.transform.parent, worldPositionStays: false);
+			PageLeft = leftButton.GetComponent<UIButton>();
+			var rightButton = Instantiate(tipsManager.PageRight);
+			rightButton.transform.SetParent(returnButton.gameObject.transform.parent, worldPositionStays: false);
+			PageRight = rightButton.GetComponent<UIButton>();
+			var pageNumberText = Instantiate(tipsManager.tipsPageText);
+			pageNumberText.transform.SetParent(returnButton.gameObject.transform.parent, worldPositionStays: false);
+			PageNumberText = pageNumberText.GetComponent<TextMeshPro>();
+
+			// Setup page text
+			var returnButtonPos = returnButton.transform.localPosition;
+			var returnButtonBounds = returnButton.Text.bounds;
+			PageNumberText.fontSize = returnButton.Text.fontSize;
+			PageNumberText.alignment = TextAlignmentOptions.Center;
+			PageNumberText.transform.localPosition = new Vector3(returnButtonPos.x + returnButtonBounds.center.x, returnButtonPos.y + 25, 0f);
+
+			// Setup buttons
+			PageLeft.transform.localPosition = new Vector3(20 + returnButtonPos.x + returnButtonBounds.min.x, returnButtonPos.y + 25, 0f);
+			PageRight.transform.localPosition = new Vector3(-20 + returnButtonPos.x + returnButtonBounds.max.x, returnButtonPos.y + 25, 0f);
+			PageLeft.transform.localScale = new Vector3(0.5f, 0.5f, 0);
+			PageRight.transform.localScale = new Vector3(0.5f, 0.5f, 0);
+			// With pixelSnap on, UIButton keeps resizing the buttons to have a 1:1 ratio with the sprite image
+			// which undoes the local scale we just set
+			PageLeft.pixelSnap = false;
+			PageRight.pixelSnap = false;
+
+			leftButton.GetComponent<Tips.TipsButton>().Setup( () => UpdatePage(movement: -1) );
+			rightButton.GetComponent<Tips.TipsButton>().Setup( () => UpdatePage(movement: 1) );
+			UpdatePage(movement: 0);
+		}
+
 		private void LoadJSONButtons()
 		{
 			if (MODChapterJumpController.ChapterJumpsOrNull != null)
 			{
+				var newList = new List<List<ChapterJumpButton>>();
 				var baseButton = JumpButtons[0];
 
 				// Copied from Onikakushi
@@ -81,15 +163,30 @@ namespace Assets.Scripts.UI.ChapterJump
 					position.y -= ySpacing;
 					if (position.y < minYPos)
 					{
-						position.y = 0;
-						position.x += 200; // Will be set properly by RelayoutButtons
+						if (position.x > 0)
+						{
+							position = new Vector3(0, 0, 0);
+							newList.Add(newButtons);
+							newButtons = new List<ChapterJumpButton>();
+						}
+						else
+						{
+							position.y = 0;
+							position.x += 200; // Will be set properly by RelayoutButtons
+						}
 					}
 				}
-				foreach (var old in JumpButtons)
+				newList.Add(newButtons);
+				foreach (var oldList in allButtons)
 				{
-					Destroy(old.gameObject);
+					foreach (var old in oldList)
+					{
+						Destroy(old.gameObject);
+					}
 				}
-				JumpButtons = newButtons;
+				allButtons = newList;
+				PopulateJumpButtonList();
+				UpdatePage(movement: 0);
 			}
 		}
 
@@ -97,11 +194,11 @@ namespace Assets.Scripts.UI.ChapterJump
 		private void RelayoutButtons()
 		{
 			// Every single game seems to have this in a slightly different position
-			var windowPos = JumpButtons[0].transform.parent.localPosition;
+			var windowPos = CurrentButtons[0].transform.parent.localPosition;
 			windowPos.x = -215; // What Onikakushi uses
-			JumpButtons[0].transform.parent.localPosition = windowPos;
+			CurrentButtons[0].transform.parent.localPosition = windowPos;
 
-			var activeButtons = JumpButtons.Where( button => button.isActiveAndEnabled ).ToList();
+			var activeButtons = CurrentButtons.Where( button => button.isActiveAndEnabled ).ToList();
 			activeButtons.ForEach( button => button.Text.ForceMeshUpdate() );
 
 			// Things with x values below this are considered to be on the left half, others are on the right
@@ -148,7 +245,7 @@ namespace Assets.Scripts.UI.ChapterJump
 			}
 
 			// Set the new positions into the buttons
-			foreach (var button in JumpButtons)
+			foreach (var button in CurrentButtons)
 			{
 				Vector3 posVector = button.transform.localPosition;
 				var pos = posVector.x;
@@ -192,10 +289,7 @@ namespace Assets.Scripts.UI.ChapterJump
 			{
 				UnityEngine.Object.Destroy(base.gameObject);
 			});
-			JumpButtons.ForEach(delegate(ChapterJumpButton a)
-			{
-				a.Disable();
-			});
+			JumpButtons.ForEach( button => button.Disable() );
 		}
 
 		private void SetFade(float f)
@@ -221,7 +315,7 @@ namespace Assets.Scripts.UI.ChapterJump
 			{
 				relayoutDone = true;
 				LoadJSONButtons();
-				RelayoutButtons();
+				SetupPageButtons();
 			}
 		}
 	}

--- a/Assets.Scripts.UI.Tips/TipsButton.cs
+++ b/Assets.Scripts.UI.Tips/TipsButton.cs
@@ -4,15 +4,26 @@ using UnityEngine;
 
 namespace Assets.Scripts.UI.Tips
 {
+	public delegate void ClickHandler();
+
 	public class TipsButton : MonoBehaviour
 	{
 		private TipsManager manager;
+
+		// We steal this button for use in other views because making buttons from scratch is a pain
+		// In those cases, this click handler will be used instead of `manager`
+		private ClickHandler clickHandler;
 
 		private bool isEnabled = true;
 
 		public void Setup(TipsManager mg)
 		{
 			manager = mg;
+		}
+
+		public void Setup(ClickHandler clickHandler)
+		{
+			this.clickHandler = clickHandler;
 		}
 
 		public void Disable()
@@ -22,6 +33,11 @@ namespace Assets.Scripts.UI.Tips
 
 		private void OnClick()
 		{
+			if (clickHandler != null)
+			{
+				clickHandler();
+				return;
+			}
 			GameSystem instance = GameSystem.Instance;
 			if (instance.GameState == GameState.TipsScreen && isEnabled && manager.isActive && UICamera.currentTouchID == -1)
 			{

--- a/Assets.Scripts.UI.TitleScreen/TitleScreen.cs
+++ b/Assets.Scripts.UI.TitleScreen/TitleScreen.cs
@@ -2,6 +2,7 @@ using Assets.Scripts.Core.Buriko;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 namespace Assets.Scripts.UI.TitleScreen
 {
@@ -67,7 +68,7 @@ namespace Assets.Scripts.UI.TitleScreen
 		{
 			BurikoVariable globalFlag = BurikoMemory.Instance.GetGlobalFlag("GFlag_GameClear");
 			BackgroundTexture.mainTexture = (globalFlag.BoolValue() ? BG2 : BG1);
-			if (BurikoMemory.Instance.GetGlobalFlag("GOnikakushiDay").IntValue() < 1)
+			if (!BurikoMemory.Instance.GetHighestChapterFlags().Where( x => x > 0 ).Any())
 			{
 				Sprites[4].transform.localPosition = new Vector3(0f, -224f, 0f);
 				UISprite uISprite = Sprites[3];

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -165,6 +165,8 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModPlayMovie", new OpType(BurikoOperations.ModPlayMovie, "s"));
 			paramLookup.Add("ModSetConfigFontSize", new OpType(BurikoOperations.ModSetConfigFontSize, "i"));
 			paramLookup.Add("ModSetChapterJumpFontSize", new OpType(BurikoOperations.ModSetChapterJumpFontSize, "ii"));
+			paramLookup.Add("ModSetHighestChapterFlag", new OpType(BurikoOperations.ModSetHighestChapterFlag, "ii"));
+			paramLookup.Add("ModGetHighestChapterFlag", new OpType(BurikoOperations.ModGetHighestChapterFlag, "i"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/MOD.Scripts.UI.ChapterJump/MODChapterJumpController.cs
+++ b/MOD.Scripts.UI.ChapterJump/MODChapterJumpController.cs
@@ -18,7 +18,9 @@ namespace MOD.Scripts.UI.ChapterJump
 			public string English;
 			public string Japanese;
 			public int ChapterNumber;
+			public int ArcNumber;
 			public string BlockName;
+			public string FileName;
 		}
 
 		public static List<ChapterJumpEntry> ChapterJumpsOrNull

--- a/MOD.Scripts.UI.ChapterJump/MODChapterJumpController.cs
+++ b/MOD.Scripts.UI.ChapterJump/MODChapterJumpController.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Assets.Scripts.Core.Buriko;
+using MOD.Scripts.Core;
+using Newtonsoft.Json;
+using UnityEngine;
+
+namespace MOD.Scripts.UI.ChapterJump
+{
+	public class MODChapterJumpController
+	{
+		private static bool initialized = false;
+		private static Dictionary<int, List<ChapterJumpEntry>> cachedChapterJumps;
+		private static readonly string ChapterJumpFilePath = Path.Combine(MODSystem.BaseDirectory, "chapterjump.json");
+
+		public class ChapterJumpEntry
+		{
+			public string English;
+			public string Japanese;
+			public int ChapterNumber;
+			public string BlockName;
+		}
+
+		public static List<ChapterJumpEntry> ChapterJumpsOrNull
+		{
+			get
+			{
+				if (!initialized)
+				{
+					initialized = true;
+					if (File.Exists(ChapterJumpFilePath))
+					{
+						try
+						{
+							using (var reader = new JsonTextReader(new StreamReader(ChapterJumpFilePath)))
+							{
+								cachedChapterJumps = JsonSerializer.Create(new JsonSerializerSettings()).Deserialize<Dictionary<int, List<ChapterJumpEntry>>>(reader);
+							}
+						}
+						catch (System.Exception e)
+						{
+							Debug.Log("Failed to parse chapter jump JSON, falling back to hardcoded chapter jumps: " + e.Message);
+						}
+					}
+					else
+					{
+						Debug.Log("No chapter jump JSON available, falling back to hardcoded chapter jumps");
+					}
+				}
+				if (cachedChapterJumps == null)
+				{
+					return null;
+				}
+				int arc;
+				try
+				{
+					arc = BurikoMemory.Instance.GetFlag("LConsoleArc").IntValue();
+				}
+				catch
+				{
+					arc = 0;
+				}
+				cachedChapterJumps.TryGetValue(arc, out var entry);
+				return entry;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Allows a file named `chapterjump.json` to be included similarly to `tips.json` to override chapter jumps

Format is
```json
{
	"0": [
		{
			"English": "Onikakushi Day 1",
			"Japanese": "鬼隠し１日目",
			"ChapterNumber": 1,
			"BlockName": "Day1"
		},
		{
			"English": "Onikakushi Day 2",
			"Japanese": "鬼隠し２日目",
			"ChapterNumber": 2,
			"BlockName": "Day2"
		}
	]
}
```
The dictionary `0` key is the console arc if applicable (otherwise use `0`)
`ChapterNumber` is used to decide whether or not to display the option in the chapter jump list based on how far the player is in the game (the `HighestDay` buriko flag)
`BlockName` is the name of a block in `flow` to jump to

At the moment, it will only show the chapters associated with the current console arc, and depending on how we handle the current day flag in console arcs, may have some issues.  If there aren't too many console jump points, we could fit them all in (instead of only showing the ones for the current arc) but I the page only fits 24 items so that seems unlikely.  Any other suggestions on fitting them all are welcome.