### PR TITLE
Fix Slider Order on Config Screen

### DIFF
--- a/Assets.Scripts.UI.Config/ConfigSlider.cs
+++ b/Assets.Scripts.UI.Config/ConfigSlider.cs
@@ -26,23 +26,23 @@ namespace Assets.Scripts.UI.Config
 			int num = 0;
 			switch (base.name)
 			{
-			case "0-TextSpeed":
-				num = GameSystem.Instance.TextController.TextSpeed;
-				break;
-			case "1-AutoSpeed":
-				num = GameSystem.Instance.TextController.AutoSpeed;
-				break;
-			case "2-AutoPageSpeed":
-				num = GameSystem.Instance.TextController.AutoPageSpeed;
-				break;
-			case "3-WindowOpacity":
+			case "0-WindowOpacity":
 				num = (int)(GameSystem.Instance.MessageWindowOpacity * 100f);
 				break;
-			case "4-BGMVolume":
+			case "1-VoiceVolume":
+				num = (int)(GameSystem.Instance.AudioController.VoiceVolume * 100f);
+				break;
+			case "2-BGMVolume":
 				num = (int)(GameSystem.Instance.AudioController.BGMVolume * 100f);
 				break;
-			case "5-SEVolume":
+			case "3-SEVolume":
 				num = (int)(GameSystem.Instance.AudioController.SoundVolume * 100f);
+				break;
+			case "4-TextSpeed":
+				num = GameSystem.Instance.TextController.TextSpeed;
+				break;
+			case "5-AutoPageSpeed":
+				num = GameSystem.Instance.TextController.AutoPageSpeed;
 				break;
 			}
 			slider.value = (float)num / 100f;
@@ -66,33 +66,36 @@ namespace Assets.Scripts.UI.Config
 				int num = (int)(100f * laststep);
 				switch (base.name)
 				{
-				case "0-TextSpeed":
-					GameSystem.Instance.TextController.TextSpeed = num;
-					BurikoMemory.Instance.SetGlobalFlag("GMessageSpeed", num);
-					break;
-				case "1-AutoSpeed":
-					GameSystem.Instance.TextController.AutoSpeed = num;
-					BurikoMemory.Instance.SetGlobalFlag("GAutoSpeed", num);
-					break;
-				case "2-AutoPageSpeed":
-					GameSystem.Instance.TextController.AutoPageSpeed = num;
-					BurikoMemory.Instance.SetGlobalFlag("GAutoAdvSpeed", num);
-					break;
-				case "3-WindowOpacity":
+				case "0-WindowOpacity":
 					GameSystem.Instance.MessageWindowOpacity = laststep;
 					GameSystem.Instance.MainUIController.SetWindowOpacity(laststep);
 					BurikoMemory.Instance.SetGlobalFlag("GWindowOpacity", num);
 					break;
-				case "4-BGMVolume":
+				case "1-VoiceVolume":
+					GameSystem.Instance.AudioController.VoiceVolume = laststep;
+					GameSystem.Instance.AudioController.RefreshLayerVolumes();
+					BurikoMemory.Instance.SetGlobalFlag("GVoiceVolume", num);
+					break;
+				case "2-BGMVolume":
 					GameSystem.Instance.AudioController.BGMVolume = laststep;
 					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GBGMVolume", num);
 					break;
-				case "5-SEVolume":
+				case "3-SEVolume":
 					GameSystem.Instance.AudioController.SoundVolume = laststep;
 					GameSystem.Instance.AudioController.SystemVolume = laststep;
 					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GSEVolume", num);
+					break;
+				case "4-TextSpeed":
+					GameSystem.Instance.TextController.TextSpeed = num;
+					BurikoMemory.Instance.SetGlobalFlag("GMessageSpeed", num);
+					GameSystem.Instance.TextController.AutoSpeed = num;
+					BurikoMemory.Instance.SetGlobalFlag("GAutoSpeed", num);
+					break;
+				case "5-AutoPageSpeed":
+					GameSystem.Instance.TextController.AutoPageSpeed = num;
+					BurikoMemory.Instance.SetGlobalFlag("GAutoAdvSpeed", num);
 					break;
 				}
 			}

--- a/Assets.Scripts.UI.Config/ConfigSlider.cs
+++ b/Assets.Scripts.UI.Config/ConfigSlider.cs
@@ -24,24 +24,24 @@ namespace Assets.Scripts.UI.Config
 				slider = GetComponent<UISlider>();
 			}
 			int num = 0;
-			switch (base.name)
+			switch (base.name) // All slider labels match original order, functionality in comment
 			{
-			case "0-WindowOpacity":
+			case "0-TextSpeed": // Window Opacity:
 				num = (int)(GameSystem.Instance.MessageWindowOpacity * 100f);
 				break;
-			case "1-VoiceVolume":
+			case "1-AutoSpeed": // Voice Volume:
 				num = (int)(GameSystem.Instance.AudioController.VoiceVolume * 100f);
 				break;
-			case "2-BGMVolume":
+			case "2-AutoPageSpeed": // BGM Volume
 				num = (int)(GameSystem.Instance.AudioController.BGMVolume * 100f);
 				break;
-			case "3-SEVolume":
+			case "3-WindowOpacity": // SE Volume
 				num = (int)(GameSystem.Instance.AudioController.SoundVolume * 100f);
 				break;
-			case "4-TextSpeed":
+			case "4-BGMVolume": // Text / Auto text speed
 				num = GameSystem.Instance.TextController.TextSpeed;
 				break;
-			case "5-AutoPageSpeed":
+			case "5-SEVolume":  // Auto Page Speed
 				num = GameSystem.Instance.TextController.AutoPageSpeed;
 				break;
 			}
@@ -64,36 +64,36 @@ namespace Assets.Scripts.UI.Config
 			{
 				laststep = slider.value;
 				int num = (int)(100f * laststep);
-				switch (base.name)
+				switch (base.name) // All slider labels match original order, functionality in comment
 				{
-				case "0-WindowOpacity":
+				case "0-TextSpeed": // Window Opacity
 					GameSystem.Instance.MessageWindowOpacity = laststep;
 					GameSystem.Instance.MainUIController.SetWindowOpacity(laststep);
 					BurikoMemory.Instance.SetGlobalFlag("GWindowOpacity", num);
 					break;
-				case "1-VoiceVolume":
+				case "1-AutoSpeed": // Voice Volume
 					GameSystem.Instance.AudioController.VoiceVolume = laststep;
 					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GVoiceVolume", num);
 					break;
-				case "2-BGMVolume":
+				case "2-AutoPageSpeed": // BGM Volume
 					GameSystem.Instance.AudioController.BGMVolume = laststep;
 					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GBGMVolume", num);
 					break;
-				case "3-SEVolume":
+				case "3-WindowOpacity": // SE Volume
 					GameSystem.Instance.AudioController.SoundVolume = laststep;
 					GameSystem.Instance.AudioController.SystemVolume = laststep;
 					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GSEVolume", num);
 					break;
-				case "4-TextSpeed":
+				case "4-BGMVolume": // Text / Auto text Speed
 					GameSystem.Instance.TextController.TextSpeed = num;
 					BurikoMemory.Instance.SetGlobalFlag("GMessageSpeed", num);
 					GameSystem.Instance.TextController.AutoSpeed = num;
 					BurikoMemory.Instance.SetGlobalFlag("GAutoSpeed", num);
 					break;
-				case "5-AutoPageSpeed":
+				case "5-SEVolume": // Auto page speed
 					GameSystem.Instance.TextController.AutoPageSpeed = num;
 					BurikoMemory.Instance.SetGlobalFlag("GAutoAdvSpeed", num);
 					break;


### PR DESCRIPTION
Change slider functionality on config screens (Issue #32). The settings image will still need to be updated to reflect this. Tested to work as intended on Onikakushi.

1. Window Opacity
2. Voice Volume
3. BGM Volume
4. SE Volume
5. Text and Autotext speed
6. Auto page speed