### PR TITLE
Multiple ADV Textboxes

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -105,6 +105,8 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GVideoOpening", 523);
 			variableReference.Add("GItaloVer", 524);
 			variableReference.Add("GAudioSwitch", 525);
+			variableReference.Add("GADVTextbox", 526);
+			variableReference.Add("GADVTextboxMaxNum", 527);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -103,8 +103,8 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GMOD_DEBUG_MODE", 521);
 			variableReference.Add("GLipSync", 522);
 			variableReference.Add("GVideoOpening", 523);
-            variableReference.Add("GItaloVer", 524);
-            variableReference.Add("GAudioSwitch", 525);
+			variableReference.Add("GItaloVer", 524);
+			variableReference.Add("GAudioSwitch", 525);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -103,6 +103,8 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GMOD_DEBUG_MODE", 521);
 			variableReference.Add("GLipSync", 522);
 			variableReference.Add("GVideoOpening", 523);
+            variableReference.Add("GItaloVer", 524);
+            variableReference.Add("GAudioSwitch", 525);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -139,6 +139,7 @@ namespace Assets.Scripts.Core.Buriko
 		ModSetChapterJumpFontSize,
 		ModSetHighestChapterFlag,
 		ModGetHighestChapterFlag,
-		ModSetMainFontOutlineWidth
+		ModSetMainFontOutlineWidth,
+		ModADVModeTextbox2SettingLoad
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2137,6 +2137,8 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODdisableNVLModeInADVMode();
 			case BurikoOperations.ModADVModeSettingLoad:
 				return OperationMODADVModeSettingLoad();
+			case BurikoOperations.ModADVModeTextbox2SettingLoad:
+				return OperationMODADVModeTextbox2SettingLoad();
 			case BurikoOperations.ModNVLModeSettingLoad:
 				return OperationMODNVLModeSettingLoad();
 			case BurikoOperations.ModNVLADVModeSettingLoad:
@@ -2322,6 +2324,27 @@ namespace Assets.Scripts.Core.Buriko
 			int lspace = ReadVariable().IntValue();
 			int fsize = ReadVariable().IntValue();
 			mODMainUIController.ADVModeSettingLoad(name, posx, posy, sizex, sizey, mleft, mtop, mright, mbottom, font, cspace, lspace, fsize);
+			return BurikoVariable.Null;
+		}
+
+		public BurikoVariable OperationMODADVModeTextbox2SettingLoad()
+		{
+			SetOperationType("ModADVModeTextbox2SettingLoad");
+			MODMainUIController mODMainUIController = new MODMainUIController();
+			string name = ReadVariable().StringValue();
+			int posx = ReadVariable().IntValue();
+			int posy = ReadVariable().IntValue();
+			int sizex = ReadVariable().IntValue();
+			int sizey = ReadVariable().IntValue();
+			int mleft = ReadVariable().IntValue();
+			int mtop = ReadVariable().IntValue();
+			int mright = ReadVariable().IntValue();
+			int mbottom = ReadVariable().IntValue();
+			int font = ReadVariable().IntValue();
+			int cspace = ReadVariable().IntValue();
+			int lspace = ReadVariable().IntValue();
+			int fsize = ReadVariable().IntValue();
+			mODMainUIController.ADVModeTextbox2SettingLoad(name, posx, posy, sizex, sizey, mleft, mtop, mright, mbottom, font, cspace, lspace, fsize);
 			return BurikoVariable.Null;
 		}
 

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -584,7 +584,8 @@ namespace Assets.Scripts.Core.Buriko
 			{
 				throw new Exception("Can't display options, two few options are present for the amount to be displayed!");
 			}
-			gameSystem.DisplayChoices(stringList, num);
+            this.gameSystem.MainUIController.HideLayerBackground(0.25f);
+            gameSystem.DisplayChoices(stringList, num);
 			gameSystem.ExecuteActions();
 			gameSystem.AddWait(new Wait(1f, WaitTypes.WaitForTime, null));
 			return null;

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -584,8 +584,8 @@ namespace Assets.Scripts.Core.Buriko
 			{
 				throw new Exception("Can't display options, two few options are present for the amount to be displayed!");
 			}
-            this.gameSystem.MainUIController.HideLayerBackground(0.25f);
-            gameSystem.DisplayChoices(stringList, num);
+			this.gameSystem.MainUIController.HideLayerBackground(0.25f);
+			gameSystem.DisplayChoices(stringList, num);
 			gameSystem.ExecuteActions();
 			gameSystem.AddWait(new Wait(1f, WaitTypes.WaitForTime, null));
 			return null;

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -189,6 +189,33 @@ namespace Assets.Scripts.Core.State
 						return true;
 					}
 				}
+				if (Input.GetKeyDown(KeyCode.Y))
+				{
+					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+					{
+						return false;
+					}
+					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
+					{
+						return false;
+					}
+					if (BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
+					{
+						return false;
+					}
+					int num17 = BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue();
+					int num18 = BurikoMemory.Instance.GetGlobalFlag("GADVTextboxMaxNum").IntValue();
+					if (num17 < num18 && num17 >= 0)
+					{
+						num17++;
+						BurikoMemory.Instance.SetGlobalFlag("GADVTextbox", num17);
+						GameSystem.Instance.MainUIController.MODADVModeTextbox2SettingLoad();
+						return true;
+					}
+					num17 = 0;
+					BurikoMemory.Instance.SetGlobalFlag("GADVTextbox", num17);
+					GameSystem.Instance.MainUIController.MODADVModeTextbox2SettingLoad();
+				}
 				if (Input.GetKeyDown(KeyCode.F1))
 				{
 					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -610,7 +610,30 @@ namespace Assets.Scripts.Core.State
 						}
 						MODSystem.instance.modTextureController.ToggleArtStyle();
 					}
-					return true;
+                    if (Input.GetKeyDown(KeyCode.I))
+                    {
+                        if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+                        {
+                            return false;
+                        }
+                        if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
+                        {
+                            return false;
+                        }
+                        if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
+                        {
+                            return false;
+                        }
+                        if (BurikoMemory.Instance.GetGlobalFlag("GItaloVer").IntValue() == 1)
+                        {
+                            BurikoMemory.Instance.SetGlobalFlag("GItaloVer", 0);
+                            GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
+                            return true;
+                        }
+                        BurikoMemory.Instance.SetGlobalFlag("GItaloVer", 1);
+                        GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
+                    }
+                    return true;
 				}
 				if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
 				{

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -610,30 +610,30 @@ namespace Assets.Scripts.Core.State
 						}
 						MODSystem.instance.modTextureController.ToggleArtStyle();
 					}
-                    if (Input.GetKeyDown(KeyCode.I))
-                    {
-                        if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-                        {
-                            return false;
-                        }
-                        if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-                        {
-                            return false;
-                        }
-                        if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-                        {
-                            return false;
-                        }
-                        if (BurikoMemory.Instance.GetGlobalFlag("GItaloVer").IntValue() == 1)
-                        {
-                            BurikoMemory.Instance.SetGlobalFlag("GItaloVer", 0);
-                            GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-                            return true;
-                        }
-                        BurikoMemory.Instance.SetGlobalFlag("GItaloVer", 1);
-                        GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-                    }
-                    return true;
+					if (Input.GetKeyDown(KeyCode.I))
+					{
+						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+						{
+							return false;
+						}
+						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
+						{
+							return false;
+						}
+						if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
+						{
+							return false;
+						}
+						if (BurikoMemory.Instance.GetGlobalFlag("GItaloVer").IntValue() == 1)
+						{
+							BurikoMemory.Instance.SetGlobalFlag("GItaloVer", 0);
+							GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
+							return true;
+						}
+						BurikoMemory.Instance.SetGlobalFlag("GItaloVer", 1);
+						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
+					}
+					return true;
 				}
 				if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
 				{

--- a/Assets.Scripts.UI.Choice/ChoiceController.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceController.cs
@@ -29,47 +29,47 @@ namespace Assets.Scripts.UI.Choice
 		public void Create(List<string> optstrings, int count)
 		{
 			GameObject gameObject = GameObject.FindGameObjectWithTag("PrimaryUIPanel");
-            for (int i = 0; i < count; i++)
-            {
-                int id = i;
-                GameObject gameObject2 = UnityEngine.Object.Instantiate(Resources.Load("ChoiceButton")) as GameObject;
-                if (gameObject2 == null)
-                {
-                    throw new Exception("Failed to instantiate ChoiceButton!");
-                }
-                gameObject2.transform.parent = gameObject.transform;
-                gameObject2.transform.localScale = Vector3.one;
-                if (count > 8)
-                {
-                    float x;
-                    if (i == count - 1 && count % 2 == 1)
-                    {
-                        x = GameSystem.Instance.GetGUIOffset();
-                    }
-                    else if (i % 2 == 0)
-                    {
-                        x = GameSystem.Instance.GetGUIOffset() - 300f;
-                    }
-                    else
-                    {
-                        x = GameSystem.Instance.GetGUIOffset() + 300f;
-                    }
-                    gameObject2.transform.localPosition = new Vector3(x, (float)(-75 * (i / 2) + 27 * count - 50), 0f);
-                }
-                else
-                {
-                    gameObject2.transform.localPosition = new Vector3(GameSystem.Instance.GetGUIOffset(), (float)(-75 * i + 27 * count + 50), 0f);
-                }
-                ChoiceButton component = gameObject2.GetComponent<ChoiceButton>();
-                component.ChangeText(optstrings[i]);
-                component.SetCallback(this, delegate
-                {
-                    GameSystem.Instance.ScriptSystem.SetFlag("SelectResult", id);
-                    Debug.Log("ID: " + id);
-                    this.FinishChoice();
-                });
-                this.options.Add(gameObject2.GetComponent<ChoiceButton>());
-            }
-        }
+			for (int i = 0; i < count; i++)
+			{
+				int id = i;
+				GameObject gameObject2 = UnityEngine.Object.Instantiate(Resources.Load("ChoiceButton")) as GameObject;
+				if (gameObject2 == null)
+				{
+					throw new Exception("Failed to instantiate ChoiceButton!");
+				}
+				gameObject2.transform.parent = gameObject.transform;
+				gameObject2.transform.localScale = Vector3.one;
+				if (count > 8)
+				{
+					float x;
+					if (i == count - 1 && count % 2 == 1)
+					{
+						x = GameSystem.Instance.GetGUIOffset();
+					}
+					else if (i % 2 == 0)
+					{
+						x = GameSystem.Instance.GetGUIOffset() - 300f;
+					}
+					else
+					{
+						x = GameSystem.Instance.GetGUIOffset() + 300f;
+					}
+					gameObject2.transform.localPosition = new Vector3(x, (float)(-75 * (i / 2) + 27 * count - 50), 0f);
+				}
+				else
+				{
+					gameObject2.transform.localPosition = new Vector3(GameSystem.Instance.GetGUIOffset(), (float)(-75 * i + 27 * count + 50), 0f);
+				}
+				ChoiceButton component = gameObject2.GetComponent<ChoiceButton>();
+				component.ChangeText(optstrings[i]);
+				component.SetCallback(this, delegate
+				{
+					GameSystem.Instance.ScriptSystem.SetFlag("SelectResult", id);
+					Debug.Log("ID: " + id);
+					this.FinishChoice();
+				});
+				this.options.Add(gameObject2.GetComponent<ChoiceButton>());
+			}
+		}
 	}
 }

--- a/Assets.Scripts.UI.Choice/ChoiceController.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceController.cs
@@ -29,35 +29,47 @@ namespace Assets.Scripts.UI.Choice
 		public void Create(List<string> optstrings, int count)
 		{
 			GameObject gameObject = GameObject.FindGameObjectWithTag("PrimaryUIPanel");
-			int num = Mathf.RoundToInt(120f / (float)(count - 1));
-			int num2 = 0;
-			while (true)
-			{
-				if (num2 >= count)
-				{
-					return;
-				}
-				int id = num2;
-				GameObject gameObject2 = UnityEngine.Object.Instantiate(Resources.Load("ChoiceButton")) as GameObject;
-				if (gameObject2 == null)
-				{
-					break;
-				}
-				gameObject2.transform.parent = gameObject.transform;
-				gameObject2.transform.localScale = Vector3.one;
-				gameObject2.transform.localPosition = new Vector3(GameSystem.Instance.GetGUIOffset(), (float)(170 - num * num2), 0f);
-				ChoiceButton component = gameObject2.GetComponent<ChoiceButton>();
-				component.ChangeText(optstrings[num2]);
-				component.SetCallback(this, delegate
-				{
-					GameSystem.Instance.ScriptSystem.SetFlag("SelectResult", id);
-					Debug.Log("ID: " + id);
-					FinishChoice();
-				});
-				options.Add(gameObject2.GetComponent<ChoiceButton>());
-				num2++;
-			}
-			throw new Exception("Failed to instantiate ChoiceButton!");
-		}
+            for (int i = 0; i < count; i++)
+            {
+                int id = i;
+                GameObject gameObject2 = UnityEngine.Object.Instantiate(Resources.Load("ChoiceButton")) as GameObject;
+                if (gameObject2 == null)
+                {
+                    throw new Exception("Failed to instantiate ChoiceButton!");
+                }
+                gameObject2.transform.parent = gameObject.transform;
+                gameObject2.transform.localScale = Vector3.one;
+                if (count > 8)
+                {
+                    float x;
+                    if (i == count - 1 && count % 2 == 1)
+                    {
+                        x = GameSystem.Instance.GetGUIOffset();
+                    }
+                    else if (i % 2 == 0)
+                    {
+                        x = GameSystem.Instance.GetGUIOffset() - 300f;
+                    }
+                    else
+                    {
+                        x = GameSystem.Instance.GetGUIOffset() + 300f;
+                    }
+                    gameObject2.transform.localPosition = new Vector3(x, (float)(-75 * (i / 2) + 27 * count - 50), 0f);
+                }
+                else
+                {
+                    gameObject2.transform.localPosition = new Vector3(GameSystem.Instance.GetGUIOffset(), (float)(-75 * i + 27 * count + 50), 0f);
+                }
+                ChoiceButton component = gameObject2.GetComponent<ChoiceButton>();
+                component.ChangeText(optstrings[i]);
+                component.SetCallback(this, delegate
+                {
+                    GameSystem.Instance.ScriptSystem.SetFlag("SelectResult", id);
+                    Debug.Log("ID: " + id);
+                    this.FinishChoice();
+                });
+                this.options.Add(gameObject2.GetComponent<ChoiceButton>());
+            }
+        }
 	}
 }

--- a/Assets.Scripts.UI.Tips/TipsManager.cs
+++ b/Assets.Scripts.UI.Tips/TipsManager.cs
@@ -105,7 +105,18 @@ namespace Assets.Scripts.UI.Tips
 			LTDescr lTDescr = LeanTween.value(base.gameObject, SetFade, 0f, 1f, 0.8f);
 			lTDescr.onComplete = delegate
 			{
-				GameSystem.Instance.AudioController.PlayAudio("msys14.ogg", Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f);
+				if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == 1)
+				{ const string Filename1 = "Original\\msys14.ogg"; GameSystem.Instance.AudioController.PlayAudio(Filename1, Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f); }
+				if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == 2)
+				{ const string Filename2 = "April2019Update\\msys14.ogg"; GameSystem.Instance.AudioController.PlayAudio(Filename2, Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f); }
+				if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == 3)
+				{ const string Filename3 = "Console\\hm11_85.ogg"; GameSystem.Instance.AudioController.PlayAudio(Filename3, Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f); }
+				if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == 4)
+				{ const string Filename4 = "MangaGamer\\mg07.ogg"; GameSystem.Instance.AudioController.PlayAudio(Filename4, Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f); }
+				if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() < 1)
+				{ GameSystem.Instance.AudioController.PlayAudio("msys14.ogg", Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f); }
+				if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() > 4)
+				{ GameSystem.Instance.AudioController.PlayAudio("msys14.ogg", Assets.Scripts.Core.Audio.AudioType.BGM, 0, 0.7f, 0f); }
 			};
 			switch (tipstype)
 			{

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -132,7 +132,14 @@ namespace Assets.Scripts.UI
 					bgLayer.SetPriority(62);
 					bgLayer.name = "Window Background 1";
 					bgLayer.IsStatic = true;
-					bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 0)
+					{
+						bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					}
+					if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 1)
+					{
+						bgLayer.DrawLayer("windo_filter_adv2", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					}
 					if (bgLayer2 == null)
 					{
 						bgLayer2 = LayerPool.ActivateLayer();
@@ -141,7 +148,14 @@ namespace Assets.Scripts.UI
 					bgLayer2.SetPriority(62);
 					bgLayer2.name = "Window Background 2";
 					bgLayer2.IsStatic = true;
-					bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 0)
+					{
+						bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					}
+					if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 1)
+					{
+						bgLayer2.DrawLayer("windo_filter_adv2", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					}
 				}
 			}
 			else

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -179,7 +179,7 @@ namespace Assets.Scripts.UI
 			}
 		}
 
-		private void HideLayerBackground(float time)
+		public void HideLayerBackground(float time)
 		{
 			if (bgLayer == null || !bgLayer.IsInUse)
 			{
@@ -531,14 +531,15 @@ namespace Assets.Scripts.UI
 			}
 			if ((BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 1) | (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 2))
 			{
-				string[] array = new string[6]
+				string[] array = new string[7]
 				{
 					"GADVMode",
 					"GAltBGM",
 					"GAltSE",
 					"GAltVoice",
 					"GAltVoicePriority",
-					"GLipSync"
+					"GLipSync",
+                    "GItaloVer"
 				};
 				string[] array2 = new string[array.Length];
 				for (int i = 0; i < array.Length; i++)
@@ -619,13 +620,19 @@ namespace Assets.Scripts.UI
 				}
 				var videoOpeningValue = BurikoMemory.Instance.GetGlobalFlag("GVideoOpening").IntValue();
 				var videoOpeningDescription = videoOpeningValue == 0 ? "Unset" : videoOpeningValue == 1 ? "Disabled" : videoOpeningValue == 2 ? "In-game" : videoOpeningValue == 3 ? "At launch + in-game" : "Unknown";
-				string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + "\nAlternative BGM Flow = " + array6[2] + array5[2] + "\nAlternative SE = " + array2[2] + "\nAlternative SE Flow = " + array6[3] + array5[3] + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
-				GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), text7, 900);
+                var AltBGMValue = BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue();
+                var AltBGMDescription = AltBGMValue == 0 ? "07th-Mod Audio Pack" : AltBGMValue == 1 ? "Original [2002]" : AltBGMValue == 2 ? "New Update [2019]" : AltBGMValue == 3 ? "Console" : AltBGMValue == 4 ? "MangaGamer [2009]" : AltBGMValue == 5 ? "Anime" : "Unknown";
+                var AltSEValue = BurikoMemory.Instance.GetGlobalFlag("GAltSEflow").IntValue();
+                var AltSEDescription = AltSEValue == 0 ? "07th-Mod Audio Pack" : AltSEValue == 1 ? "Original [2002]" : AltSEValue == 2 ? "New Update [2019]" : AltSEValue == 3 ? "Console" : AltSEValue == 4 ? "MangaGamer [2009]" : "Unknown";
+                var AudioSwitchValue = BurikoMemory.Instance.GetGlobalFlag("GAudioSwitch").IntValue();
+                var AudioSwitchDescription = AudioSwitchValue == 0 ? "Ask" : AudioSwitchValue == 1 ? "In Progress" : AudioSwitchValue == 2 ? "Don't ask again" : AudioSwitchValue == 3 ? "Keep last used" : "Unknown";
+                string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + $"\nAlternative BGM Flow = {AltBGMDescription} ({AltBGMValue})" + "\nItalo Remakes = " + array2[6] + "\nAlternative SE = " + array2[2] + $"\nAlternative SE Flow = {AltSEDescription} ({AltSEValue})" + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + $"\nStartup Audio Switch = {AudioSwitchDescription} ({AudioSwitchValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
+                GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), text7, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 2)
 			{
-				string text8 = "[Vanilla Hotkey]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF : FullScreen\nSpace : Hide Text\nL : Swap Language\nP : Swap Sprites\n\n[MOD Hotkey]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Setting Monitor\nM : Increase Voice Volume\nN : Decrease Voice Volume\n1 : Alternative BGM\n2 : Alternative BGM Flow\n3 : Alternative SE\n4 : Alternative SE Flow\n5 : Alternative Voice\n6 : Alternative Voice Priority\n7 : Lip-Sync\nLShift + F9 : Restore Settings\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MIN";
-				GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), text8, 900);
+                string text8 = "[Vanilla Hotkey]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF : FullScreen\nSpace : Hide Text\nL : Swap Language\nP : Swap Sprites\n\n[MOD Hotkey]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Setting Monitor\nM : Increase Voice Volume\nN : Decrease Voice Volume\nI : Toggle Italo's BGM Remakes\n1 : Alternative BGM\n2 : Alternative BGM Flow\n3 : Alternative SE\n4 : Alternative SE Flow\n5 : Alternative Voice\n6 : Alternative Voice Priority\n7 : Lip-Sync\nLShift + F9 : Restore Settings\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MIN";
+                GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), text8, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() >= 3)
 			{
@@ -651,7 +658,9 @@ namespace Assets.Scripts.UI
 					"GFlagForTest3",
 					"GMOD_DEBUG_MODE",
 					"GLipSync",
-					"GVideoOpening"
+					"GVideoOpening",
+                    "GItaloVer",
+                    "GAudioSwitch"
 				};
 				string[] array8 = new string[array7.Length];
 				for (int l = 0; l < array7.Length; l++)

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -539,7 +539,7 @@ namespace Assets.Scripts.UI
 					"GAltVoice",
 					"GAltVoicePriority",
 					"GLipSync",
-                    "GItaloVer"
+					"GItaloVer"
 				};
 				string[] array2 = new string[array.Length];
 				for (int i = 0; i < array.Length; i++)
@@ -620,18 +620,18 @@ namespace Assets.Scripts.UI
 				}
 				var videoOpeningValue = BurikoMemory.Instance.GetGlobalFlag("GVideoOpening").IntValue();
 				var videoOpeningDescription = videoOpeningValue == 0 ? "Unset" : videoOpeningValue == 1 ? "Disabled" : videoOpeningValue == 2 ? "In-game" : videoOpeningValue == 3 ? "At launch + in-game" : "Unknown";
-                var AltBGMValue = BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue();
-                var AltBGMDescription = AltBGMValue == 0 ? "07th-Mod Audio Pack" : AltBGMValue == 1 ? "Original [2002]" : AltBGMValue == 2 ? "New Update [2019]" : AltBGMValue == 3 ? "Console" : AltBGMValue == 4 ? "MangaGamer [2009]" : AltBGMValue == 5 ? "Anime" : "Unknown";
-                var AltSEValue = BurikoMemory.Instance.GetGlobalFlag("GAltSEflow").IntValue();
-                var AltSEDescription = AltSEValue == 0 ? "07th-Mod Audio Pack" : AltSEValue == 1 ? "Original [2002]" : AltSEValue == 2 ? "New Update [2019]" : AltSEValue == 3 ? "Console" : AltSEValue == 4 ? "MangaGamer [2009]" : "Unknown";
-                var AudioSwitchValue = BurikoMemory.Instance.GetGlobalFlag("GAudioSwitch").IntValue();
-                var AudioSwitchDescription = AudioSwitchValue == 0 ? "Ask" : AudioSwitchValue == 1 ? "In Progress" : AudioSwitchValue == 2 ? "Don't ask again" : AudioSwitchValue == 3 ? "Keep last used" : "Unknown";
-                string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + $"\nAlternative BGM Flow = {AltBGMDescription} ({AltBGMValue})" + "\nItalo Remakes = " + array2[6] + "\nAlternative SE = " + array2[2] + $"\nAlternative SE Flow = {AltSEDescription} ({AltSEValue})" + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + $"\nStartup Audio Switch = {AudioSwitchDescription} ({AudioSwitchValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
+				var AltBGMValue = BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue();
+				var AltBGMDescription = AltBGMValue == 0 ? "07th-Mod Audio Pack" : AltBGMValue == 1 ? "Original [2002]" : AltBGMValue == 2 ? "New Update [2019]" : AltBGMValue == 3 ? "Console" : AltBGMValue == 4 ? "MangaGamer [2009]" : AltBGMValue == 5 ? "Anime" : "Unknown";
+				var AltSEValue = BurikoMemory.Instance.GetGlobalFlag("GAltSEflow").IntValue();
+				var AltSEDescription = AltSEValue == 0 ? "07th-Mod Audio Pack" : AltSEValue == 1 ? "Original [2002]" : AltSEValue == 2 ? "New Update [2019]" : AltSEValue == 3 ? "Console" : AltSEValue == 4 ? "MangaGamer [2009]" : "Unknown";
+				var AudioSwitchValue = BurikoMemory.Instance.GetGlobalFlag("GAudioSwitch").IntValue();
+				var AudioSwitchDescription = AudioSwitchValue == 0 ? "Ask" : AudioSwitchValue == 1 ? "In Progress" : AudioSwitchValue == 2 ? "Don't ask again" : AudioSwitchValue == 3 ? "Keep last used" : "Unknown";
+				string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + $"\nAlternative BGM Flow = {AltBGMDescription} ({AltBGMValue})" + "\nItalo Remakes = " + array2[6] + "\nAlternative SE = " + array2[2] + $"\nAlternative SE Flow = {AltSEDescription} ({AltSEValue})" + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + $"\nStartup Audio Switch = {AudioSwitchDescription} ({AudioSwitchValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
                 GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), text7, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 2)
 			{
-                string text8 = "[Vanilla Hotkey]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF : FullScreen\nSpace : Hide Text\nL : Swap Language\nP : Swap Sprites\n\n[MOD Hotkey]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Setting Monitor\nM : Increase Voice Volume\nN : Decrease Voice Volume\nI : Toggle Italo's BGM Remakes\n1 : Alternative BGM\n2 : Alternative BGM Flow\n3 : Alternative SE\n4 : Alternative SE Flow\n5 : Alternative Voice\n6 : Alternative Voice Priority\n7 : Lip-Sync\nLShift + F9 : Restore Settings\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MIN";
+				string text8 = "[Vanilla Hotkey]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF : FullScreen\nSpace : Hide Text\nL : Swap Language\nP : Swap Sprites\n\n[MOD Hotkey]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Setting Monitor\nM : Increase Voice Volume\nN : Decrease Voice Volume\nI : Toggle Italo's BGM Remakes\n1 : Alternative BGM\n2 : Alternative BGM Flow\n3 : Alternative SE\n4 : Alternative SE Flow\n5 : Alternative Voice\n6 : Alternative Voice Priority\n7 : Lip-Sync\nLShift + F9 : Restore Settings\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MIN";
                 GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), text8, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() >= 3)
@@ -659,8 +659,8 @@ namespace Assets.Scripts.UI
 					"GMOD_DEBUG_MODE",
 					"GLipSync",
 					"GVideoOpening",
-                    "GItaloVer",
-                    "GAudioSwitch"
+					"GItaloVer",
+					"GAudioSwitch"
 				};
 				string[] array8 = new string[array7.Length];
 				for (int l = 0; l < array7.Length; l++)

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -627,12 +627,12 @@ namespace Assets.Scripts.UI
 				var AudioSwitchValue = BurikoMemory.Instance.GetGlobalFlag("GAudioSwitch").IntValue();
 				var AudioSwitchDescription = AudioSwitchValue == 0 ? "Ask" : AudioSwitchValue == 1 ? "In Progress" : AudioSwitchValue == 2 ? "Don't ask again" : AudioSwitchValue == 3 ? "Keep last used" : "Unknown";
 				string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + $"\nAlternative BGM Flow = {AltBGMDescription} ({AltBGMValue})" + "\nItalo Remakes = " + array2[6] + "\nAlternative SE = " + array2[2] + $"\nAlternative SE Flow = {AltSEDescription} ({AltSEValue})" + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + $"\nStartup Audio Switch = {AudioSwitchDescription} ({AudioSwitchValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
-                GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), text7, 900);
+				GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), text7, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 2)
 			{
 				string text8 = "[Vanilla Hotkey]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF : FullScreen\nSpace : Hide Text\nL : Swap Language\nP : Swap Sprites\n\n[MOD Hotkey]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Setting Monitor\nM : Increase Voice Volume\nN : Decrease Voice Volume\nI : Toggle Italo's BGM Remakes\n1 : Alternative BGM\n2 : Alternative BGM Flow\n3 : Alternative SE\n4 : Alternative SE Flow\n5 : Alternative Voice\n6 : Alternative Voice Priority\n7 : Lip-Sync\nLShift + F9 : Restore Settings\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MIN";
-                GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), text8, 900);
+				GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), text8, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() >= 3)
 			{

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -481,7 +481,55 @@ namespace Assets.Scripts.UI
 			}
 			else
 			{
-				BurikoMemory.Instance.SetGlobalFlag("GADVMode", 1);
+				if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 1)
+				{
+					BurikoMemory.Instance.SetGlobalFlag("GADVMode", 1);
+					BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+					GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
+					GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
+					GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv2", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+					GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv2", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+					mODMainUIController.ADVModeTextbox2SettingStore();
+				}
+				if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 0)
+				{
+					BurikoMemory.Instance.SetGlobalFlag("GADVMode", 1);
+					BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+					GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
+					GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
+					GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+					GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+					mODMainUIController.ADVModeSettingStore();
+				}
+			}
+		}
+
+		public void MODADVModeTextbox2SettingLoad()
+		{
+			MODMainUIController mODMainUIController = new MODMainUIController();
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 1)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GADVTextbox", 1);
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
+				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
+				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv2", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv2", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				mODMainUIController.ADVModeTextbox2SettingStore();
+			}
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 0)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GADVTextbox", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
+				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
+				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				mODMainUIController.ADVModeSettingStore();
+			}
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() > 1)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GADVTextbox", 0);
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
 				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
 				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
@@ -626,7 +674,8 @@ namespace Assets.Scripts.UI
 				var AltSEDescription = AltSEValue == 0 ? "07th-Mod Audio Pack" : AltSEValue == 1 ? "Original [2002]" : AltSEValue == 2 ? "New Update [2019]" : AltSEValue == 3 ? "Console" : AltSEValue == 4 ? "MangaGamer [2009]" : "Unknown";
 				var AudioSwitchValue = BurikoMemory.Instance.GetGlobalFlag("GAudioSwitch").IntValue();
 				var AudioSwitchDescription = AudioSwitchValue == 0 ? "Ask" : AudioSwitchValue == 1 ? "In Progress" : AudioSwitchValue == 2 ? "Don't ask again" : AudioSwitchValue == 3 ? "Keep last used" : "Unknown";
-				string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + $"\nAlternative BGM Flow = {AltBGMDescription} ({AltBGMValue})" + "\nItalo Remakes = " + array2[6] + "\nAlternative SE = " + array2[2] + $"\nAlternative SE Flow = {AltSEDescription} ({AltSEValue})" + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + $"\nStartup Audio Switch = {AudioSwitchDescription} ({AudioSwitchValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
+				var ADVTextboxValue = BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue();
+				string text7 = "[MOD SETTINGS]\nADV-MODE = " + array2[0] + $"\nADV Textbox = {ADVTextboxValue}" + "\nLip-Sync = " + array2[5] + "\nAlternative BGM = " + array2[1] + $"\nAlternative BGM Flow = {AltBGMDescription} ({AltBGMValue})" + "\nItalo Remakes = " + array2[6] + "\nAlternative SE = " + array2[2] + $"\nAlternative SE Flow = {AltSEDescription} ({AltSEValue})" + "\nAlternative Voice = " + array2[3] + "\nAlternative Voice Priority = " + array2[4] + "\nVoice Matching Level = " + array6[0] + array5[0] + "\nEffect Level = " + array6[1] + array5[1] + "\nVoice Volume = " + text2 + $"\nOP movies = {videoOpeningDescription} ({videoOpeningValue})" + $"\nStartup Audio Switch = {AudioSwitchDescription} ({AudioSwitchValue})" + "\n\n[Restore Game Settings]" + text + "\n\n[Status]\n" + text4 + text3 + text5 + text6;
 				GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), text7, 900);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 2)
@@ -660,7 +709,8 @@ namespace Assets.Scripts.UI
 					"GLipSync",
 					"GVideoOpening",
 					"GItaloVer",
-					"GAudioSwitch"
+					"GAudioSwitch",
+					"GADVTextbox"
 				};
 				string[] array8 = new string[array7.Length];
 				for (int l = 0; l < array7.Length; l++)

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -168,6 +168,7 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModSetHighestChapterFlag", new OpType(BurikoOperations.ModSetHighestChapterFlag, "ii"));
 			paramLookup.Add("ModGetHighestChapterFlag", new OpType(BurikoOperations.ModGetHighestChapterFlag, "i"));
 			paramLookup.Add("ModSetMainFontOutlineWidth", new OpType(BurikoOperations.ModSetMainFontOutlineWidth, "i"));
+			paramLookup.Add("ModADVModeTextbox2SettingLoad", new OpType(BurikoOperations.ModADVModeTextbox2SettingLoad, "siiiiiiiiiiii"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -125,10 +125,13 @@ namespace MOD.Scripts.UI
 			ADVModeCharSpacing = cspace;
 			ADVModeLineSpacing = lspace;
 			ADVModeFontSize = fsize;
-			if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 0)
 			{
-				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
-				ADVModeSettingStore();
+				if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+				{
+					BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+					ADVModeSettingStore();
+				}
 			}
 		}
 
@@ -147,10 +150,13 @@ namespace MOD.Scripts.UI
 			ADVModeTextbox2CharSpacing = cspace;
 			ADVModeTextbox2LineSpacing = lspace;
 			ADVModeTextbox2FontSize = fsize;
-			if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVTextbox").IntValue() == 1)
 			{
-				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
-				ADVModeTextbox2SettingStore();
+				if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+				{
+					BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+					ADVModeTextbox2SettingStore();
+				}
 			}
 		}
 

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -32,6 +32,32 @@ namespace MOD.Scripts.UI
 
 		private static int ADVModeFontID;
 
+		private static string ADVModeTextbox2NameFormat;
+
+		private static int ADVModeTextbox2WindowPosX;
+
+		private static int ADVModeTextbox2WindowPosY;
+
+		private static int ADVModeTextbox2WindowSizeX;
+
+		private static int ADVModeTextbox2WindowSizeY;
+
+		private static int ADVModeTextbox2LineSpacing;
+
+		private static int ADVModeTextbox2CharSpacing;
+
+		private static int ADVModeTextbox2FontSize;
+
+		private static int ADVModeTextbox2WindowMarginLeft;
+
+		private static int ADVModeTextbox2WindowMarginTop;
+
+		private static int ADVModeTextbox2WindowMarginRight;
+
+		private static int ADVModeTextbox2WindowMarginBottom;
+
+		private static int ADVModeTextbox2FontID;
+
 		private static string NVLModeNameFormat;
 
 		private static int NVLModeWindowPosX;
@@ -106,6 +132,28 @@ namespace MOD.Scripts.UI
 			}
 		}
 
+		public void ADVModeTextbox2SettingLoad(string name, int posx, int posy, int sizex, int sizey, int mleft, int mtop, int mright, int mbottom, int font, int cspace, int lspace, int fsize)
+		{
+			ADVModeTextbox2NameFormat = name;
+			ADVModeTextbox2WindowPosX = posx;
+			ADVModeTextbox2WindowPosY = posy;
+			ADVModeTextbox2WindowSizeX = sizex;
+			ADVModeTextbox2WindowSizeY = sizey;
+			ADVModeTextbox2WindowMarginLeft = mleft;
+			ADVModeTextbox2WindowMarginTop = mtop;
+			ADVModeTextbox2WindowMarginRight = mright;
+			ADVModeTextbox2WindowMarginBottom = mbottom;
+			ADVModeTextbox2FontID = font;
+			ADVModeTextbox2CharSpacing = cspace;
+			ADVModeTextbox2LineSpacing = lspace;
+			ADVModeTextbox2FontSize = fsize;
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+				ADVModeTextbox2SettingStore();
+			}
+		}
+
 		public void NVLModeSettingLoad(string name, int posx, int posy, int sizex, int sizey, int mleft, int mtop, int mright, int mbottom, int font, int cspace, int lspace, int fsize)
 		{
 			NVLModeNameFormat = name;
@@ -160,6 +208,31 @@ namespace MOD.Scripts.UI
 			int aDVModeCharSpacing = ADVModeCharSpacing;
 			int aDVModeLineSpacing = ADVModeLineSpacing;
 			int aDVModeFontSize = ADVModeFontSize;
+			GameSystem.Instance.TextController.NameFormat = aDVModeNameFormat;
+			GameSystem.Instance.MainUIController.SetWindowPos(aDVModeWindowPosX, aDVModeWindowPosY);
+			GameSystem.Instance.MainUIController.SetWindowSize(aDVModeWindowSizeX, aDVModeWindowSizeY);
+			GameSystem.Instance.MainUIController.SetWindowMargins(aDVModeWindowMarginLeft, aDVModeWindowMarginTop, aDVModeWindowMarginRight, aDVModeWindowMarginBottom);
+			GameSystem.Instance.MainUIController.ChangeFontId(aDVModeFontID);
+			GameSystem.Instance.MainUIController.SetCharSpacing(aDVModeCharSpacing);
+			GameSystem.Instance.MainUIController.SetLineSpacing(aDVModeLineSpacing);
+			GameSystem.Instance.MainUIController.SetFontSize(aDVModeFontSize);
+		}
+
+		public void ADVModeTextbox2SettingStore()
+		{
+			string aDVModeNameFormat = ADVModeTextbox2NameFormat;
+			int aDVModeWindowPosX = ADVModeTextbox2WindowPosX;
+			int aDVModeWindowPosY = ADVModeTextbox2WindowPosY;
+			int aDVModeWindowSizeX = ADVModeTextbox2WindowSizeX;
+			int aDVModeWindowSizeY = ADVModeTextbox2WindowSizeY;
+			int aDVModeWindowMarginLeft = ADVModeTextbox2WindowMarginLeft;
+			int aDVModeWindowMarginTop = ADVModeTextbox2WindowMarginTop;
+			int aDVModeWindowMarginRight = ADVModeTextbox2WindowMarginRight;
+			int aDVModeWindowMarginBottom = ADVModeTextbox2WindowMarginBottom;
+			int aDVModeFontID = ADVModeTextbox2FontID;
+			int aDVModeCharSpacing = ADVModeTextbox2CharSpacing;
+			int aDVModeLineSpacing = ADVModeTextbox2LineSpacing;
+			int aDVModeFontSize = ADVModeTextbox2FontSize;
 			GameSystem.Instance.TextController.NameFormat = aDVModeNameFormat;
 			GameSystem.Instance.MainUIController.SetWindowPos(aDVModeWindowPosX, aDVModeWindowPosY);
 			GameSystem.Instance.MainUIController.SetWindowSize(aDVModeWindowSizeX, aDVModeWindowSizeY);


### PR DESCRIPTION
As mentioned in discord, I looked at adding multi adv textbox support and managed to get somewhere with it https://gfycat.com/craftysoupyarabianoryx

I was told to make a WIP PR with this, I hope this is the right thing.
Also there's some stuff in the branch for audio switch stuff I've been doing, latest commit is just the textbox stuff.


This is fixed in https://github.com/07th-mod/higurashi-assembly/pull/29/commits/76071085b574ab2582b9bad2b42d682c49ea53b8 ///
Main bug I've noticed so far that I'm not sure how to fix right now is that when you first start the game like, the text is in the style for the new adv box but shows the old textbox and doesn't update until you toggle adv/nvl or change the adv textbox style
![2019-05-19_07-47-11](https://user-images.githubusercontent.com/8584772/57978770-368dc380-7a0b-11e9-8f03-2f3cbbd93170.png)
///

in init.txt
```
    ModADVModeTextbox2SettingLoad(
        "<size=+4>{0}\n</size>", //NameFormat
        -170, //WindowPosX
        -300, //WindowPosY
        1150, //WindowSizeX
        250, //WindowSizeY
        60, //WindowMarginLeft
        30, //WindowMarginTop
        50, //WindowMarginRight
        30, //WindowMarginBottom
        1, //FontID
        0, //CharSpacing
        8, //LineSpacing
        28 //FontSize
    );
```
needs to be added.
The new textbox needs to be windo_filter_adv2.png and old windo_filter_adv.png

Toggle button is currently Y but another key would probably be better.

I'm not sure if it's the best method for the textbox switch, but I hope it helps.