### PR TITLE
Hide the text box when a choice is prompted

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -607,6 +607,7 @@ namespace Assets.Scripts.Core.Buriko
 			{
 				throw new Exception("Can't display options, two few options are present for the amount to be displayed!");
 			}
+			this.gameSystem.MainUIController.HideLayerBackground(0.25f);
 			gameSystem.DisplayChoices(stringList, num);
 			gameSystem.ExecuteActions();
 			gameSystem.AddWait(new Wait(1f, WaitTypes.WaitForTime, null));

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -179,7 +179,7 @@ namespace Assets.Scripts.UI
 			}
 		}
 
-		private void HideLayerBackground(float time)
+		public void HideLayerBackground(float time)
 		{
 			if (bgLayer == null || !bgLayer.IsInUse)
 			{


### PR DESCRIPTION
This fixes an issue where the message box is [drawn on top of choice options](https://cdn.discordapp.com/attachments/414850343751385090/529130882997420061/unknown.png).  The fix is just to make a call that hides the window inside the handler for the Select() call.