### PR TITLE
Mod Menu + Original/Ryukishi Mode + Misc changes

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -230,6 +230,7 @@
     <Compile Include="MOD.Scripts.Core.Movie\TextureMovieRenderer.cs" />
     <Compile Include="MOD.Scripts.Core.Scene\MODSceneController.cs" />
     <Compile Include="MOD.Scripts.Core.Scene\MODTextureController.cs" />
+    <Compile Include="MOD.Scripts.Core.State\MODStateDisableInput.cs" />
     <Compile Include="MOD.Scripts.Core.State\StateMovie.cs" />
     <Compile Include="MOD.Scripts.Core.TextWindow\MODTextController.cs" />
     <Compile Include="MOD.Scripts.Core\MODSystem.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -237,7 +237,14 @@
     <Compile Include="MOD.Scripts.Core\MODUtility.cs" />
     <Compile Include="MOD.Scripts.UI.ChapterJump\MODChapterJumpController.cs" />
     <Compile Include="MOD.Scripts.UI.Tips\MODTipsController.cs" />
+    <Compile Include="MOD.Scripts.UI\MODKeyboardShortcuts.cs" />
     <Compile Include="MOD.Scripts.UI\MODMainUIController.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenu.cs" />
+    <Compile Include="MOD.Scripts.UI\MODActions.cs" />
+    <Compile Include="MOD.Scripts.UI\MODSimpleTimer.cs" />
+    <Compile Include="MOD.Scripts.UI\MODSound.cs" />
+    <Compile Include="MOD.Scripts.UI\MODStyleManager.cs" />
+    <Compile Include="MOD.Scripts.UI\MODToaster.cs" />
     <Compile Include="Newtonsoft.Json.Bson\BsonArray.cs" />
     <Compile Include="Newtonsoft.Json.Bson\BsonBinaryType.cs" />
     <Compile Include="Newtonsoft.Json.Bson\BsonBinaryWriter.cs" />

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -33,6 +33,7 @@ namespace Assets.Scripts.Core.AssetManagement
 		public bool ShouldSerializeArtsets = false;
 
 		private Texture2D windowTexture;
+		private string windowTexturePath = string.Empty;
 		private Texture2D dummyTexture;
 
 		private string assetPath = Application.streamingAssetsPath;
@@ -240,8 +241,14 @@ namespace Assets.Scripts.Core.AssetManagement
 
 		public Texture2D LoadTexture(string textureName)
 		{
+			return LoadTexture(textureName, out _);
+		}
+
+		public Texture2D LoadTexture(string textureName, out string texturePath)
+		{
 			if (textureName == "windo_filter" && windowTexture != null)
 			{
+				texturePath = windowTexturePath;
 				return windowTexture;
 			}
 			string path = null;
@@ -260,6 +267,7 @@ namespace Assets.Scripts.Core.AssetManagement
 				{
 					dummyTexture = new Texture2D(0, 0, TextureFormat.ARGB32, mipmap: true);
 				}
+				texturePath = "dummy_texture";
 				return dummyTexture;
 			}
 			byte[] array = File.ReadAllBytes(path);
@@ -281,7 +289,9 @@ namespace Assets.Scripts.Core.AssetManagement
 			if (textureName == "windo_filter")
 			{
 				windowTexture = texture2D;
+				windowTexturePath = path;
 			}
+			texturePath = path;
 			return texture2D;
 		}
 

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -33,6 +33,7 @@ namespace Assets.Scripts.Core.AssetManagement
 		public bool ShouldSerializeArtsets = false;
 
 		private Texture2D windowTexture;
+		private Texture2D dummyTexture;
 
 		private string assetPath = Application.streamingAssetsPath;
 
@@ -252,7 +253,14 @@ namespace Assets.Scripts.Core.AssetManagement
 			if (path == null)
 			{
 				Logger.LogWarning("Could not find texture asset " + textureName.ToLower() + " in " + CurrentArtset.nameEN);
-				return null;
+				// When returning null here, most functions won't crash, but this call chain does crash:
+				// OperationDrawSpriteWithFiltering() -> DrawSpriteWithFiltering() -> DrawLayerWithMask()
+				// Returning a dummy texture instead of null prevents these crashes
+				if (dummyTexture == null)
+				{
+					dummyTexture = new Texture2D(0, 0, TextureFormat.ARGB32, mipmap: true);
+				}
+				return dummyTexture;
 			}
 			byte[] array = File.ReadAllBytes(path);
 			if (array == null || array.Length == 0)

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -197,6 +197,26 @@ namespace Assets.Scripts.Core.AssetManagement
 					}
 				}
 			}
+
+			// If we want to use the game just to compile scripts in an automated manner, we need
+			// some way to terminate the game after scripts are compiled.
+			// The below code will terminate the game after scripts are compiled if "quitaftercompile"
+			// is passed as a command-line argument to the game
+			// The code will also try to write a higu_script_compile_status.txt as proof that
+			// the scripts really did compile OK
+			if (Environment.GetCommandLineArgs().Contains("quitaftercompile"))
+			{
+				GameSystem.Instance.CanExit = true;
+				try
+				{
+					System.IO.File.WriteAllText("higu_script_compile_status.txt", "Compile OK");
+				}
+				catch
+				{
+
+				}
+				Application.Quit();
+			}
 		}
 
 		private string GetArchiveNameByAudioType(Assets.Scripts.Core.Audio.AudioType audioType)

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -104,6 +104,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GLipSync", 522);
 			variableReference.Add("GVideoOpening", 523);
 			variableReference.Add("GChoiceMode", 524);
+			variableReference.Add("GHideCG", 525);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -106,6 +106,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GChoiceMode", 524);
 			variableReference.Add("GHideCG", 525);
 			variableReference.Add("GRyukishiMode", 526);
+			variableReference.Add("GStretchBackgrounds", 527);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -107,6 +107,8 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GHideCG", 525);
 			variableReference.Add("GRyukishiMode", 526);
 			variableReference.Add("GStretchBackgrounds", 527);
+			variableReference.Add("GBackgroundSet", 528);
+
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -105,6 +105,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GVideoOpening", 523);
 			variableReference.Add("GChoiceMode", 524);
 			variableReference.Add("GHideCG", 525);
+			variableReference.Add("GClampSprite43", 526);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -105,7 +105,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GVideoOpening", 523);
 			variableReference.Add("GChoiceMode", 524);
 			variableReference.Add("GHideCG", 525);
-			variableReference.Add("GClampSprite43", 526);
+			variableReference.Add("GRyukishiMode", 526);
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);
 			SetGlobalFlag("GAutoSpeed", 50);

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -143,5 +143,6 @@ namespace Assets.Scripts.Core.Buriko
 		ModSetLayerFilter,
 		ModAddArtset,
 		ModClearArtsets,
+		ModRyukishiModeSettingLoad,
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -144,5 +144,6 @@ namespace Assets.Scripts.Core.Buriko
 		ModAddArtset,
 		ModClearArtsets,
 		ModRyukishiModeSettingLoad,
+		ModRyukishiSetGuiPosition,
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoSaveManager.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoSaveManager.cs
@@ -8,10 +8,12 @@ namespace Assets.Scripts.Core.Buriko
 	public class BurikoSaveManager
 	{
 		private readonly Dictionary<int, SaveEntry> saveList;
+		public static string lastSaveError;
 
 		public BurikoSaveManager()
 		{
 			saveList = new Dictionary<int, SaveEntry>();
+			lastSaveError = null;
 			for (int i = 0; i < 100; i++)
 			{
 				string path = Path.Combine(MGHelper.GetSavePath(), string.Format("save{0}.dat", i.ToString("D3")));
@@ -97,7 +99,8 @@ namespace Assets.Scripts.Core.Buriko
 				}
 				catch (Exception ex)
 				{
-					Logger.LogWarning("Could not read from save file " + path + "\nException: " + ex);
+					lastSaveError = "Could not read from save file " + path + "\nException: " + ex;
+					Logger.LogWarning(lastSaveError);
 					throw;
 					IL_013f:;
 				}

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2318,14 +2318,14 @@ namespace Assets.Scripts.Core.Buriko
 		private BurikoVariable OperationMODenableNVLModeInADVMode()
 		{
 			SetOperationType("ModEnableNVLModeInADVMode");
-			gameSystem.MainUIController.MODenableNVLModeINADVMode();
+			MODActions.EnableNVLModeINADVMode();
 			return BurikoVariable.Null;
 		}
 
 		private BurikoVariable OperationMODdisableNVLModeInADVMode()
 		{
 			SetOperationType("ModDisableNVLModeInADVMode");
-			gameSystem.MainUIController.MODdisableNVLModeINADVMode();
+			MODActions.DisableNVLModeINADVMode();
 			return BurikoVariable.Null;
 		}
 

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2168,6 +2168,8 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODAddArtset();
 			case BurikoOperations.ModClearArtsets:
 				return OperationMODClearArtsets();
+			case BurikoOperations.ModRyukishiModeSettingLoad:
+				return OperationMODRyukishiModeSettingLoad();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;
@@ -2374,6 +2376,27 @@ namespace Assets.Scripts.Core.Buriko
 			int lspace = ReadVariable().IntValue();
 			int fsize = ReadVariable().IntValue();
 			mODMainUIController.NVLADVModeSettingLoad(name, posx, posy, sizex, sizey, mleft, mtop, mright, mbottom, font, cspace, lspace, fsize);
+			return BurikoVariable.Null;
+		}
+
+		public BurikoVariable OperationMODRyukishiModeSettingLoad()
+		{
+			SetOperationType("ModRyukishiModeSettingLoad");
+			MODMainUIController mODMainUIController = new MODMainUIController();
+			string name = ReadVariable().StringValue();
+			int posx = ReadVariable().IntValue();
+			int posy = ReadVariable().IntValue();
+			int sizex = ReadVariable().IntValue();
+			int sizey = ReadVariable().IntValue();
+			int mleft = ReadVariable().IntValue();
+			int mtop = ReadVariable().IntValue();
+			int mright = ReadVariable().IntValue();
+			int mbottom = ReadVariable().IntValue();
+			int font = ReadVariable().IntValue();
+			int cspace = ReadVariable().IntValue();
+			int lspace = ReadVariable().IntValue();
+			int fsize = ReadVariable().IntValue();
+			mODMainUIController.RyukishiModeSettingLoad(name, posx, posy, sizex, sizey, mleft, mtop, mright, mbottom, font, cspace, lspace, fsize);
 			return BurikoVariable.Null;
 		}
 

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -1868,12 +1868,23 @@ namespace Assets.Scripts.Core.Buriko
 			return BurikoVariable.Null;
 		}
 
+		// This has been modified so that we can save the 'default' UI position
 		private BurikoVariable OperationSetGuiPosition()
 		{
 			SetOperationType("SetGUIPosition");
 			int x = ReadVariable().IntValue();
 			int y = ReadVariable().IntValue();
-			gameSystem.MainUIController.UpdateGuiPosition(x, y);
+			MODMainUIController mODMainUIController = new MODMainUIController();
+			mODMainUIController.WideGuiPositionLoad(x, y);
+			return BurikoVariable.Null;
+		}
+		private BurikoVariable OperationSetRyukishiGuiPosition()
+		{
+			SetOperationType("ModRyukishiGuiPositionLoad");
+			int x = ReadVariable().IntValue();
+			int y = ReadVariable().IntValue();
+			MODMainUIController mODMainUIController = new MODMainUIController();
+			mODMainUIController.RyukishiGuiPositionLoad(x, y);
 			return BurikoVariable.Null;
 		}
 
@@ -2170,6 +2181,8 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODClearArtsets();
 			case BurikoOperations.ModRyukishiModeSettingLoad:
 				return OperationMODRyukishiModeSettingLoad();
+			case BurikoOperations.ModRyukishiSetGuiPosition:
+				return OperationSetRyukishiGuiPosition();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;

--- a/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
@@ -30,6 +30,8 @@ namespace Assets.Scripts.Core.Buriko
 
 		private readonly string[] tempSnapshotText = new string[2];
 
+		public bool FlowWasReached { get; private set; }
+
 		public static BurikoScriptSystem Instance
 		{
 			get;
@@ -90,6 +92,11 @@ namespace Assets.Scripts.Core.Buriko
 
 		public void CallScript(string scriptname, string blockname = "main")
 		{
+			if(scriptname == "flow")
+			{
+				FlowWasReached = true;
+			}
+
 			Logger.Log($"{currentScript.Filename}: calling script {scriptname} (block {blockname})");
 			callStack.Push(new BurikoStackEntry(currentScript, currentScript.Position, currentScript.LineNum));
 			scriptname = scriptname.ToLower();

--- a/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
@@ -1,6 +1,7 @@
 using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Audio;
 using Assets.Scripts.Core.Interfaces;
+using MOD.Scripts.UI;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -415,11 +416,11 @@ namespace Assets.Scripts.Core.Buriko
 						GameSystem.Instance.TextController.SetTextFade(flag2 == 1);
 						if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1 && BurikoMemory.Instance.GetGlobalFlag("GLinemodeSp").IntValue() == 2 && BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 0)
 						{
-							GameSystem.Instance.MainUIController.MODdisableNVLModeINADVMode();
+							MODActions.DisableNVLModeINADVMode();
 						}
 						if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1 && BurikoMemory.Instance.GetGlobalFlag("GLinemodeSp").IntValue() == 0 && BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
 						{
-							GameSystem.Instance.MainUIController.MODenableNVLModeINADVMode();
+							MODActions.EnableNVLModeINADVMode();
 						}
 					}
 				}

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -329,7 +329,7 @@ namespace Assets.Scripts.Core.Scene
 
 		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, int finalXOffset)
 		{
-			bool ryukishiClamp = Buriko.BurikoMemory.Instance.GetGlobalFlag("GClampSprite43").IntValue() == 1;
+			bool ryukishiClamp = Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1;
 
 			if (mesh == null ||
 				!Mathf.Approximately((float)width / height, aspectRatio) ||

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -330,7 +330,7 @@ namespace Assets.Scripts.Core.Scene
 
 		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, bool isBustShot, int finalXOffset, string texturePath)
 		{
-			bool ryukishiClamp = isBustShot && Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1;
+			bool ryukishiClamp = isBustShot && Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1 && (texturePath.Contains("sprite/") || texturePath.Contains("sprite\\"));
 			bool stretchToFit = false;
 			if (texturePath != null)
 			{

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -327,9 +327,9 @@ namespace Assets.Scripts.Core.Scene
 			}
 		}
 
-		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, int finalXOffset)
+		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, bool isBustShot, int finalXOffset)
 		{
-			bool ryukishiClamp = Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1;
+			bool ryukishiClamp = isBustShot && Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1;
 
 			if (mesh == null ||
 				!Mathf.Approximately((float)width / height, aspectRatio) ||
@@ -374,6 +374,7 @@ namespace Assets.Scripts.Core.Scene
 				width: texture2D.width, height: texture2D.height,
 				alignment: ((x != 0 || y != 0) && !isBustshot) ? LayerAlignment.AlignTopleft : LayerAlignment.AlignCenter,
 				origin: origin,
+				isBustShot: isBustshot,
 				finalXOffset: x
 			);
 			SetRange(startRange);
@@ -448,6 +449,7 @@ namespace Assets.Scripts.Core.Scene
 						width: texture2D.width, height: texture2D.height,
 						alignment: ((x != 0 || y != 0) && !isBustshot) ? LayerAlignment.AlignTopleft : LayerAlignment.AlignCenter,
 						origin: origin,
+						isBustShot: isBustshot,
 						finalXOffset: x
 					);
 					aspectRatio = (float)texture2D.width / texture2D.height;
@@ -674,8 +676,7 @@ namespace Assets.Scripts.Core.Scene
 				else
 				{
 					SetPrimaryTexture(texture2D);
-					//TODO: this function call doesn't know if it is a bustshot
-					EnsureCorrectlySizedMesh(texture2D.width, texture2D.height, alignment, origin, finalXOffset: (int) base.transform.localPosition.x);
+					EnsureCorrectlySizedMesh(texture2D.width, texture2D.height, alignment, origin, isBustShot: cachedIsBustShot, finalXOffset: (int) base.transform.localPosition.x);
 				}
 			}
 		}
@@ -822,6 +823,7 @@ namespace Assets.Scripts.Core.Scene
 					width: tex2d.width, height: tex2d.height,
 					alignment: ((x != 0 || y != 0) && !isBustshot) ? LayerAlignment.AlignTopleft : LayerAlignment.AlignCenter,
 					origin: origin,
+					isBustShot: isBustshot,
 					finalXOffset: x
 				);
 				if (primary != null)

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -328,13 +328,13 @@ namespace Assets.Scripts.Core.Scene
 			}
 		}
 
-		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, bool isBustShot, int finalXOffset, string newPrimaryName)
+		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, bool isBustShot, int finalXOffset, string texturePath)
 		{
 			bool ryukishiClamp = isBustShot && Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1;
 			bool stretchToFit = false;
-			if (newPrimaryName != null)
+			if (texturePath != null)
 			{
-				stretchToFit = Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 1 && newPrimaryName.Contains("background/");
+				stretchToFit = Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 1 && texturePath.Contains("OGBackgrounds");
 			}
 
 			if (mesh == null ||
@@ -366,7 +366,7 @@ namespace Assets.Scripts.Core.Scene
 		public void DrawLayerWithMask(string textureName, string maskName, int x, int y, Vector2? origin, bool isBustshot, int style, float wait, bool isBlocking)
 		{
 			cachedIsBustShot = isBustshot;
-			Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, textureName);
+			Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, textureName, out string texturePath);
 			Texture2D maskTexture = AssetManager.Instance.LoadTexture(maskName);
 			material.shader = shaderMasked;
 			SetPrimaryTexture(texture2D);
@@ -384,7 +384,7 @@ namespace Assets.Scripts.Core.Scene
 				origin: origin,
 				isBustShot: isBustshot,
 				finalXOffset: x,
-				newPrimaryName: textureName
+				texturePath: texturePath
 			);
 			SetRange(startRange);
 			base.transform.localPosition = new Vector3((float)x, (float)(-y), (float)Priority * -0.1f);
@@ -432,7 +432,7 @@ namespace Assets.Scripts.Core.Scene
 			}
 			else
 			{
-				Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, textureName);
+				Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, textureName, out string texturePath);
 				if (texture2D == null)
 				{
 					Logger.LogError("Failed to load texture " + textureName);
@@ -460,7 +460,7 @@ namespace Assets.Scripts.Core.Scene
 						origin: origin,
 						isBustShot: isBustshot,
 						finalXOffset: x,
-						newPrimaryName: textureName
+						texturePath: texturePath
 					);
 					aspectRatio = (float)texture2D.width / texture2D.height;
 					if (primary != null)
@@ -678,7 +678,7 @@ namespace Assets.Scripts.Core.Scene
 			}
 			else
 			{
-				Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, PrimaryName);
+				Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, PrimaryName, out string texturePath);
 				if (texture2D == null)
 				{
 					Logger.LogError("Failed to load texture " + PrimaryName);
@@ -693,7 +693,7 @@ namespace Assets.Scripts.Core.Scene
 						origin,
 						isBustShot: cachedIsBustShot,
 						finalXOffset: (int) base.transform.localPosition.x,
-						newPrimaryName: PrimaryName
+						texturePath: texturePath
 					);
 				}
 			}
@@ -851,7 +851,7 @@ namespace Assets.Scripts.Core.Scene
 					origin: origin,
 					isBustShot: isBustshot,
 					finalXOffset: x,
-					newPrimaryName: textureName
+					texturePath: null
 				);
 				if (primary != null)
 				{

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -327,8 +327,10 @@ namespace Assets.Scripts.Core.Scene
 			}
 		}
 
-		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, bool ryukishiClamp, int finalXOffset)
+		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, int finalXOffset)
 		{
+			bool ryukishiClamp = Buriko.BurikoMemory.Instance.GetGlobalFlag("GClampSprite43").IntValue() == 1;
+
 			if (mesh == null ||
 				!Mathf.Approximately((float)width / height, aspectRatio) ||
 				this.alignment != alignment ||
@@ -372,7 +374,6 @@ namespace Assets.Scripts.Core.Scene
 				width: texture2D.width, height: texture2D.height,
 				alignment: ((x != 0 || y != 0) && !isBustshot) ? LayerAlignment.AlignTopleft : LayerAlignment.AlignCenter,
 				origin: origin,
-				ryukishiClamp: isBustshot,
 				finalXOffset: x
 			);
 			SetRange(startRange);
@@ -447,7 +448,6 @@ namespace Assets.Scripts.Core.Scene
 						width: texture2D.width, height: texture2D.height,
 						alignment: ((x != 0 || y != 0) && !isBustshot) ? LayerAlignment.AlignTopleft : LayerAlignment.AlignCenter,
 						origin: origin,
-						ryukishiClamp: isBustshot,
 						finalXOffset: x
 					);
 					aspectRatio = (float)texture2D.width / texture2D.height;
@@ -675,7 +675,7 @@ namespace Assets.Scripts.Core.Scene
 				{
 					SetPrimaryTexture(texture2D);
 					//TODO: this function call doesn't know if it is a bustshot
-					EnsureCorrectlySizedMesh(texture2D.width, texture2D.height, alignment, origin, ryukishiClamp: false, finalXOffset: (int) base.transform.localPosition.x);
+					EnsureCorrectlySizedMesh(texture2D.width, texture2D.height, alignment, origin, finalXOffset: (int) base.transform.localPosition.x);
 				}
 			}
 		}
@@ -822,7 +822,6 @@ namespace Assets.Scripts.Core.Scene
 					width: tex2d.width, height: tex2d.height,
 					alignment: ((x != 0 || y != 0) && !isBustshot) ? LayerAlignment.AlignTopleft : LayerAlignment.AlignCenter,
 					origin: origin,
-					ryukishiClamp: isBustshot,
 					finalXOffset: x
 				);
 				if (primary != null)

--- a/Assets.Scripts.Core.Scene/LayerOld.cs
+++ b/Assets.Scripts.Core.Scene/LayerOld.cs
@@ -43,7 +43,7 @@ namespace Assets.Scripts.Core.Scene
 			{
 				meshRenderer = base.gameObject.AddComponent<MeshRenderer>();
 			}
-			mesh = MGHelper.CreateMesh(width, height, align);
+			mesh = MGHelper.CreateMesh(width, height, align,false, 0);
 			if (material != null)
 			{
 				if (!retainMainTexture)

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -170,6 +170,11 @@ namespace Assets.Scripts.Core.Scene
 
 		public void DrawBustshot(int layer, string textureName, int x, int y, int z, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking)
 		{
+			if (MODSkipImage(textureName))
+			{
+				return;
+			}
+
 			Layer i = GetLayer(layer);
 			while (i.FadingOut)
 			{
@@ -326,6 +331,11 @@ namespace Assets.Scripts.Core.Scene
 
 		public void DrawBG(string texture, float wait, bool isblocking)
 		{
+			if (MODSkipImage(texture))
+			{
+				return;
+			}
+
 			Scene scene = GetActiveScene();
 			scene.BackgroundLayer.DrawLayer(texture, 0, 0, 0, null, 0f, /*isBustshot:*/ false, 0, wait, isblocking);
 		}
@@ -376,6 +386,11 @@ namespace Assets.Scripts.Core.Scene
 
 		public void DrawSceneWithMask(string backgroundfilename, string maskname, float time)
 		{
+			if (MODSkipImage(backgroundfilename))
+			{
+				return;
+			}
+
 			SwapActiveScenes();
 			Scene s = GetActiveScene();
 			s.UpdateRange(0f);
@@ -393,6 +408,11 @@ namespace Assets.Scripts.Core.Scene
 
 		public void DrawScene(string backgroundfilename, float time)
 		{
+			if (MODSkipImage(backgroundfilename))
+			{
+				return;
+			}
+
 			SwapActiveScenes();
 			Scene s = GetActiveScene();
 			s.GetComponent<Camera>().enabled = false;
@@ -811,6 +831,11 @@ namespace Assets.Scripts.Core.Scene
 
 		public void MODDrawBustshot(int layer, string textureName, Texture2D tex2d, int x, int y, int z, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking)
 		{
+			if (MODSkipImage(textureName))
+			{
+				return;
+			}
+
 			Layer layer2 = GetLayer(layer);
 			while (layer2.FadingOut)
 			{
@@ -927,6 +952,16 @@ namespace Assets.Scripts.Core.Scene
 		{
 			MODLipSyncCoroutine = MODDrawLipSync(character, audiolayer, audiofile);
 			StartCoroutine(MODLipSyncCoroutine);
+		}
+
+		private bool MODSkipImage(string backgroundfilename)
+		{
+			if(Buriko.BurikoMemory.Instance.GetGlobalFlag("GHideCG").IntValue() == 1 && backgroundfilename.Contains("scene/"))
+			{
+				return true;
+			}
+
+			return false;
 		}
 	}
 }

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -209,6 +209,7 @@ namespace Assets.Scripts.Core.State
 					}
 					if (BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
 					{
+						GameSystem.Instance.MainUIController.ShowToast($"Can't toggle now - try later", maybeSound: null);
 						return false;
 					}
 					GameSystem.Instance.MainUIController.MODResetLayerBackground();
@@ -227,21 +228,14 @@ namespace Assets.Scripts.Core.State
 					{
 						return false;
 					}
-					int num4 = BurikoMemory.Instance.GetGlobalFlag("GCensor").IntValue();
-					int num5 = BurikoMemory.Instance.GetGlobalFlag("GCensorMaxNum").IntValue();
-					if (num4 < num5 && num4 >= 0)
-					{
-						num4++;
-						string str3 = num4.ToString();
-						string str4 = ".ogg";
-						string filename2 = "switchsound/" + str3 + str4;
-						GameSystem.Instance.AudioController.PlaySystemSound(filename2);
-						BurikoMemory.Instance.SetGlobalFlag("GCensor", num4);
-						return true;
-					}
-					num4 = 0;
-					BurikoMemory.Instance.SetGlobalFlag("GCensor", num4);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/0.ogg");
+					int censorNum = BurikoMemory.Instance.GetGlobalFlag("GCensor").IntValue();
+					int maxCensorNum = BurikoMemory.Instance.GetGlobalFlag("GCensorMaxNum").IntValue();
+					censorNum = (censorNum + 1) % (maxCensorNum + 1); //cycle from 0 to maxCensorNum
+					BurikoMemory.Instance.SetGlobalFlag("GCensor", censorNum);
+					GameSystem.Instance.MainUIController.ShowToast(
+						$"Censorship Level: {censorNum}{(censorNum == 2 ? " (default)" : "")}",
+						numberedSound: censorNum
+					);
 				}
 				if (Input.GetKeyDown(KeyCode.F3))
 				{
@@ -521,14 +515,11 @@ namespace Assets.Scripts.Core.State
 					{
 						return false;
 					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GLipSync").IntValue() == 1)
-					{
-						BurikoMemory.Instance.SetGlobalFlag("GLipSync", 0);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-						return true;
-					}
-					BurikoMemory.Instance.SetGlobalFlag("GLipSync", 1);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
+
+					// Toggle lipsync between 0 and 1
+					int newLipSync = (BurikoMemory.Instance.GetGlobalFlag("GLipSync").IntValue() + 1) % 2;
+					BurikoMemory.Instance.SetGlobalFlag("GLipSync", newLipSync);
+					GameSystem.Instance.MainUIController.ShowToast($"Lip Sync: {(newLipSync == 1 ? "ON": "OFF")}");
 				}
 				if (Input.GetKeyDown(KeyCode.M))
 				{

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -31,6 +31,8 @@ namespace Assets.Scripts.Core.State
 		{
 		}
 
+		// NOTE: Returning "false" from this function prevents the game from advancing!
+		// See GameSystem.Update() in  for details.
 		public bool InputHandler()
 		{
 			if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
@@ -100,500 +102,40 @@ namespace Assets.Scripts.Core.State
 				}
 				return false;
 			}
-			if (!Input.GetMouseButtonDown(1) && !Input.GetKeyDown(KeyCode.Escape))
+
+			// Right click or ESC key toggles the menu
+			if (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape))
 			{
-				if (Input.GetKey(KeyCode.LeftShift))
+				if (!gameSystem.MessageBoxVisible && gameSystem.GameState == GameState.Normal)
 				{
-					if (Input.GetKeyDown(KeyCode.F10))
-					{
-						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-						{
-							return false;
-						}
-						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-						{
-							return false;
-						}
-						if (BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 0)
-						{
-							return false;
-						}
-						if (BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 1)
-						{
-							BurikoMemory.Instance.SetGlobalFlag("GMOD_DEBUG_MODE", 2);
-							GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-							return true;
-						}
-						BurikoMemory.Instance.SetGlobalFlag("GMOD_DEBUG_MODE", 1);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-						return true;
-					}
-					if (Input.GetKeyDown(KeyCode.F9))
-					{
-						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-						{
-							return false;
-						}
-						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-						{
-							return false;
-						}
-						int num = BurikoMemory.Instance.GetGlobalFlag("GMOD_SETTING_LOADER").IntValue();
-						if (num < 3 && num >= 0)
-						{
-							num++;
-							string str = num.ToString();
-							string str2 = ".ogg";
-							string filename = "switchsound/" + str + str2;
-							GameSystem.Instance.AudioController.PlaySystemSound(filename);
-							BurikoMemory.Instance.SetGlobalFlag("GMOD_SETTING_LOADER", num);
-							return true;
-						}
-						num = 0;
-						BurikoMemory.Instance.SetGlobalFlag("GMOD_SETTING_LOADER", num);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/0.ogg");
-					}
-					if (Input.GetKeyDown(KeyCode.M))
-					{
-						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-						{
-							return false;
-						}
-						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-						{
-							return false;
-						}
-						AdjustVoiceVolumeAbsolute(100);
-						return true;
-					}
-					if (Input.GetKeyDown(KeyCode.N))
-					{
-						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-						{
-							return false;
-						}
-						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-						{
-							return false;
-						}
-						if (BurikoMemory.Instance.GetGlobalFlag("GVoiceVolume").IntValue() == 0)
-						{
-							return true;
-						}
-						AdjustVoiceVolumeAbsolute(0);
-						return true;
-					}
+					return false;
 				}
-				if (Input.GetKeyDown(KeyCode.F1))
+				if (gameSystem.IsAuto && gameSystem.ClickDuringAuto)
 				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+					gameSystem.IsAuto = false;
+					if (gameSystem.WaitList.Exists((Wait a) => a.Type == WaitTypes.WaitForAuto))
 					{
-						return false;
+						gameSystem.AddWait(new Wait(0f, WaitTypes.WaitForInput, null));
 					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
-					{
-						GameSystem.Instance.MainUIController.ShowToast($"Can't toggle now - try later", maybeSound: null);
-						return false;
-					}
-					GameSystem.Instance.MainUIController.MODResetLayerBackground();
+					return false;
 				}
-				if (Input.GetKeyDown(KeyCode.F2))
+				gameSystem.IsSkipping = false;
+				gameSystem.IsForceSkip = false;
+				if (gameSystem.RightClickMenu)
 				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					int censorNum = BurikoMemory.Instance.GetGlobalFlag("GCensor").IntValue();
-					int maxCensorNum = BurikoMemory.Instance.GetGlobalFlag("GCensorMaxNum").IntValue();
-					censorNum = (censorNum + 1) % (maxCensorNum + 1); //cycle from 0 to maxCensorNum
-					BurikoMemory.Instance.SetGlobalFlag("GCensor", censorNum);
-					GameSystem.Instance.MainUIController.ShowToast(
-						$"Censorship Level: {censorNum}{(censorNum == 2 ? " (default)" : "")}",
-						numberedSound: censorNum
-					);
+					gameSystem.SwitchToRightClickMenu();
 				}
-				if (Input.GetKeyDown(KeyCode.F3))
+				else
 				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					int num6 = BurikoMemory.Instance.GetGlobalFlag("GEffectExtend").IntValue();
-					int num7 = BurikoMemory.Instance.GetGlobalFlag("GEffectExtendMaxNum").IntValue();
-					if (num6 < num7 && num6 >= 0)
-					{
-						num6++;
-						string str5 = num6.ToString();
-						string str6 = ".ogg";
-						string filename3 = "switchsound/" + str5 + str6;
-						GameSystem.Instance.AudioController.PlaySystemSound(filename3);
-						BurikoMemory.Instance.SetGlobalFlag("GEffectExtend", num6);
-						return true;
-					}
-					num6 = 0;
-					BurikoMemory.Instance.SetGlobalFlag("GEffectExtend", num6);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/0.ogg");
+					gameSystem.SwitchToHiddenWindow2();
 				}
-				if (Input.GetKeyDown(KeyCode.F5))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (!gameSystem.CanSave)
-					{
-						return false;
-					}
-					BurikoScriptSystem.Instance.SaveQuickSave();
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.F7))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					BurikoScriptSystem.Instance.LoadQuickSave();
-				}
-				if (Input.GetKeyDown(KeyCode.F10))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() != 1 && BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() != 2)
-					{
-						if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 0)
-						{
-							BurikoMemory.Instance.SetFlag("LFlagMonitor", 1);
-							return true;
-						}
-						if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 1)
-						{
-							BurikoMemory.Instance.SetFlag("LFlagMonitor", 2);
-							return true;
-						}
-						BurikoMemory.Instance.SetFlag("LFlagMonitor", 0);
-						return true;
-					}
-					int num8 = BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue();
-					if (num8 < 4)
-					{
-						num8++;
-						BurikoMemory.Instance.SetFlag("LFlagMonitor", num8);
-						return true;
-					}
-					if (num8 >= 4 || num8 < 0)
-					{
-						BurikoMemory.Instance.SetFlag("LFlagMonitor", 0);
-						return true;
-					}
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha0) || Input.GetKeyDown(KeyCode.Keypad0))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 1 || BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 2)
-					{
-						GameSystem.Instance.MainUIController.MODDebugFontSizeChanger();
-					}
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue() == 1)
-					{
-						BurikoMemory.Instance.SetGlobalFlag("GAltBGM", 0);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-						return true;
-					}
-					BurikoMemory.Instance.SetGlobalFlag("GAltBGM", 1);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					int num9 = BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue();
-					int num10 = BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue();
-					if (num9 < num10 && num9 >= 0)
-					{
-						num9++;
-						string str7 = num9.ToString();
-						string str8 = ".ogg";
-						string filename4 = "switchsound/" + str7 + str8;
-						GameSystem.Instance.AudioController.PlaySystemSound(filename4);
-						BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", num9);
-						return true;
-					}
-					num9 = 0;
-					BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", num9);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/0.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue() == 1)
-					{
-						BurikoMemory.Instance.SetGlobalFlag("GAltSE", 0);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-						return true;
-					}
-					BurikoMemory.Instance.SetGlobalFlag("GAltSE", 1);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					int num11 = BurikoMemory.Instance.GetGlobalFlag("GAltSEflow").IntValue();
-					int num12 = BurikoMemory.Instance.GetGlobalFlag("GAltSEflowMaxNum").IntValue();
-					if (num11 < num12 && num11 >= 0)
-					{
-						num11++;
-						string str9 = num11.ToString();
-						string str10 = ".ogg";
-						string filename5 = "switchsound/" + str9 + str10;
-						GameSystem.Instance.AudioController.PlaySystemSound(filename5);
-						BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", num11);
-						return true;
-					}
-					num11 = 0;
-					BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", num11);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/0.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha5) || Input.GetKeyDown(KeyCode.Keypad5))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltVoice").IntValue() == 1)
-					{
-						BurikoMemory.Instance.SetGlobalFlag("GAltVoice", 0);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-						return true;
-					}
-					BurikoMemory.Instance.SetGlobalFlag("GAltVoice", 1);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha6) || Input.GetKeyDown(KeyCode.Keypad6))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltVoicePriority").IntValue() == 1)
-					{
-						BurikoMemory.Instance.SetGlobalFlag("GAltVoicePriority", 0);
-						GameSystem.Instance.AudioController.PlaySystemSound("switchsound/disable.ogg");
-						return true;
-					}
-					BurikoMemory.Instance.SetGlobalFlag("GAltVoicePriority", 1);
-					GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
-				}
-				if (Input.GetKeyDown(KeyCode.Alpha7) || Input.GetKeyDown(KeyCode.Keypad7))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
-					if (BurikoMemory.Instance.GetFlag("DisableModHotkey").IntValue() == 1)
-					{
-						return false;
-					}
+				return false;
 
-					// Toggle lipsync between 0 and 1
-					int newLipSync = (BurikoMemory.Instance.GetGlobalFlag("GLipSync").IntValue() + 1) % 2;
-					BurikoMemory.Instance.SetGlobalFlag("GLipSync", newLipSync);
-					GameSystem.Instance.MainUIController.ShowToast($"Lip Sync: {(newLipSync == 1 ? "ON": "OFF")}");
-				}
-				if (Input.GetKeyDown(KeyCode.M))
-				{
-					if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-					{
-						return false;
-					}
-					if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-					{
-						return false;
-					}
+			}
 
-					AdjustVoiceVolumeRelative(5);
-
-					return true;
-				}
-				if (!Input.GetKeyDown(KeyCode.N))
-				{
-					if (Input.GetKeyDown(KeyCode.A))
-					{
-						gameSystem.IsAuto = !gameSystem.IsAuto;
-						if (gameSystem.IsAuto)
-						{
-							return true;
-						}
-						if (gameSystem.WaitList.Exists((Wait a) => a.Type == WaitTypes.WaitForAuto))
-						{
-							gameSystem.AddWait(new Wait(0f, WaitTypes.WaitForInput, null));
-						}
-					}
-					if (Input.GetKeyDown(KeyCode.S))
-					{
-						gameSystem.IsSkipping = !gameSystem.IsSkipping;
-					}
-					if (Input.GetKeyDown(KeyCode.F))
-					{
-						if (GameSystem.Instance.IsFullscreen)
-						{
-							int num14 = PlayerPrefs.GetInt("width");
-							int num15 = PlayerPrefs.GetInt("height");
-							if (num14 == 0 || num15 == 0)
-							{
-								num14 = 640;
-								num15 = 480;
-							}
-							GameSystem.Instance.DeFullscreen(width: num14, height: num15);
-						}
-						else
-						{
-							GameSystem.Instance.GoFullscreen();
-						}
-					}
-					if (Input.GetKeyDown(KeyCode.L))
-					{
-						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-						{
-							return false;
-						}
-						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForText))
-						{
-							GameSystem.Instance.UseEnglishText = !GameSystem.Instance.UseEnglishText;
-							int val = 0;
-							if (gameSystem.UseEnglishText)
-							{
-								val = 1;
-							}
-							gameSystem.TextController.SwapLanguages();
-							BurikoMemory.Instance.SetGlobalFlag("GLanguage", val);
-						}
-					}
-					if (Input.GetKeyDown(KeyCode.P))
-					{
-						if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
-						{
-							return false;
-						}
-						if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
-						{
-							return false;
-						}
-						MODSystem.instance.modTextureController.ToggleArtStyle();
-					}
-					return true;
-				}
-
-				// The below section of code is executed if the N key is pressed.
-				// TODO: lift the body of the `if (!Input.GetKeyDown(KeyCode.N))` statement outside so it is less confusing.
+			// Quicksave
+			if (Input.GetKeyDown(KeyCode.F5))
+			{
 				if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
 				{
 					return false;
@@ -602,65 +144,95 @@ namespace Assets.Scripts.Core.State
 				{
 					return false;
 				}
-				int num16 = BurikoMemory.Instance.GetGlobalFlag("GVoiceVolume").IntValue();
-				if (num16 == 0)
+				if (!gameSystem.CanSave)
+				{
+					return false;
+				}
+				BurikoScriptSystem.Instance.SaveQuickSave();
+				GameSystem.Instance.AudioController.PlaySystemSound("switchsound/enable.ogg");
+			}
+
+			// Quickload
+			if (Input.GetKeyDown(KeyCode.F7))
+			{
+				if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+				{
+					return false;
+				}
+				if (!gameSystem.HasWaitOfType(WaitTypes.WaitForInput))
+				{
+					return false;
+				}
+				BurikoScriptSystem.Instance.LoadQuickSave();
+			}
+
+			// Auto-Mode
+			if (Input.GetKeyDown(KeyCode.A))
+			{
+				gameSystem.IsAuto = !gameSystem.IsAuto;
+				if (gameSystem.IsAuto)
 				{
 					return true;
 				}
-
-				AdjustVoiceVolumeRelative(-5);
-
-				return true;
-			}
-			if (!gameSystem.MessageBoxVisible && gameSystem.GameState == GameState.Normal)
-			{
-				return false;
-			}
-			if (gameSystem.IsAuto && gameSystem.ClickDuringAuto)
-			{
-				gameSystem.IsAuto = false;
 				if (gameSystem.WaitList.Exists((Wait a) => a.Type == WaitTypes.WaitForAuto))
 				{
 					gameSystem.AddWait(new Wait(0f, WaitTypes.WaitForInput, null));
 				}
-				return false;
 			}
-			gameSystem.IsSkipping = false;
-			gameSystem.IsForceSkip = false;
-			if (gameSystem.RightClickMenu)
+
+			// Skip
+			if (Input.GetKeyDown(KeyCode.S))
 			{
-				gameSystem.SwitchToRightClickMenu();
+				gameSystem.IsSkipping = !gameSystem.IsSkipping;
 			}
-			else
+
+			// Fullscreen
+			if (Input.GetKeyDown(KeyCode.F))
 			{
-				gameSystem.SwitchToHiddenWindow2();
+				if (GameSystem.Instance.IsFullscreen)
+				{
+					int num14 = PlayerPrefs.GetInt("width");
+					int num15 = PlayerPrefs.GetInt("height");
+					if (num14 == 0 || num15 == 0)
+					{
+						num14 = 640;
+						num15 = 480;
+					}
+					GameSystem.Instance.DeFullscreen(width: num14, height: num15);
+				}
+				else
+				{
+					GameSystem.Instance.GoFullscreen();
+				}
 			}
-			return false;
+
+			// Toggle Language
+			if (Input.GetKeyDown(KeyCode.L))
+			{
+				if (!gameSystem.MessageBoxVisible || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+				{
+					return false;
+				}
+				if (!gameSystem.HasWaitOfType(WaitTypes.WaitForText))
+				{
+					GameSystem.Instance.UseEnglishText = !GameSystem.Instance.UseEnglishText;
+					int val = 0;
+					if (gameSystem.UseEnglishText)
+					{
+						val = 1;
+					}
+					gameSystem.TextController.SwapLanguages();
+					BurikoMemory.Instance.SetGlobalFlag("GLanguage", val);
+				}
+			}
+
+			// Returning true here allows the game to continue
+			return true;
 		}
 
 		public GameState GetStateType()
 		{
 			return GameState.Normal;
-		}
-
-		private void AdjustVoiceVolumeRelative(int difference)
-		{
-			// Maintaining volume within limits is done in AdjustVoiceVolumeAbsolute()
-			AdjustVoiceVolumeAbsolute(BurikoMemory.Instance.GetGlobalFlag("GVoiceVolume").IntValue() + difference);
-		}
-
-		private void AdjustVoiceVolumeAbsolute(int uncheckedNewVolume)
-		{
-			int newVolume = Mathf.Clamp(uncheckedNewVolume, 0, 100);
-
-			BurikoMemory.Instance.SetGlobalFlag("GVoiceVolume", newVolume);
-			GameSystem.Instance.AudioController.VoiceVolume = (float)newVolume / 100f;
-			GameSystem.Instance.AudioController.RefreshLayerVolumes();
-
-			// Play a sample voice file so the user can get feedback on the set volume
-			// For some reason the script uses "256" as the default volume, which gets divided by 128 to become 2.0f,
-			// so to keep in line with the script, the test volume is set to "2.0f"
-			GameSystem.Instance.AudioController.PlayVoice("voice_test.ogg", 3, 2.0f);
 		}
 	}
 }

--- a/Assets.Scripts.Core/GameState.cs
+++ b/Assets.Scripts.Core/GameState.cs
@@ -20,6 +20,7 @@ namespace Assets.Scripts.Core
 		ChapterScreen,
 		ChapterJumpScreen,
 		ChapterPreview,
-		Movie
+		Movie,
+		MODDisableInput
 	}
 }

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -164,6 +164,11 @@ namespace Assets.Scripts.Core
 
 		public float AspectRatio;
 
+		// Set to True to ignore normal gameplay inputs:
+		// - Disables normal inputs (e.g to advance text) in main GameSystem loop
+		// - Disables some GUI inputs by manually added checks in each button type
+		public bool MODIgnoreInputs;
+
 		// Unity will attempt to deserialize public properties and these aren't in the AssetBundle,
 		// so use private ones with public accessors
 		private bool _isFullscreen;
@@ -847,7 +852,7 @@ namespace Assets.Scripts.Core
 				{
 					if (blockInputTime <= 0f)
 					{
-						if ((CanInput || GameState != GameState.Normal) && (inputHandler == null || !inputHandler()))
+						if ((CanInput || GameState != GameState.Normal) && (MODIgnoreInputs || inputHandler == null || !inputHandler()))
 						{
 							return;
 						}

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -143,6 +143,7 @@ namespace Assets.Scripts.Core
 		private PromptController promptController;
 
 		private ConfigManager configManager;
+		public ConfigManager ConfigManager() => configManager;
 
 		private GalleryManager galleryManager;
 

--- a/Assets.Scripts.Core/MGHelper.cs
+++ b/Assets.Scripts.Core/MGHelper.cs
@@ -55,12 +55,8 @@ namespace Assets.Scripts.Core
 					float ratio = newX / vertices[i].x;
 					vertices[i].x = newX;
 
-					// Adjust UV X coordinates proportinally by how much we adjusted each vector
-					// TODO: this is more complicated than I thought, as need to make sure that 
-					// the resultant image appears in the same place.
+					// Adjust UV X coordinates proportionally by how much we adjusted each vector
 					uv[i].x = scaleFromOrigin(uv[i].x, ratio);
-
-					Logger.Log($"newX: {newX} ratio: {ratio} uv[{i}].x: {uv[i].x}");
 				}
 			}
 		}

--- a/Assets.Scripts.Core/MGHelper.cs
+++ b/Assets.Scripts.Core/MGHelper.cs
@@ -28,7 +28,44 @@ namespace Assets.Scripts.Core
 
 		private static bool typeCheck;
 
-		public static Mesh CreateMeshWithOrigin(int width, int height, Vector2 origin)
+		public static void ClampValuesIfNecessary(Vector3[] vertices, Vector2[] uv, bool ryukishiClamp, int finalXOffset)
+		{
+			float scaleFromOrigin(float value, float scale)
+			{
+				return ((value - .5f) * scale) + .5f;
+			}
+
+			Vector2 scaleVector2FromOrigin(Vector2 vec, float xScale, float yScale)
+			{
+				return new Vector2(scaleFromOrigin(vec.x, xScale), scaleFromOrigin(vec.y, yScale));
+			}
+
+
+			if (ryukishiClamp)
+			{
+				// Ryukishi is nominally has x limited to [-320, 320]
+				// but since the x transform happens afterwards, we need to adjust for that
+				float minX = -320 - finalXOffset;
+				float maxX = 320 - finalXOffset;
+
+				for (int i = 0; i < 4; i++)
+				{
+					// Clamp the x of each vertex
+					float newX = Mathf.Clamp(vertices[i].x, minX, maxX);
+					float ratio = newX / vertices[i].x;
+					vertices[i].x = newX;
+
+					// Adjust UV X coordinates proportinally by how much we adjusted each vector
+					// TODO: this is more complicated than I thought, as need to make sure that 
+					// the resultant image appears in the same place.
+					uv[i].x = scaleFromOrigin(uv[i].x, ratio);
+
+					Logger.Log($"newX: {newX} ratio: {ratio} uv[{i}].x: {uv[i].x}");
+				}
+			}
+		}
+
+		public static Mesh CreateMeshWithOrigin(int width, int height, Vector2 origin, bool ryukishiClamp, int finalXOffset)
 		{
 			Mesh mesh = new Mesh();
 			float num = Mathf.Round((float)width / 2f);
@@ -41,11 +78,14 @@ namespace Assets.Scripts.Core
 			Vector3 vector4 = new Vector3(0f - num - origin.x, 0f - num2 + origin.y, 0f);
 			Vector3[] vertices = new Vector3[4]
 			{
-				vector2,
-				vector3,
-				vector,
-				vector4
+				// I'm not sure which one is actually top/bottom left/right, 
+				// as it depends on where the camera is, and unity's coordinate system.
+				vector2, // 426,  240
+				vector3, // 426, -240
+				vector,  //-426,  240
+				vector4  //-426, -240
 			};
+
 			Vector2[] uv = new Vector2[4]
 			{
 				new Vector2(1f, 1f),
@@ -53,6 +93,9 @@ namespace Assets.Scripts.Core
 				new Vector2(0f, 1f),
 				new Vector2(0f, 0f)
 			};
+
+			ClampValuesIfNecessary(vertices, uv, ryukishiClamp, finalXOffset);
+
 			int[] triangles = new int[6]
 			{
 				0,
@@ -70,7 +113,7 @@ namespace Assets.Scripts.Core
 			return mesh;
 		}
 
-		public static Mesh CreateMesh(int width, int height, LayerAlignment alignment)
+		public static Mesh CreateMesh(int width, int height, LayerAlignment alignment, bool ryukishiClamp, int finalXOffset)
 		{
 			Mesh mesh = new Mesh();
 			float num = Mathf.Round((float)width / 2f);
@@ -117,6 +160,9 @@ namespace Assets.Scripts.Core
 				new Vector2(0f, 1f),
 				new Vector2(0f, 0f)
 			};
+
+			ClampValuesIfNecessary(vertices, uv, ryukishiClamp, finalXOffset);
+
 			int[] triangles = new int[6]
 			{
 				0,

--- a/Assets.Scripts.UI.Config/ConfigManager.cs
+++ b/Assets.Scripts.UI.Config/ConfigManager.cs
@@ -18,6 +18,8 @@ namespace Assets.Scripts.UI.Config
 
 		private UIPanel panel;
 
+		public float PanelAlpha() => panel.alpha;
+
 		private IEnumerator LeaveScreen(LeaveConfigDelegate callback)
 		{
 			panel = Panel.GetComponent<UIPanel>();

--- a/Assets.Scripts.UI.Menu/MenuUIButton.cs
+++ b/Assets.Scripts.UI.Menu/MenuUIButton.cs
@@ -15,11 +15,17 @@ namespace Assets.Scripts.UI.Menu
 
 		private GameSystem gameSystem;
 
+		private UIButton button;
+
 		private void OnClick()
 		{
 			if (gameSystem == null)
 			{
 				gameSystem = GameSystem.Instance;
+			}
+			if(gameSystem.MODIgnoreInputs)
+			{
+				return;
 			}
 			if (gameSystem.GameState == GameState.RightClickMenu && !(time > 0f) && UICamera.currentTouchID == -1 && isEnabled)
 			{
@@ -91,6 +97,16 @@ namespace Assets.Scripts.UI.Menu
 		private void Update()
 		{
 			time -= Time.deltaTime;
+		}
+
+		private void Awake()
+		{
+			button = GetComponent<UIButton>();
+		}
+
+		private void LateUpdate()
+		{
+			button.isEnabled = !GameSystem.Instance.MODIgnoreInputs;
 		}
 	}
 }

--- a/Assets.Scripts.UI.TitleScreen/TitleScreenButton.cs
+++ b/Assets.Scripts.UI.TitleScreen/TitleScreenButton.cs
@@ -28,6 +28,9 @@ namespace Assets.Scripts.UI.TitleScreen
 		private void OnClick()
 		{
 			GameSystem gameSystem = GameSystem.Instance;
+
+			if(gameSystem.MODIgnoreInputs) { return; }
+
 			if (gameSystem.GameState == GameState.TitleScreen && !(time > 0f) && UICamera.currentTouchID == -1)
 			{
 				StateTitle stateTitle = gameSystem.GetStateObject() as StateTitle;
@@ -102,7 +105,7 @@ namespace Assets.Scripts.UI.TitleScreen
 
 		private void LateUpdate()
 		{
-			button.isEnabled = (GameSystem.Instance.GameState == GameState.TitleScreen && !IsLeaving);
+			button.isEnabled = (!GameSystem.Instance.MODIgnoreInputs && GameSystem.Instance.GameState == GameState.TitleScreen && !IsLeaving);
 			if (!isReady && time < 0f)
 			{
 				if (!button.enabled)

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -75,6 +75,7 @@ namespace Assets.Scripts.UI
 			Normal,
 			ADV,
 			NVLInADV,
+			OG,
 		}
 
 		public enum ModSetting
@@ -526,6 +527,10 @@ namespace Assets.Scripts.UI
 			{
 				windowFilterTextureName = "windo_filter_nvladv";
 			}
+			else if (filterType == WindowFilterType.OG)
+			{
+				windowFilterTextureName = "windo_filter_og";
+			}
 
 			ui.bgLayer.ReleaseTextures();
 			ui.bgLayer2.ReleaseTextures();
@@ -587,7 +592,7 @@ namespace Assets.Scripts.UI
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
 				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 1);
 				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
-				TryRedrawTextWindowBackground(WindowFilterType.Normal);
+				TryRedrawTextWindowBackground(WindowFilterType.OG);
 				mODMainUIController.RyukishiGuiPositionStore();
 				mODMainUIController.RyukishiModeSettingStore();
 				GameSystem.Instance.MainUIController.ShowToast($"Set OG Mode", isEnable: false);

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -724,7 +724,7 @@ namespace Assets.Scripts.UI
 					english: Core.AssetManagement.AssetManager.Instance.CurrentArtset.nameEN
 				);
 				string textToDraw = string.Join("\n", new string[] {
-					"[MOD SETTINGS]",
+					"[MOD SETTINGS] (Press F10 to toggle)",
 					boolDesc("GADVMode",                             "ADV-MODE"),
 					boolDesc("GLipSync",                             "Lip-Sync"),
 					boolDesc("GAltBGM",                              "Alternative BGM"),
@@ -766,7 +766,7 @@ namespace Assets.Scripts.UI
 					"F5 : QuickSave",
 					"F7 : QuickLoad",
 					"F10 : Setting Monitor",
-					"F11 : OP Movies",
+					"SHIFT-F11 : OP Movies",
 					"M : Increase Voice Volume",
 					"N : Decrease Voice Volume",
 					"1 : Alternative BGM (Not Used)",
@@ -1138,6 +1138,10 @@ namespace Assets.Scripts.UI
 				{
 					return Action.RestoreSettings;
 				}
+				else if (Input.GetKeyDown(KeyCode.F11))
+				{
+					return Action.OpeningVideo;
+				}
 				else if (Input.GetKeyDown(KeyCode.M))
 				{
 					return Action.VoiceVolumeMax;
@@ -1171,10 +1175,6 @@ namespace Assets.Scripts.UI
 			else if (Input.GetKeyDown(KeyCode.F10))
 			{
 				return Action.FlagMonitor;
-			}
-			else if (Input.GetKeyDown(KeyCode.F11))
-			{
-				return Action.OpeningVideo;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha0) || Input.GetKeyDown(KeyCode.Keypad0))
 			{

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -515,8 +515,15 @@ namespace Assets.Scripts.UI
 		// https://forum.unity.com/threads/gui-that-hidden-bastard.257383/
 		// https://answers.unity.com/questions/259870/performance-of-an-empty-ongui-fixedupdate.html
 		// Consider moving this to its own class, then disabling it if there is nothing to be drawn.
+		// NOTE: this function can be called before Update() if CTRL (skip) down during game startup
 		public void OnGUI()
 		{
+			// This can happen if you hold CTRL (skip) during game startup, presumably because OnGUI() gets called before the first Update() call
+			if(this.gameSystem == null)
+			{
+				return;
+			}
+
 			if(this.styleManager == null)
 			{
 				this.styleManager = new MODStyleManager();

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -441,6 +441,19 @@ namespace Assets.Scripts.UI
 
 		private void Update()
 		{
+			if (Input.GetKeyDown(KeyCode.F11))
+			{
+				// Loop "GVideoOpening" over the values 1-3.
+				// 0 is skipped as it represents "value not set"
+				int newVideoOpening = BurikoMemory.Instance.GetGlobalFlag("GVideoOpening").IntValue() + 1;
+				if (newVideoOpening > 3)
+				{
+					newVideoOpening = 1;
+				}
+				BurikoMemory.Instance.SetGlobalFlag("GVideoOpening", newVideoOpening);
+				GameSystem.Instance.MainUIController.ShowToast($"OP Video: {VideoOpeningDescription(newVideoOpening)} ({newVideoOpening})");
+			}
+
 			// Update the toast countdown timer, making sure it doesn't go below 0
 			toastNotificationTimer = Math.Max(0, toastNotificationTimer - Time.deltaTime);
 			if (gameSystem == null)
@@ -637,7 +650,6 @@ namespace Assets.Scripts.UI
 				string canSaveDesc = gameSystem.CanSave ? "" : "You can't save now\n";
 				string canInputDesc = gameSystem.CanInput ? "" : "Game avoid any input now\n";
 				var videoOpeningValue = BurikoMemory.Instance.GetGlobalFlag("GVideoOpening").IntValue();
-				var videoOpeningDescription = videoOpeningValue == 0 ? "Unset" : videoOpeningValue == 1 ? "Disabled" : videoOpeningValue == 2 ? "In-game" : videoOpeningValue == 3 ? "At launch + in-game" : "Unknown";
 				var artsetDescription = "Art = " + GameSystem.Instance.ChooseJapaneseEnglish(
 					japanese: Core.AssetManagement.AssetManager.Instance.CurrentArtset.nameJP,
 					english: Core.AssetManagement.AssetManager.Instance.CurrentArtset.nameEN
@@ -655,7 +667,7 @@ namespace Assets.Scripts.UI
 					intDesc ("GCensor",       "GCensorMaxNum",       "Voice Matching Level"),
 					intDesc ("GEffectExtend", "GEffectExtendMaxNum", "Effect Level"),
 					"Voice Volume = " + BurikoMemory.Instance.GetGlobalFlag("GVoiceVolume").IntValue().ToString(),
-					$"OP Movies = {videoOpeningDescription} ({videoOpeningValue})",
+					$"OP Movies = {VideoOpeningDescription(videoOpeningValue)} ({videoOpeningValue})",
 					artsetDescription,
 					"\n[Restore Game Settings]",
 					settingLoaderDesc,
@@ -685,6 +697,7 @@ namespace Assets.Scripts.UI
 					"F5 : QuickSave",
 					"F7 : QuickLoad",
 					"F10 : Setting Monitor",
+					"F11 : OP Movies",
 					"M : Increase Voice Volume",
 					"N : Decrease Voice Volume",
 					"1 : Alternative BGM",
@@ -901,6 +914,23 @@ namespace Assets.Scripts.UI
 			}
 
 			ShowToast(toastText, sound, toastDuration);
+		}
+
+		public static string VideoOpeningDescription(int videoOpeningValue)
+		{
+			switch(videoOpeningValue)
+			{
+				case 0:
+					return "Unset";
+				case 1:
+					return "Disabled";
+				case 2:
+					return "In-game";
+				case 3:
+					return "At launch + in-game";
+			}
+
+			return "Unknown";
 		}
 	}
 }

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -519,6 +519,12 @@ namespace Assets.Scripts.UI
 		// NOTE: this function can be called before Update() if CTRL (skip) down during game startup
 		public void OnGUI()
 		{
+			if(BurikoSaveManager.lastSaveError != null)
+			{
+				MODMenu.EmergencyModMenu("Error loading save file! Please backup your saves, DISABLE STEAM SYNC, then delete the following save file:", BurikoSaveManager.lastSaveError);
+				return;
+			}
+
 			// This can happen if you hold CTRL (skip) during game startup, presumably because OnGUI() gets called before the first Update() call
 			if(this.gameSystem == null)
 			{

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -743,7 +743,7 @@ namespace Assets.Scripts.UI
 					"\n[Status]",
 					hotkeyDesc + nvlAdvDesc + canSaveDesc + canInputDesc
 				});
-				GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), textToDraw, 900);
+				GUIUnclickableTextArea(new Rect(0f, 0f, 320f, 1080f), textToDraw);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() == 2)
 			{
@@ -780,7 +780,7 @@ namespace Assets.Scripts.UI
 					"LShift + M : Voice Volume MAX",
 					"LShift + N : Voice Volume MIN"
 				});
-				GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), textToDraw, 900);
+				GUIUnclickableTextArea(new Rect(320f, 0f, 320f, 1080f), textToDraw);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() >= 3)
 			{
@@ -829,7 +829,7 @@ namespace Assets.Scripts.UI
 					"CanInput = " + (gameSystem.CanInput ? "true" : "false"),
 					"CanSave = " + (gameSystem.CanSave ? "true" : "false"),
 				});
-				GUI.TextArea(new Rect(0f, 0f, 320f, 1080f), textToDraw, 900);
+				GUIUnclickableTextArea(new Rect(0f, 0f, 320f, 1080f), textToDraw);
 			}
 			if (BurikoMemory.Instance.GetFlag("LFlagMonitor").IntValue() >= 4)
 			{
@@ -887,7 +887,7 @@ namespace Assets.Scripts.UI
 					.Select(flag => flag + " = " + (getOptionalLocalFlag(flag)?.IntValue().ToString() ?? "disable"))
 					.ToArray()
 				);
-				GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), textToDraw, 900);
+				GUIUnclickableTextArea(new Rect(320f, 0f, 320f, 1080f), textToDraw);
 			}
 
 			if(toastNotificationTimer > 0)
@@ -1400,6 +1400,15 @@ namespace Assets.Scripts.UI
 			}
 
 			return true;
+		}
+
+		/// <summary>
+		/// This looks the same as a TextArea, but you can't click on it
+		/// WARNING: Only call this function from OnGUI()
+		/// </summary>
+		private static void GUIUnclickableTextArea(Rect rect, string text)
+		{
+			GUI.Label(rect, text, GUI.skin.textArea);
 		}
 	}
 }

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -1122,6 +1122,7 @@ namespace Assets.Scripts.UI
 			ToggleArtStyle,
 			DebugMode,
 			RestoreSettings,
+			StretchBackgrounds,
 		}
 
 		private Action? GetUserAction()
@@ -1148,6 +1149,10 @@ namespace Assets.Scripts.UI
 				else if (Input.GetKeyDown(KeyCode.Alpha9) || Input.GetKeyDown(KeyCode.Keypad9))
 				{
 					return Action.ForceShowCG;
+				}
+				else if (Input.GetKeyDown(KeyCode.Alpha8) || Input.GetKeyDown(KeyCode.Keypad8))
+				{
+					return Action.StretchBackgrounds;
 				}
 			}
 
@@ -1359,6 +1364,14 @@ namespace Assets.Scripts.UI
 					{
 						int restoreGameSettingsNum = IncrementGlobalFlagWithRollover("GMOD_SETTING_LOADER", 0, 3);
 						GameSystem.Instance.MainUIController.ShowToast($"Reset Settings: {restoreGameSettingsNum} (see F10 menu)", numberedSound: restoreGameSettingsNum);
+					}
+					break;
+
+				case Action.StretchBackgrounds:
+					{
+						bool shouldStretchBackgrounds = ToggleFlagAndSave("GStretchBackgrounds");
+						GameSystem.Instance.SceneController.ReloadAllImages();
+						GameSystem.Instance.MainUIController.ShowToast($"Background Stretching: {(shouldStretchBackgrounds ? "ON" : "OFF")}", isEnable: shouldStretchBackgrounds);
 					}
 					break;
 

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -164,6 +164,7 @@ namespace Assets.Scripts.UI
 				}
 				else
 				{
+					bool isRyukishiMode = BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1;
 					if (bgLayer == null)
 					{
 						bgLayer = LayerPool.ActivateLayer();
@@ -172,7 +173,7 @@ namespace Assets.Scripts.UI
 					bgLayer.SetPriority(62);
 					bgLayer.name = "Window Background 1";
 					bgLayer.IsStatic = true;
-					bgLayer.DrawLayer("windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					bgLayer.DrawLayer(isRyukishiMode ? "windo_filter_nvladv" : "windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
 					if (bgLayer2 == null)
 					{
 						bgLayer2 = LayerPool.ActivateLayer();
@@ -181,7 +182,7 @@ namespace Assets.Scripts.UI
 					bgLayer2.SetPriority(62);
 					bgLayer2.name = "Window Background 2";
 					bgLayer2.IsStatic = true;
-					bgLayer2.DrawLayer("windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
+					bgLayer2.DrawLayer(isRyukishiMode ? "windo_filter_nvladv" : "windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, time, /*isBlocking:*/ false);
 				}
 			}
 		}

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -1226,91 +1226,7 @@ namespace Assets.Scripts.UI
 					break;
 
 				case Action.RyukishiMode:
-					{
-						// TODO: need to consider how these settings will be restored on startup
-						// as may interfere with other settings!
-						// Instead of just one setting, might be better to have multiple flags toggled when you press this one button.
-						if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 0)
-						{
-							////// Switch to Console / 16:9 Mode
-
-							// Disable clamping sprites to 4:3
-							BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 0);
-
-							// Enable CGs
-							BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
-
-							//TODO: Change game aspect ratio to 16:9
-							//gameSystem.UpdateAspectRatio(16.0f / 9.0f);
-
-							//TODO: Restore UI for 16:9, Save setting (see note about GUI position in 'else' statement below)
-							gameSystem.MainUIController.UpdateGuiPosition(170, 0);
-
-							//TODO: Restore textbox size for 16:9
-							MODMainUIController mODMainUIController = new MODMainUIController();
-							mODMainUIController.NVLModeSettingLoad(
-								"",   //name
-								-170,    //posx
-								-10,  //posy
-								1240, //sizex
-								720,  //sizey
-								60,   //mleft
-								30,   //mtop
-								50,   //mright
-								30,   //mbottom
-								1,    //font
-								0,    //cspace
-								8,    //lspace
-								34);  //fsize
-
-							// Set ADV mode (take settings from init file), Save setting
-							MODSetAndSaveADV(setADVMode: true);
-
-							//TODO: Optional - disable image stretching 16:9
-							GameSystem.Instance.MainUIController.ShowToast($"Enabled Console Mode");
-						}
-						else
-						{
-							////// Switch to Ryukishi / 4:3 Mode
-
-							// Enable clamping sprites to 4:3
-							BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 1);
-
-							// Disable CGs (displayed CGs would be cut off). Can press Shift-9 to forcibly show CGs
-							BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
-
-							//TODO: Force NVL mode for 4:3 (may need to add another option in the init.txt file), save setting
-							MODSetAndSaveADV(setADVMode: false);
-
-							//TODO: Shift UI for 4:3, save setting
-							// NOTE: The textbox location seems tied to the Gui position (as in, the text/textbox is parented to the GUI)
-							// This means that when we change the Gui position from (170, 0) to (0, 0), you don't need the -170 offset that we use in our mod
-							gameSystem.MainUIController.UpdateGuiPosition(0, 0);
-
-							//TODO: Squish textbox
-							MODMainUIController mODMainUIController = new MODMainUIController();
-							mODMainUIController.NVLModeSettingLoad(
-								"",   //name
-								0,    //posx
-								-10,  //posy
-								1024, //sizex
-								768,  //sizey
-								60,   //mleft
-								30,   //mtop
-								50,   //mright
-								30,   //mbottom
-								1,    //font
-								0,    //cspace
-								8,    //lspace
-								34);  //fsize
-
-							// Change game aspect ration to 4:3
-							//gameSystem.UpdateAspectRatio(4.0f / 3.0f);
-
-							//TODO: Optional - stretch backgrounds to 16:9 if wrong resolution? entirely optional though, maybe do later, Save setting
-							GameSystem.Instance.MainUIController.ShowToast($"Enabled Ryukishi Mode");
-						}
-					}
+					ModToggleRyukishiMode();
 					break;
 
 				case Action.DebugFontSize when BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 1 || BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 2:
@@ -1428,6 +1344,103 @@ namespace Assets.Scripts.UI
 			}
 
 			return true;
+		}
+
+		public void ModToggleRyukishiMode()
+		{
+			// TODO: need to consider how these settings will be restored on startup
+			// as may interfere with other settings!
+			// Instead of just one setting, might be better to have multiple flags toggled when you press this one button.
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 0)
+			{
+				////// Switch to Console / 16:9 Mode
+
+				// Disable clamping sprites to 4:3
+				BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 0);
+
+				// Enable CGs
+				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
+
+				//TODO: Change game aspect ratio to 16:9
+				//gameSystem.UpdateAspectRatio(16.0f / 9.0f);
+
+				//TODO: Restore UI for 16:9, Save setting (see note about GUI position in 'else' statement below)
+				gameSystem.MainUIController.UpdateGuiPosition(170, 0);
+
+				//TODO: Restore textbox size for 16:9
+				MODMainUIController mODMainUIController = new MODMainUIController();
+				mODMainUIController.NVLModeSettingLoad(
+					"",   //name
+					-170,    //posx
+					-10,  //posy
+					1240, //sizex
+					720,  //sizey
+					60,   //mleft
+					30,   //mtop
+					50,   //mright
+					30,   //mbottom
+					1,    //font
+					0,    //cspace
+					8,    //lspace
+					34);  //fsize
+
+				// Set ADV mode (take settings from init file), Save setting
+				MODSetAndSaveADV(setADVMode: true);
+
+				//TODO: Optional - disable image stretching 16:9
+				GameSystem.Instance.MainUIController.ShowToast($"Enabled Console Mode");
+			}
+			else
+			{
+				////// Switch to Ryukishi / 4:3 Mode
+
+				// The following things depend on GClampSprite43:
+				// - Sprites are clamped to 4:3
+				// - UI position is set to (0,0) with UpdateGuiPosition()
+				BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 1);
+
+
+				// Disable CGs (displayed CGs would be cut off). Can press Shift-9 to forcibly show CGs
+				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
+
+				//TODO: Force NVL mode for 4:3 (may need to add another option in the init.txt file), save setting
+				MODSetAndSaveADV(setADVMode: false);
+
+				//TODO: Shift UI for 4:3, save setting
+				gameSystem.MainUIController.UpdateGuiPosition(0, 0);
+
+				//TODO: Squish textbox
+				// NOTE: The textbox location seems tied to the aspect ratio
+				// This means that:
+				//   - when the Gui position is (170, 0) and the aspect is 16:9,
+				//     you set the textbox posx to -170 (this is how the mod is by default)
+				//
+				//   - when the Gui position is (  0, 0) and the aspect is 16:9,
+				//     you set the textbox posx to -170 (this is how I've setup ryukishi mode)
+				//   - when the Gui position is (  0, 0) and the aspect is 4:3,
+				//     you set the textbox posx to 0 (this is the original game's setting)
+				MODMainUIController mODMainUIController = new MODMainUIController();
+				mODMainUIController.NVLModeSettingLoad(
+					"",   //name
+					-170, //posx
+					-10,  //posy
+					1024, //sizex
+					768,  //sizey
+					60,   //mleft
+					30,   //mtop
+					50,   //mright
+					30,   //mbottom
+					1,    //font
+					0,    //cspace
+					8,    //lspace
+					34);  //fsize
+
+				// Change game aspect ration to 4:3
+				//gameSystem.UpdateAspectRatio(4.0f / 3.0f);
+
+				//TODO: Optional - stretch backgrounds to 16:9 if wrong resolution? entirely optional though, maybe do later, Save setting
+				GameSystem.Instance.MainUIController.ShowToast($"Enabled Ryukishi Mode");
+			}
 		}
 
 	}

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -1234,11 +1234,14 @@ namespace Assets.Scripts.UI
 						{
 							////// Switch to Console / 16:9 Mode
 
-							//TODO: Enable CG and save setting
+							// Disable clamping sprites to 4:3
+							BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 0);
+
+							// Enable CGs
 							BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
 
 							//TODO: Change game aspect ratio to 16:9
-							gameSystem.UpdateAspectRatio(16.0f / 9.0f);
+							//gameSystem.UpdateAspectRatio(16.0f / 9.0f);
 
 							//TODO: Restore UI for 16:9, Save setting (see note about GUI position in 'else' statement below)
 							gameSystem.MainUIController.UpdateGuiPosition(170, 0);
@@ -1260,7 +1263,7 @@ namespace Assets.Scripts.UI
 								8,    //lspace
 								34);  //fsize
 
-							//TODO: Set ADV mode (take settings from init file), Save setting
+							// Set ADV mode (take settings from init file), Save setting
 							MODSetAndSaveADV(setADVMode: true);
 
 							//TODO: Optional - disable image stretching 16:9
@@ -1270,7 +1273,10 @@ namespace Assets.Scripts.UI
 						{
 							////// Switch to Ryukishi / 4:3 Mode
 
-							//TODO: Disable CG and save settings (displayed CGs would be cut off)
+							// Enable clamping sprites to 4:3
+							BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 1);
+
+							// Disable CGs (displayed CGs would be cut off). Can press Shift-9 to forcibly show CGs
 							BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
 
 							//TODO: Force NVL mode for 4:3 (may need to add another option in the init.txt file), save setting
@@ -1298,8 +1304,8 @@ namespace Assets.Scripts.UI
 								8,    //lspace
 								34);  //fsize
 
-							//TODO: Change game aspect ration to 4:3
-							gameSystem.UpdateAspectRatio(4.0f / 3.0f);
+							// Change game aspect ration to 4:3
+							//gameSystem.UpdateAspectRatio(4.0f / 3.0f);
 
 							//TODO: Optional - stretch backgrounds to 16:9 if wrong resolution? entirely optional though, maybe do later, Save setting
 							GameSystem.Instance.MainUIController.ShowToast($"Enabled Ryukishi Mode");

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -487,6 +487,14 @@ namespace Assets.Scripts.UI
 			}
 		}
 
+		public void LateUpdate()
+		{
+			if (modMenu != null)
+			{
+				modMenu.LateUpdate();
+			}
+		}
+
 		public void TryRedrawTextWindowBackground(string windowFilterTextureName)
 		{
 			MainUIController ui = GameSystem.Instance.MainUIController;

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -1120,6 +1120,9 @@ namespace Assets.Scripts.UI
 				{
 					////// Switch to Console / 16:9 Mode
 
+					//TODO: Enable CG and save setting
+					BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
+
 					//TODO: Change game aspect ratio to 16:9
 					gameSystem.UpdateAspectRatio(16.0f / 9.0f);
 
@@ -1146,14 +1149,15 @@ namespace Assets.Scripts.UI
 					//TODO: Set ADV mode (take settings from init file), Save setting
 					MODSetAndSaveADV(setADVMode: true);
 
-					//TODO: Enable CG and save setting
-
 					//TODO: Optional - disable image stretching 16:9
 					GameSystem.Instance.MainUIController.ShowToast($"Enabled Console Mode");
 				}
 				else
 				{
 					////// Switch to Ryukishi / 4:3 Mode
+
+					//TODO: Disable CG and save settings (displayed CGs would be cut off)
+					BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
 
 					//TODO: Force NVL mode for 4:3 (may need to add another option in the init.txt file), save setting
 					MODSetAndSaveADV(setADVMode: false);
@@ -1182,8 +1186,6 @@ namespace Assets.Scripts.UI
 
 					//TODO: Change game aspect ration to 4:3
 					gameSystem.UpdateAspectRatio(4.0f / 3.0f);
-
-					//TODO: Disable CG and save settings (displayed CGs would be cut off)
 
 					//TODO: Optional - stretch backgrounds to 16:9 if wrong resolution? entirely optional though, maybe do later, Save setting
 					GameSystem.Instance.MainUIController.ShowToast($"Enabled Ryukishi Mode");

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -70,6 +70,13 @@ namespace Assets.Scripts.UI
 			Pluck5,
 		}
 
+		private enum WindowFilterType
+		{
+			Normal,
+			ADV,
+			NVLInADV,
+		}
+
 		public void UpdateGuiPosition(int x, int y)
 		{
 			unscaledPosition = new Vector3((float)x, (float)y, 0f);
@@ -493,6 +500,32 @@ namespace Assets.Scripts.UI
 			}
 		}
 
+		private void TryRedrawTextWindowBackground(WindowFilterType filterType)
+		{
+			MainUIController ui = GameSystem.Instance.MainUIController;
+
+			// If this function is called from the main menu, the bgLayers might be null
+			if (ui.bgLayer == null || ui.bgLayer2 == null)
+			{
+				return;
+			}
+
+			string windowFilterTextureName = "windo_filter";
+			if (filterType == WindowFilterType.ADV)
+			{
+				windowFilterTextureName = "windo_filter_adv";
+			}
+			else if (filterType == WindowFilterType.NVLInADV)
+			{
+				windowFilterTextureName = "windo_filter_nvladv";
+			}
+
+			ui.bgLayer.ReleaseTextures();
+			ui.bgLayer2.ReleaseTextures();
+			ui.bgLayer.DrawLayer(windowFilterTextureName, 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+			ui.bgLayer2.DrawLayer(windowFilterTextureName, 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+		}
+
 		/// <summary>
 		/// Toggles, then saves ADV/NVL mode.
 		/// </summary>
@@ -513,10 +546,7 @@ namespace Assets.Scripts.UI
 			{
 				BurikoMemory.Instance.SetGlobalFlag("GADVMode", 1);
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
-				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
-				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				TryRedrawTextWindowBackground(WindowFilterType.ADV);
 				mODMainUIController.ADVModeSettingStore();
 				GameSystem.Instance.MainUIController.ShowToast($"Textbox: ADV Mode", isEnable: true);
 			}
@@ -524,10 +554,7 @@ namespace Assets.Scripts.UI
 			{
 				BurikoMemory.Instance.SetGlobalFlag("GADVMode", 0);
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
-				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
-				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				TryRedrawTextWindowBackground(WindowFilterType.Normal);
 				mODMainUIController.NVLModeSettingStore();
 				GameSystem.Instance.MainUIController.ShowToast($"Textbox: NVL Mode", isEnable: false);
 			}
@@ -540,10 +567,7 @@ namespace Assets.Scripts.UI
 			{
 				MODMainUIController mODMainUIController = new MODMainUIController();
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
-				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_nvladv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
-				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_nvladv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				TryRedrawTextWindowBackground(WindowFilterType.NVLInADV);
 				mODMainUIController.NVLADVModeSettingStore();
 			}
 		}
@@ -555,10 +579,7 @@ namespace Assets.Scripts.UI
 			{
 				MODMainUIController mODMainUIController = new MODMainUIController();
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
-				GameSystem.Instance.MainUIController.bgLayer.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer2.ReleaseTextures();
-				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
-				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+				TryRedrawTextWindowBackground(WindowFilterType.ADV);
 				mODMainUIController.ADVModeSettingStore();
 			}
 		}

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -51,6 +51,25 @@ namespace Assets.Scripts.UI
 
 		private Vector3 unscaledPosition;
 
+		// While this timer is > 0, the current toast will be displayed (in seconds)
+		private float toastNotificationTimer;
+		private string toastText = "Example Toast Notification";
+		private GUIStyle labelStyle;
+
+		public enum Sound
+		{
+			Click,
+			LoudBang,
+			Disable,
+			Enable,
+			Pluck0,
+			Pluck1,
+			Pluck2,
+			Pluck3,
+			Pluck4,
+			Pluck5,
+		}
+
 		public void UpdateGuiPosition(int x, int y)
 		{
 			unscaledPosition = new Vector3((float)x, (float)y, 0f);
@@ -422,6 +441,8 @@ namespace Assets.Scripts.UI
 
 		private void Update()
 		{
+			// Update the toast countdown timer, making sure it doesn't go below 0
+			toastNotificationTimer = Math.Max(0, toastNotificationTimer - Time.deltaTime);
 			if (gameSystem == null)
 			{
 				gameSystem = GameSystem.Instance;
@@ -479,6 +500,7 @@ namespace Assets.Scripts.UI
 				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
 				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
 				mODMainUIController.NVLModeSettingStore();
+				GameSystem.Instance.MainUIController.ShowToast($"Textbox: NVL Mode", isEnable: false);
 			}
 			else
 			{
@@ -489,6 +511,7 @@ namespace Assets.Scripts.UI
 				GameSystem.Instance.MainUIController.bgLayer.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
 				GameSystem.Instance.MainUIController.bgLayer2.DrawLayer("windo_filter_adv", 0, 0, 0, null, gameSystem.MessageWindowOpacity, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
 				mODMainUIController.ADVModeSettingStore();
+				GameSystem.Instance.MainUIController.ShowToast($"Textbox: ADV Mode", isEnable: true);
 			}
 		}
 
@@ -524,6 +547,32 @@ namespace Assets.Scripts.UI
 
 		public void OnGUI()
 		{
+			// This sets up the style of the toast notification (mostly to make the font bigger and the text anchor location)
+			// From what I've read, The GUIStyle must be initialized in OnGUI(), otherwise
+			// GUI.skin.label will not be defined, so please do not move this part elsewhere without testing it.
+			if(labelStyle == null)
+			{
+				labelStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
+				{
+					alignment = TextAnchor.UpperCenter,
+					fontSize = 40,
+					fontStyle = FontStyle.Bold,
+				};
+				int width = 1;
+				int height = 1;
+				Color[] pix = new Color[width * height];
+				for(int i = 0; i < pix.Length; i++)
+				{
+					pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.8f);
+				}
+				Texture2D result = new Texture2D(width, height);
+				result.SetPixels(pix);
+				result.Apply();
+				labelStyle.normal.background = result;
+
+				labelStyle.normal.textColor = Color.white;
+			}
+
 			// Helper Functions for processing flags
 			string boolDesc(string flag, string name)
 			{
@@ -758,11 +807,100 @@ namespace Assets.Scripts.UI
 				);
 				GUI.TextArea(new Rect(320f, 0f, 320f, 1080f), textToDraw, 900);
 			}
+
+			if(toastNotificationTimer > 0)
+			{
+				// This scrolls the toast notification off the window when it's nearly finished
+				float toastYPosition = Math.Min(50f, 200f * toastNotificationTimer - 50f);
+				float toastWidth = 700f;
+				float toastXPosition = (Screen.width - toastWidth) / 2.0f;
+				GUILayout.BeginArea(new Rect(toastXPosition, toastYPosition, 700f, 200f));
+				GUILayout.Box(toastText, labelStyle);
+				GUILayout.EndArea();
+			}
 		}
 
 		public void MODDebugFontSizeChanger()
 		{
 			new MODMainUIController().DebugFontChangerSettingStore();
+		}
+
+		private string GetSoundPathFromEnum(Sound sound)
+		{
+			switch (sound)
+			{
+				case Sound.Click:
+					return "wa_038.ogg";
+				case Sound.LoudBang:
+					return "wa_040.ogg";
+				case Sound.Disable:
+					return "switchsound/disable.ogg";
+				case Sound.Enable:
+					return "switchsound/enable.ogg";
+				case Sound.Pluck0:
+					return "switchsound/0.ogg";
+				case Sound.Pluck1:
+					return "switchsound/1.ogg";
+				case Sound.Pluck2:
+					return "switchsound/2.ogg";
+				case Sound.Pluck3:
+					return "switchsound/3.ogg";
+				case Sound.Pluck4:
+					return "switchsound/4.ogg";
+				case Sound.Pluck5:
+					return "switchsound/5.ogg";
+			}
+
+			return "wa_038.ogg";
+		}
+
+		/// <summary>
+		/// Displays a toast notification. It will appear ontop of everything else on the screen.
+		/// </summary>
+		/// <param name="toastText">The text to display in the toast</param>
+		/// <param name="toastDuration">The duration the toast will be shown for.
+		/// The toast will slide off the screen for the last part of this duration.</param>
+		public void ShowToast(string toastText, Sound? maybeSound = Sound.Click, float toastDuration = 3)
+		{
+			this.toastText = toastText;
+			this.toastNotificationTimer = toastDuration;
+			if (maybeSound is Sound sound)
+			{
+				GameSystem.Instance.AudioController.PlaySystemSound(GetSoundPathFromEnum(sound));
+			}
+		}
+
+		public void ShowToast(string toastText, bool isEnable, float toastDuration = 3)
+		{
+			ShowToast(toastText, isEnable ? Sound.Enable : Sound.Disable, toastDuration);
+		}
+
+		public void ShowToast(string toastText, int numberedSound, float toastDuration = 3)
+		{
+			Sound sound = Sound.Click;
+			switch (numberedSound)
+			{
+				case 0:
+					sound = Sound.Pluck0;
+					break;
+				case 1:
+					sound = Sound.Pluck1;
+					break;
+				case 2:
+					sound = Sound.Pluck2;
+					break;
+				case 3:
+					sound = Sound.Pluck3;
+					break;
+				case 4:
+					sound = Sound.Pluck4;
+					break;
+				case 5:
+					sound = Sound.Pluck5;
+					break;
+			}
+
+			ShowToast(toastText, sound, toastDuration);
 		}
 	}
 }

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -1369,7 +1369,7 @@ namespace Assets.Scripts.UI
 				////// Switch to Console / 16:9 Mode
 
 				// Disable clamping sprites to 4:3
-				BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 0);
 
 				// Enable CGs
 				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
@@ -1407,10 +1407,10 @@ namespace Assets.Scripts.UI
 			{
 				////// Switch to Ryukishi / 4:3 Mode
 
-				// The following things depend on GClampSprite43:
+				// The following things depend on GRyukishiMode:
 				// - Sprites are clamped to 4:3
 				// - UI position is set to (0,0) with UpdateGuiPosition()
-				BurikoMemory.Instance.SetGlobalFlag("GClampSprite43", 1);
+				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 1);
 
 
 				// Disable CGs (displayed CGs would be cut off). Can press Shift-9 to forcibly show CGs

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -1068,6 +1068,7 @@ namespace Assets.Scripts.UI
 			FlagMonitor,
 			OpeningVideo,
 			RyukishiMode,
+			ForceShowCG,
 			DebugFontSize,
 			AltBGM,
 			AltBGMFlow,
@@ -1105,6 +1106,10 @@ namespace Assets.Scripts.UI
 				else if (Input.GetKeyDown(KeyCode.N))
 				{
 					return Action.VoiceVolumeMin;
+				}
+				else if (Input.GetKeyDown(KeyCode.Alpha9) || Input.GetKeyDown(KeyCode.Keypad9))
+				{
+					return Action.ForceShowCG;
 				}
 			}
 
@@ -1228,6 +1233,14 @@ namespace Assets.Scripts.UI
 				case Action.RyukishiMode:
 					ModToggleRyukishiMode();
 					break;
+
+				case Action.ForceShowCG:
+					{
+						bool cgIsHidden = ToggleFlagAndSave("GHideCG");
+						GameSystem.Instance.MainUIController.ShowToast($"Hide CG: {(cgIsHidden ? "ON" : "OFF")}", isEnable: cgIsHidden);
+					}
+					break;
+
 
 				case Action.DebugFontSize when BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 1 || BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 2:
 					GameSystem.Instance.MainUIController.MODDebugFontSizeChanger();

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -172,6 +172,7 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModAddArtset", new OpType(BurikoOperations.ModAddArtset, "sss"));
 			paramLookup.Add("ModClearArtsets", new OpType(BurikoOperations.ModClearArtsets, string.Empty));
 			paramLookup.Add("ModRyukishiModeSettingLoad", new OpType(BurikoOperations.ModRyukishiModeSettingLoad, "siiiiiiiiiiii"));
+			paramLookup.Add("ModRyukishiSetGuiPosition", new OpType(BurikoOperations.ModRyukishiSetGuiPosition, "ii"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -171,6 +171,7 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModSetLayerFilter", new OpType(BurikoOperations.ModSetLayerFilter, "iis"));
 			paramLookup.Add("ModAddArtset", new OpType(BurikoOperations.ModAddArtset, "sss"));
 			paramLookup.Add("ModClearArtsets", new OpType(BurikoOperations.ModClearArtsets, string.Empty));
+			paramLookup.Add("ModRyukishiModeSettingLoad", new OpType(BurikoOperations.ModRyukishiModeSettingLoad, "siiiiiiiiiiii"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/MOD.Scripts.Core.Scene/MODSceneController.cs
+++ b/MOD.Scripts.Core.Scene/MODSceneController.cs
@@ -204,8 +204,13 @@ namespace MOD.Scripts.Core.Scene
 
 		public static Texture2D LoadTextureWithFilters(int? layer, string textureName)
 		{
+			return LoadTextureWithFilters(layer, textureName, out _);
+		}
+
+		public static Texture2D LoadTextureWithFilters(int? layer, string textureName, out string texturePath)
+		{
 			var watch = System.Diagnostics.Stopwatch.StartNew();
-			Texture2D texture = GameSystem.Instance.AssetManager.LoadTexture(textureName);
+			Texture2D texture = GameSystem.Instance.AssetManager.LoadTexture(textureName, out texturePath);
 			watch.Stop();
 			MODUtility.FlagMonitorOnlyLog("Loaded " + textureName + " in " + watch.ElapsedMilliseconds + "ms");
 			if (layer is int actualLayer) { ApplyFilters(actualLayer, texture); }

--- a/MOD.Scripts.Core.Scene/MODTextureController.cs
+++ b/MOD.Scripts.Core.Scene/MODTextureController.cs
@@ -53,7 +53,7 @@ namespace MOD.Scripts.Core.Scene
 			BurikoMemory.Instance.SetGlobalFlag("GArtStyle", AssetManager.Instance.CurrentArtsetIndex);
 			RestoreTextures();
 			GameSystem.Instance.SceneController.ReloadAllImages();
-			GameSystem.Instance.MainUIController.ShowToast($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}");
+			UI.MODToaster.Show($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}");
 		}
 	}
 }

--- a/MOD.Scripts.Core.Scene/MODTextureController.cs
+++ b/MOD.Scripts.Core.Scene/MODTextureController.cs
@@ -3,6 +3,8 @@ using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.Scene;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 
 namespace MOD.Scripts.Core.Scene
 {
@@ -50,10 +52,28 @@ namespace MOD.Scripts.Core.Scene
 			{
 				AssetManager.Instance.CurrentArtsetIndex = 0;
 			}
-			BurikoMemory.Instance.SetGlobalFlag("GArtStyle", AssetManager.Instance.CurrentArtsetIndex);
-			RestoreTextures();
-			GameSystem.Instance.SceneController.ReloadAllImages();
-			UI.MODToaster.Show($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}");
+
+			SetArtStyle(AssetManager.Instance.CurrentArtsetIndex);
+		}
+
+		public void SetArtStyle(int artSetIndex)
+		{
+			if(artSetIndex >= 0 && artSetIndex < AssetManager.Instance.ArtsetCount)
+			{
+				AssetManager.Instance.CurrentArtsetIndex = artSetIndex;
+				BurikoMemory.Instance.SetGlobalFlag("GArtStyle", AssetManager.Instance.CurrentArtsetIndex);
+				BurikoMemory.Instance.SetGlobalFlag("GBackgroundSet", 0);
+				RestoreTextures();
+				GameSystem.Instance.SceneController.ReloadAllImages();
+				UI.MODToaster.Show($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}");
+			}
+		}
+
+		public int GetArtStyle() => AssetManager.Instance.CurrentArtsetIndex;
+
+		public GUIContent[] GetArtStyleDescriptions()
+		{
+			return AssetManager.Instance.Artsets.Select(x => new GUIContent(x.nameEN, x.nameEN)).ToArray();
 		}
 	}
 }

--- a/MOD.Scripts.Core.Scene/MODTextureController.cs
+++ b/MOD.Scripts.Core.Scene/MODTextureController.cs
@@ -53,6 +53,7 @@ namespace MOD.Scripts.Core.Scene
 			BurikoMemory.Instance.SetGlobalFlag("GArtStyle", AssetManager.Instance.CurrentArtsetIndex);
 			RestoreTextures();
 			GameSystem.Instance.SceneController.ReloadAllImages();
+			GameSystem.Instance.MainUIController.ShowToast($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}");
 		}
 	}
 }

--- a/MOD.Scripts.Core.Scene/MODTextureController.cs
+++ b/MOD.Scripts.Core.Scene/MODTextureController.cs
@@ -56,7 +56,7 @@ namespace MOD.Scripts.Core.Scene
 			SetArtStyle(AssetManager.Instance.CurrentArtsetIndex);
 		}
 
-		public void SetArtStyle(int artSetIndex)
+		public void SetArtStyle(int artSetIndex, bool showInfoToast = true)
 		{
 			if(artSetIndex >= 0 && artSetIndex < AssetManager.Instance.ArtsetCount)
 			{
@@ -65,7 +65,7 @@ namespace MOD.Scripts.Core.Scene
 				BurikoMemory.Instance.SetGlobalFlag("GBackgroundSet", 0);
 				RestoreTextures();
 				GameSystem.Instance.SceneController.ReloadAllImages();
-				UI.MODToaster.Show($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}");
+				if (showInfoToast) { UI.MODToaster.Show($"Art Style: {AssetManager.Instance.CurrentArtset.nameEN}"); }
 			}
 		}
 

--- a/MOD.Scripts.Core.State/MODStateDisableInput.cs
+++ b/MOD.Scripts.Core.State/MODStateDisableInput.cs
@@ -1,0 +1,20 @@
+﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.State;
+
+namespace MOD.Scripts.Core.State
+{
+	// This state is used to disable most of the game's input, so that
+	// you don't trigger the game's inputs while you're in the mod menu.
+	// Note: certain buttons are still clickable even in this state, but
+	// - you can use GameSystem.HideUI() to hide the normal game buttons
+	// - you can register a LeaveConfigScreen() action to close the config screen
+	class MODStateDisableInput : IGameState
+	{
+		public void RequestLeaveImmediate() => GameSystem.Instance.PopStateStack();
+		public void RequestLeave() => GameSystem.Instance.PopStateStack();
+		public void OnLeaveState() {}
+		public void OnRestoreState() {}
+		public bool InputHandler() => false;
+		public GameState GetStateType() => GameState.MODDisableInput;
+	}
+}

--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using Assets.Scripts.Core.Buriko;
 using UnityEngine;
 
@@ -8,6 +10,13 @@ using UnityEngine;
 /// </summary>
 public static class MODUtility
 {
+	public enum Platform
+	{
+		Windows,
+		MacOS,
+		Linux
+	}
+
 	/// <summary>
 	/// Merges another dictionary into self, overwriting any duplicate keys
 	/// </summary>
@@ -42,6 +51,59 @@ public static class MODUtility
 			{
 				Debug.Log("Not attempting Retina, no library");
 			}
+		}
+	}
+
+	public static string CombinePaths(params string[] paths)
+	{
+		return paths.Aggregate((lhs, rhs) => System.IO.Path.Combine(lhs, rhs));
+	}
+
+	/// <returns>True if is 2000 series unity, False if is old unity versioning (5.x, 4.x etc)</returns>
+	public static bool IsUnity2000()
+	{
+		if (GetUnityVersionMajor() is int version)
+		{
+			return version > 2000;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Gets the major part of the unity version, eg 2018, 2017, 5, 4, 3, as an integer
+	/// </summary>
+	/// <returns>Returns the major unity version as an int - returns null if version can't be determined</returns>
+	public static int? GetUnityVersionMajor()
+	{
+		string[] versions = Application.unityVersion.Split('.');
+		if (versions.Length > 0 && int.TryParse(versions[0], out int version))
+		{
+			return version;
+		}
+
+		return null;
+	}
+
+	public static Platform GetPlatform()
+	{
+		switch (Application.platform)
+		{
+			case RuntimePlatform.OSXEditor:
+			case RuntimePlatform.OSXPlayer:
+			case RuntimePlatform.IPhonePlayer:
+				return Platform.MacOS;
+
+			case RuntimePlatform.WindowsPlayer:
+			case RuntimePlatform.WindowsEditor:
+				return Platform.Windows;
+
+			case RuntimePlatform.LinuxPlayer:
+				return Platform.Linux;
+
+			// All other platforms are not possible for Higurashi, just assume windows
+			default:
+				return Platform.Windows;
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -102,7 +102,7 @@ namespace MOD.Scripts.UI
 				TryRedrawTextWindowBackground(WindowFilterType.Normal);
 				mODMainUIController.WideGuiPositionStore();
 				mODMainUIController.NVLModeSettingStore();
-				Core.MODSystem.instance.modTextureController.SetArtStyle(1);
+				Core.MODSystem.instance.modTextureController.SetArtStyle(0);
 				MODToaster.Show($"Set NVL Mode", isEnable: false);
 			}
 			else if (setting == ModPreset.OG)

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -89,6 +89,7 @@ namespace MOD.Scripts.UI
 					feedbackString += "\nIn NVL region - changes won't be displayed until later";
 					toastDuration = 5;
 				}
+				Core.MODSystem.instance.modTextureController.SetArtStyle(0);
 				MODToaster.Show(feedbackString, isEnable: true, toastDuration: toastDuration);
 			}
 			else if (setting == ModPreset.NVL)
@@ -101,6 +102,7 @@ namespace MOD.Scripts.UI
 				TryRedrawTextWindowBackground(WindowFilterType.Normal);
 				mODMainUIController.WideGuiPositionStore();
 				mODMainUIController.NVLModeSettingStore();
+				Core.MODSystem.instance.modTextureController.SetArtStyle(1);
 				MODToaster.Show($"Set NVL Mode", isEnable: false);
 			}
 			else if (setting == ModPreset.OG)
@@ -113,6 +115,7 @@ namespace MOD.Scripts.UI
 				TryRedrawTextWindowBackground(WindowFilterType.OG);
 				mODMainUIController.RyukishiGuiPositionStore();
 				mODMainUIController.RyukishiModeSettingStore();
+				Core.MODSystem.instance.modTextureController.SetArtStyle(2);
 				MODToaster.Show($"Set OG Mode", isEnable: false);
 			}
 

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -40,7 +40,7 @@ namespace MOD.Scripts.UI
 			}
 			else if (filterType == WindowFilterType.OG)
 			{
-				windowFilterTextureName = "windo_filter_og";
+				windowFilterTextureName = "windo_filter_nvladv";
 			}
 
 			GameSystem.Instance.MainUIController.TryRedrawTextWindowBackground(windowFilterTextureName);

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -69,7 +69,7 @@ namespace MOD.Scripts.UI
 		/// </summary>
 		/// <param name="setADVMode">If True, sets and saves ADV mode. If False, sets and saves NVL mode</param>
 		/// <returns>True if set and displayed, false if in a NVL_in_ADV region and value might not be applied immediately</returns>
-		public static void SetAndSaveADV(ModPreset setting, bool stretch = false)
+		public static void SetAndSaveADV(ModPreset setting)
 		{
 			MODMainUIController mODMainUIController = new MODMainUIController();
 			if (setting == ModPreset.ADV)
@@ -111,7 +111,7 @@ namespace MOD.Scripts.UI
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
 				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 1);
 				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
-				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", stretch ? 1 : 0);
+				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", 0);
 				TryRedrawTextWindowBackground(WindowFilterType.OG);
 				mODMainUIController.RyukishiGuiPositionStore();
 				mODMainUIController.RyukishiModeSettingStore();

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -70,8 +70,10 @@ namespace MOD.Scripts.UI
 		/// Sets and saves NVL/ADV mode
 		/// </summary>
 		/// <param name="setADVMode">If True, sets and saves ADV mode. If False, sets and saves NVL mode</param>
+		/// <param name="showInfoToast">If True, always shows a toast indicting the NVL/ADV status.
+		/// If False, will only show toast if there is a warning (like you are in a nvl_in_adv region)</param>
 		/// <returns>True if set and displayed, false if in a NVL_in_ADV region and value might not be applied immediately</returns>
-		public static void SetAndSaveADV(ModPreset setting)
+		public static void SetAndSaveADV(ModPreset setting, bool showInfoToast = true)
 		{
 			MODMainUIController mODMainUIController = new MODMainUIController();
 			if (setting == ModPreset.ADV)
@@ -86,13 +88,14 @@ namespace MOD.Scripts.UI
 				mODMainUIController.ADVModeSettingStore();
 				string feedbackString = $"Set ADV Mode";
 				int toastDuration = 3;
-				if(BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
+				Core.MODSystem.instance.modTextureController.SetArtStyle(0, showInfoToast);
+				bool is_nvl_in_adv_region = BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1;
+				if (is_nvl_in_adv_region)
 				{
 					feedbackString += "\nIn NVL region - changes won't be displayed until later";
 					toastDuration = 5;
 				}
-				Core.MODSystem.instance.modTextureController.SetArtStyle(0);
-				MODToaster.Show(feedbackString, isEnable: true, toastDuration: toastDuration);
+				if (is_nvl_in_adv_region || showInfoToast) { MODToaster.Show(feedbackString, isEnable: true, toastDuration: toastDuration); }
 			}
 			else if (setting == ModPreset.NVL)
 			{
@@ -104,8 +107,8 @@ namespace MOD.Scripts.UI
 				TryRedrawTextWindowBackground(WindowFilterType.Normal);
 				mODMainUIController.WideGuiPositionStore();
 				mODMainUIController.NVLModeSettingStore();
-				Core.MODSystem.instance.modTextureController.SetArtStyle(0);
-				MODToaster.Show($"Set NVL Mode", isEnable: false);
+				Core.MODSystem.instance.modTextureController.SetArtStyle(0, showInfoToast);
+				if (showInfoToast) { MODToaster.Show($"Set NVL Mode", isEnable: false); }
 			}
 			else if (setting == ModPreset.OG)
 			{
@@ -117,12 +120,9 @@ namespace MOD.Scripts.UI
 				TryRedrawTextWindowBackground(WindowFilterType.OG);
 				mODMainUIController.RyukishiGuiPositionStore();
 				mODMainUIController.RyukishiModeSettingStore();
-				Core.MODSystem.instance.modTextureController.SetArtStyle(2);
-				MODToaster.Show($"Set OG Mode", isEnable: false);
+				Core.MODSystem.instance.modTextureController.SetArtStyle(2, showInfoToast);
+				if (showInfoToast) { MODToaster.Show($"Set OG Mode", isEnable: false); }
 			}
-
-			// Return false if in a NVL_in_ADV region to tell users that value might not be applied immediately
-			//return BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 0;
 		}
 
 		public static void EnableNVLModeINADVMode()

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -69,7 +69,7 @@ namespace MOD.Scripts.UI
 		/// </summary>
 		/// <param name="setADVMode">If True, sets and saves ADV mode. If False, sets and saves NVL mode</param>
 		/// <returns>True if set and displayed, false if in a NVL_in_ADV region and value might not be applied immediately</returns>
-		public static void SetAndSaveADV(ModPreset setting)
+		public static void SetAndSaveADV(ModPreset setting, bool stretch = false)
 		{
 			MODMainUIController mODMainUIController = new MODMainUIController();
 			if (setting == ModPreset.ADV)
@@ -111,7 +111,7 @@ namespace MOD.Scripts.UI
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
 				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 1);
 				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
-				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", stretch ? 1 : 0);
 				TryRedrawTextWindowBackground(WindowFilterType.OG);
 				mODMainUIController.RyukishiGuiPositionStore();
 				mODMainUIController.RyukishiModeSettingStore();

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -1,0 +1,244 @@
+﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.Buriko;
+using Assets.Scripts.UI;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	static class MODActions
+	{
+		private enum WindowFilterType
+		{
+			Normal,
+			ADV,
+			NVLInADV,
+			OG,
+		}
+
+		public enum ModPreset
+		{
+			ADV = 0,
+			NVL = 1,
+			OG = 2,
+		}
+
+		private static void TryRedrawTextWindowBackground(WindowFilterType filterType)
+		{
+			string windowFilterTextureName = "windo_filter";
+			if (filterType == WindowFilterType.ADV)
+			{
+				windowFilterTextureName = "windo_filter_adv";
+			}
+			else if (filterType == WindowFilterType.NVLInADV)
+			{
+				windowFilterTextureName = "windo_filter_nvladv";
+			}
+			else if (filterType == WindowFilterType.OG)
+			{
+				windowFilterTextureName = "windo_filter_og";
+			}
+
+			GameSystem.Instance.MainUIController.TryRedrawTextWindowBackground(windowFilterTextureName);
+		}
+
+		/// <summary>
+		/// Cycles and saves ADV->NVL->OG->ADV...
+		/// </summary>
+		/// <returns>True if set and displayed, false if in a NVL_in_ADV region and value might not be applied immediately</returns>
+		public static void ToggleAndSaveADVMode()
+		{
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				SetAndSaveADV(ModPreset.ADV);
+			}
+			else if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			{
+				SetAndSaveADV(ModPreset.NVL);
+			}
+			else
+			{
+				SetAndSaveADV(ModPreset.OG);
+			}
+		}
+
+		/// <summary>
+		/// Sets and saves NVL/ADV mode
+		/// </summary>
+		/// <param name="setADVMode">If True, sets and saves ADV mode. If False, sets and saves NVL mode</param>
+		/// <returns>True if set and displayed, false if in a NVL_in_ADV region and value might not be applied immediately</returns>
+		public static void SetAndSaveADV(ModPreset setting)
+		{
+			MODMainUIController mODMainUIController = new MODMainUIController();
+			if (setting == ModPreset.ADV)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GADVMode", 1);
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", 0);
+				TryRedrawTextWindowBackground(WindowFilterType.ADV);
+				mODMainUIController.WideGuiPositionStore();
+				mODMainUIController.ADVModeSettingStore();
+				string feedbackString = $"Set ADV Mode";
+				int toastDuration = 3;
+				if(BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
+				{
+					feedbackString += "\nIn NVL region - changes won't be displayed until later";
+					toastDuration = 5;
+				}
+				MODToaster.Show(feedbackString, isEnable: true, toastDuration: toastDuration);
+			}
+			else if (setting == ModPreset.NVL)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GADVMode", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
+				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", 0);
+				TryRedrawTextWindowBackground(WindowFilterType.Normal);
+				mODMainUIController.WideGuiPositionStore();
+				mODMainUIController.NVLModeSettingStore();
+				MODToaster.Show($"Set NVL Mode", isEnable: false);
+			}
+			else if (setting == ModPreset.OG)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GADVMode", 0);
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
+				BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode", 1);
+				BurikoMemory.Instance.SetGlobalFlag("GHideCG", 1);
+				BurikoMemory.Instance.SetGlobalFlag("GStretchBackgrounds", 0);
+				TryRedrawTextWindowBackground(WindowFilterType.OG);
+				mODMainUIController.RyukishiGuiPositionStore();
+				mODMainUIController.RyukishiModeSettingStore();
+				MODToaster.Show($"Set OG Mode", isEnable: false);
+			}
+
+			// Return false if in a NVL_in_ADV region to tell users that value might not be applied immediately
+			//return BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 0;
+		}
+
+		public static void EnableNVLModeINADVMode()
+		{
+			BurikoMemory.Instance.SetFlag("NVL_in_ADV", 1);
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			{
+				MODMainUIController mODMainUIController = new MODMainUIController();
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
+				TryRedrawTextWindowBackground(WindowFilterType.NVLInADV);
+				mODMainUIController.NVLADVModeSettingStore();
+			}
+		}
+
+		public static void DisableNVLModeINADVMode()
+		{
+			BurikoMemory.Instance.SetFlag("NVL_in_ADV", 0);
+			if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			{
+				MODMainUIController mODMainUIController = new MODMainUIController();
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 0);
+				TryRedrawTextWindowBackground(WindowFilterType.ADV);
+				mODMainUIController.ADVModeSettingStore();
+			}
+		}
+
+		public static void DebugFontSizeChanger()
+		{
+			new MODMainUIController().DebugFontChangerSettingStore();
+		}
+
+		public static void AdjustVoiceVolumeRelative(int difference)
+		{
+			// Maintaining volume within limits is done in AdjustVoiceVolumeAbsolute()
+			AdjustVoiceVolumeAbsolute(BurikoMemory.Instance.GetGlobalFlag("GVoiceVolume").IntValue() + difference);
+		}
+
+		public static void AdjustVoiceVolumeAbsolute(int uncheckedNewVolume)
+		{
+			int newVolume = Mathf.Clamp(uncheckedNewVolume, 0, 100);
+
+			BurikoMemory.Instance.SetGlobalFlag("GVoiceVolume", newVolume);
+			GameSystem.Instance.AudioController.VoiceVolume = (float)newVolume / 100f;
+			GameSystem.Instance.AudioController.RefreshLayerVolumes();
+
+			// Play a sample voice file so the user can get feedback on the set volume
+			// For some reason the script uses "256" as the default volume, which gets divided by 128 to become 2.0f,
+			// so to keep in line with the script, the test volume is set to "2.0f"
+			GameSystem.Instance.AudioController.PlayVoice("voice_test.ogg", 3, 2.0f);
+		}
+
+		// Variant for global flags, using another variable as max limit
+		public static int IncrementGlobalFlagWithRollover(string flagName, string maxFlagName)
+		{
+			return _IncrementFlagWithRollover(flagName, 0, BurikoMemory.Instance.GetGlobalFlag(maxFlagName).IntValue(), isLocalFlag: false);
+		}
+
+		// Variant for global flags, using literal limits
+		public static int IncrementGlobalFlagWithRollover(string flagName, int minValueInclusive, int maxValueInclusive)
+		{
+			return _IncrementFlagWithRollover(flagName, minValueInclusive, maxValueInclusive, isLocalFlag: false);
+		}
+
+		// Variant for local flags
+		public static int IncrementLocalFlagWithRollover(string flagName, int minValueInclusive, int maxValueInclusive)
+		{
+			return _IncrementFlagWithRollover(flagName, minValueInclusive, maxValueInclusive, isLocalFlag: true);
+		}
+
+		/// <summary>
+		/// Increment a flag with rollover (from GetGlobalFlag())
+		/// If min/max set to (3,6), it will loop over the values 3,4,5,6
+		/// </summary>
+		/// <param name="flagName">the name of the global flag, eg. "GVoiceVolume"</param>
+		/// <param name="minValueInclusive">This is the minvalue the flag can be allowed to have before it rolls over, inclusive.</param>
+		/// <param name="maxValueInclusive">This is the max value the flag can be allowed to have before it rolls over, inclusive.</param>
+		/// <returns></returns>
+		static int _IncrementFlagWithRollover(string flagName, int minValueInclusive, int maxValueInclusive, bool isLocalFlag)
+		{
+			int initialValue = isLocalFlag ? BurikoMemory.Instance.GetFlag(flagName).IntValue() : BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
+
+			int newValue = initialValue + 1;
+			if (newValue > maxValueInclusive)
+			{
+				newValue = minValueInclusive;
+			}
+
+			if (isLocalFlag)
+			{
+				BurikoMemory.Instance.SetFlag(flagName, newValue);
+			}
+			else
+			{
+				BurikoMemory.Instance.SetGlobalFlag(flagName, newValue);
+			}
+
+			return newValue;
+		}
+
+		public static bool ToggleFlagAndSave(string flagName)
+		{
+			int newValue = (BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue() + 1) % 2;
+			BurikoMemory.Instance.SetGlobalFlag(flagName, newValue);
+
+			return newValue == 1;
+		}
+		public static string VideoOpeningDescription(int videoOpeningValue)
+		{
+			switch (videoOpeningValue)
+			{
+				case 0:
+					return "Unset";
+				case 1:
+					return "Disabled";
+				case 2:
+					return "In-game";
+				case 3:
+					return "At launch + in-game";
+			}
+
+			return "Unknown";
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -73,6 +73,8 @@ namespace MOD.Scripts.UI
 		/// <param name="showInfoToast">If True, always shows a toast indicting the NVL/ADV status.
 		/// If False, will only show toast if there is a warning (like you are in a nvl_in_adv region)</param>
 		/// <returns>True if set and displayed, false if in a NVL_in_ADV region and value might not be applied immediately</returns>
+		///
+		/// NOTE: if this function is updated, you should update the corresponding "GetModeFromFlags()" function immediately below
 		public static void SetAndSaveADV(ModPreset setting, bool showInfoToast = true)
 		{
 			MODMainUIController mODMainUIController = new MODMainUIController();
@@ -122,6 +124,51 @@ namespace MOD.Scripts.UI
 				mODMainUIController.RyukishiModeSettingStore();
 				Core.MODSystem.instance.modTextureController.SetArtStyle(2, showInfoToast);
 				if (showInfoToast) { MODToaster.Show($"Set OG Mode", isEnable: false); }
+			}
+		}
+
+		// This expressions for 'presetModified' should be updated each time SetAndSaveADV() above is changed,
+		// so that the player knows when the flags have changed from their default values for the current preset
+		public static int GetADVNVLRyukishiModeFromFlags(out bool presetModified)
+		{
+			// If background override is enabled on any preset, the preset has been modified
+			presetModified = BurikoMemory.Instance.GetGlobalFlag("GBackgroundSet").IntValue() != 0;
+
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				presetModified = presetModified ||
+					BurikoMemory.Instance.GetGlobalFlag("GArtStyle").IntValue() != 2 ||
+					BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GLinemodeSp").IntValue() != 2 ||
+					BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() != 1 ||
+					BurikoMemory.Instance.GetGlobalFlag("GHideCG").IntValue() != 1 ||
+					BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() != 0;
+
+				return 2;
+			}
+			else if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
+			{
+				presetModified = presetModified ||
+					BurikoMemory.Instance.GetGlobalFlag("GArtStyle").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() != 1 ||
+					BurikoMemory.Instance.GetGlobalFlag("GLinemodeSp").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GHideCG").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() != 0;
+
+				return 0;
+			}
+			else
+			{
+				presetModified = presetModified ||
+					BurikoMemory.Instance.GetGlobalFlag("GArtStyle").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GLinemodeSp").IntValue() != 2 ||
+					BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GHideCG").IntValue() != 0 ||
+					BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() != 0;
+
+				return 1;
 			}
 		}
 

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -251,7 +251,7 @@ namespace MOD.Scripts.UI
 		/// If min/max set to (3,6), it will loop over the values 3,4,5,6
 		/// </summary>
 		/// <param name="flagName">the name of the global flag, eg. "GVoiceVolume"</param>
-		/// <param name="minValueInclusive">This is the minvalue the flag can be allowed to have before it rolls over, inclusive.</param>
+		/// <param name="minValueInclusive">This is the min value the flag can be allowed to have before it rolls over, inclusive.</param>
 		/// <param name="maxValueInclusive">This is the max value the flag can be allowed to have before it rolls over, inclusive.</param>
 		/// <returns></returns>
 		static int _IncrementFlagWithRollover(string flagName, int minValueInclusive, int maxValueInclusive, bool isLocalFlag)

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -294,21 +294,22 @@ namespace MOD.Scripts.UI
 		//NOTE: paths might not open properly on windows if they contain backslashes
 		public static void ShowFile(string path)
 		{
+			Assets.Scripts.Core.Logger.Log($"MOD ShowFile(): Showing [{path}]");
 			try
 			{
 				switch (MODUtility.GetPlatform())
 				{
 					case MODUtility.Platform.Windows:
 					default:
-						Process.Start("explorer", path);
+						Process.Start("explorer", path.Replace('/', '\\'));
 						break;
 
 					case MODUtility.Platform.MacOS:
-						Process.Start("open", path);
+						Process.Start("open", path.Replace('\\', '/'));
 						break;
 
 					case MODUtility.Platform.Linux:
-						Process.Start("xdg-open", path);
+						Process.Start("xdg-open", path.Replace('\\', '/'));
 						break;
 				}
 			}

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -62,7 +62,14 @@ namespace MOD.Scripts.UI
 			}
 			else
 			{
-				SetAndSaveADV(ModPreset.OG);
+				if(HasOGBackgrounds())
+				{
+					SetAndSaveADV(ModPreset.OG);
+				}
+				else
+				{
+					SetAndSaveADV(ModPreset.ADV);
+				}
 			}
 		}
 
@@ -364,6 +371,11 @@ namespace MOD.Scripts.UI
 			{
 				Assets.Scripts.Core.Logger.Log($"Failed to open {path}:\n{e}");
 			}
+		}
+
+		public static bool HasOGBackgrounds()
+		{
+			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, "OGBackgrounds"));
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -10,9 +10,23 @@ namespace MOD.Scripts.UI
 	static class MODKeyboardShortcuts
 	{
 
-		private static bool ModInputHandlingAllowed()
+		public static bool ModInputHandlingAllowed()
 		{
 			GameSystem gameSystem = GameSystem.Instance;
+
+			switch (gameSystem.GameState)
+			{
+				case GameState.RightClickMenu:
+				case GameState.Normal:
+				case GameState.TitleScreen:
+				case GameState.MODDisableInput:
+					break;
+
+				default:
+					return false;
+			}
+
+
 			if (!gameSystem.IsInitialized || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
 			{
 				return false;
@@ -184,20 +198,6 @@ namespace MOD.Scripts.UI
 					}
 					break;
 
-				case Action.ModMenu:
-					{
-						MODMenu menu = GameSystem.Instance.MainUIController.modMenu;
-						if (menu.visible)
-						{
-							menu.Hide();
-						}
-						else
-						{
-							menu.Show();
-						}
-					}
-					break;
-
 				case Action.OpeningVideo:
 					{
 						// Loop "GVideoOpening" over the values 1-3.
@@ -311,13 +311,20 @@ namespace MOD.Scripts.UI
 		{
 			if (GetUserAction() is Action action)
 			{
-				if (!ModInputHandlingAllowed())
+				if (action == Action.ModMenu)
 				{
-					MODToaster.Show($"Please let animation finish first");
+					GameSystem.Instance.MainUIController.modMenu.ToggleVisibility();
 				}
 				else
 				{
-					ModHandleUserAction(action);
+					if (!ModInputHandlingAllowed())
+					{
+						MODToaster.Show($"Please let animation finish first and/or close the menu");
+					}
+					else
+					{
+						ModHandleUserAction(action);
+					}
 				}
 			}
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -38,6 +38,7 @@ namespace MOD.Scripts.UI
 			CensorshipLevel,
 			EffectLevel,
 			FlagMonitor,
+			ModMenu,
 			OpeningVideo,
 			DebugFontSize,
 			AltBGM,
@@ -61,17 +62,21 @@ namespace MOD.Scripts.UI
 			// These take priority over the non-shift key buttons
 			if (Input.GetKey(KeyCode.LeftShift))
 			{
-				if (Input.GetKeyDown(KeyCode.F10))
-				{
-					return Action.DebugMode;
-				}
-				else if (Input.GetKeyDown(KeyCode.F9))
+				if (Input.GetKeyDown(KeyCode.F9))
 				{
 					return Action.RestoreSettings;
+				}
+				else if (Input.GetKeyDown(KeyCode.F10))
+				{
+					return Action.FlagMonitor;
 				}
 				else if (Input.GetKeyDown(KeyCode.F11))
 				{
 					return Action.OpeningVideo;
+				}
+				else if (Input.GetKeyDown(KeyCode.F12))
+				{
+					return Action.DebugMode;
 				}
 				else if (Input.GetKeyDown(KeyCode.M))
 				{
@@ -97,7 +102,7 @@ namespace MOD.Scripts.UI
 			}
 			else if (Input.GetKeyDown(KeyCode.F10))
 			{
-				return Action.FlagMonitor;
+				return Action.ModMenu;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha0) || Input.GetKeyDown(KeyCode.Keypad0))
 			{
@@ -175,8 +180,12 @@ namespace MOD.Scripts.UI
 				case Action.FlagMonitor:
 					{
 						int maxFlagMonitorValue = BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 0 ? 2 : 4;
-						int flagMonitorEnabled = MODActions.IncrementLocalFlagWithRollover("LFlagMonitor", 0, maxFlagMonitorValue);
+						MODActions.IncrementLocalFlagWithRollover("LFlagMonitor", 0, maxFlagMonitorValue);
+					}
+					break;
 
+				case Action.ModMenu:
+					{
 						MODMenu menu = GameSystem.Instance.MainUIController.modMenu;
 						if (menu.visible)
 						{

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -39,7 +39,6 @@ namespace MOD.Scripts.UI
 			EffectLevel,
 			FlagMonitor,
 			OpeningVideo,
-			ForceShowCG,
 			DebugFontSize,
 			AltBGM,
 			AltBGMFlow,
@@ -55,7 +54,6 @@ namespace MOD.Scripts.UI
 			ToggleArtStyle,
 			DebugMode,
 			RestoreSettings,
-			StretchBackgrounds,
 		}
 
 		private static Action? GetUserAction()
@@ -82,14 +80,6 @@ namespace MOD.Scripts.UI
 				else if (Input.GetKeyDown(KeyCode.N))
 				{
 					return Action.VoiceVolumeMin;
-				}
-				else if (Input.GetKeyDown(KeyCode.Alpha9) || Input.GetKeyDown(KeyCode.Keypad9))
-				{
-					return Action.ForceShowCG;
-				}
-				else if (Input.GetKeyDown(KeyCode.Alpha8) || Input.GetKeyDown(KeyCode.Keypad8))
-				{
-					return Action.StretchBackgrounds;
 				}
 			}
 
@@ -208,14 +198,6 @@ namespace MOD.Scripts.UI
 					}
 					break;
 
-				case Action.ForceShowCG:
-					{
-						bool cgIsHidden = MODActions.ToggleFlagAndSave("GHideCG");
-						MODToaster.Show($"Hide CG: {(cgIsHidden ? "ON" : "OFF")}", isEnable: cgIsHidden);
-					}
-					break;
-
-
 				case Action.DebugFontSize when BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 1 || BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 2:
 					MODActions.DebugFontSizeChanger();
 					break;
@@ -303,14 +285,6 @@ namespace MOD.Scripts.UI
 					{
 						int restoreGameSettingsNum = MODActions.IncrementGlobalFlagWithRollover("GMOD_SETTING_LOADER", 0, 3);
 						MODToaster.Show($"Reset Settings: {restoreGameSettingsNum} (see F10 menu)", numberedSound: restoreGameSettingsNum);
-					}
-					break;
-
-				case Action.StretchBackgrounds:
-					{
-						bool shouldStretchBackgrounds = MODActions.ToggleFlagAndSave("GStretchBackgrounds");
-						GameSystem.Instance.SceneController.ReloadAllImages();
-						MODToaster.Show($"Background Stretching: {(shouldStretchBackgrounds ? "ON" : "OFF")}", isEnable: shouldStretchBackgrounds);
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -1,0 +1,344 @@
+﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.Buriko;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	static class MODKeyboardShortcuts
+	{
+
+		private static bool ModInputHandlingAllowed()
+		{
+			GameSystem gameSystem = GameSystem.Instance;
+			if (!gameSystem.IsInitialized || gameSystem.IsAuto || gameSystem.IsSkipping || gameSystem.IsForceSkip)
+			{
+				return false;
+			}
+
+			// Don't allow mod options on any wait, except "WaitForInput"
+			// Note: if this is removed, it mostly still works, but if changing art style during
+			// an animation, some things may bug out until the next scene.
+			foreach (Wait w in gameSystem.WaitList)
+			{
+				if (w.Type != WaitTypes.WaitForInput)
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		enum Action
+		{
+			ToggleADV,
+			CensorshipLevel,
+			EffectLevel,
+			FlagMonitor,
+			OpeningVideo,
+			ForceShowCG,
+			DebugFontSize,
+			AltBGM,
+			AltBGMFlow,
+			AltSE,
+			AltSEFlow,
+			AltVoice,
+			AltVoicePriority,
+			LipSync,
+			VoiceVolumeUp,
+			VoiceVolumeDown,
+			VoiceVolumeMax,
+			VoiceVolumeMin,
+			ToggleArtStyle,
+			DebugMode,
+			RestoreSettings,
+			StretchBackgrounds,
+		}
+
+		private static Action? GetUserAction()
+		{
+			// These take priority over the non-shift key buttons
+			if (Input.GetKey(KeyCode.LeftShift))
+			{
+				if (Input.GetKeyDown(KeyCode.F10))
+				{
+					return Action.DebugMode;
+				}
+				else if (Input.GetKeyDown(KeyCode.F9))
+				{
+					return Action.RestoreSettings;
+				}
+				else if (Input.GetKeyDown(KeyCode.F11))
+				{
+					return Action.OpeningVideo;
+				}
+				else if (Input.GetKeyDown(KeyCode.M))
+				{
+					return Action.VoiceVolumeMax;
+				}
+				else if (Input.GetKeyDown(KeyCode.N))
+				{
+					return Action.VoiceVolumeMin;
+				}
+				else if (Input.GetKeyDown(KeyCode.Alpha9) || Input.GetKeyDown(KeyCode.Keypad9))
+				{
+					return Action.ForceShowCG;
+				}
+				else if (Input.GetKeyDown(KeyCode.Alpha8) || Input.GetKeyDown(KeyCode.Keypad8))
+				{
+					return Action.StretchBackgrounds;
+				}
+			}
+
+			if (Input.GetKeyDown(KeyCode.F1))
+			{
+				return Action.ToggleADV;
+			}
+			else if (Input.GetKeyDown(KeyCode.F2))
+			{
+				return Action.CensorshipLevel;
+			}
+			else if (Input.GetKeyDown(KeyCode.F3))
+			{
+				return Action.EffectLevel;
+			}
+			else if (Input.GetKeyDown(KeyCode.F10))
+			{
+				return Action.FlagMonitor;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha0) || Input.GetKeyDown(KeyCode.Keypad0))
+			{
+				return Action.DebugFontSize;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
+			{
+				return Action.AltBGM;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
+			{
+				return Action.AltBGMFlow;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3))
+			{
+				return Action.AltSE;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4))
+			{
+				return Action.AltSEFlow;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha5) || Input.GetKeyDown(KeyCode.Keypad5))
+			{
+				return Action.AltVoice;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha6) || Input.GetKeyDown(KeyCode.Keypad6))
+			{
+				return Action.AltVoicePriority;
+			}
+			else if (Input.GetKeyDown(KeyCode.Alpha7) || Input.GetKeyDown(KeyCode.Keypad7))
+			{
+				return Action.LipSync;
+			}
+			else if (Input.GetKeyDown(KeyCode.M))
+			{
+				return Action.VoiceVolumeUp;
+			}
+			else if (Input.GetKeyDown(KeyCode.P))
+			{
+				return Action.ToggleArtStyle;
+			}
+			else if (Input.GetKeyDown(KeyCode.N))
+			{
+				return Action.VoiceVolumeDown;
+			}
+
+			return null;
+		}
+
+		private static void ModHandleUserAction(Action action)
+		{
+			switch (action)
+			{
+				case Action.ToggleADV:
+					MODActions.ToggleAndSaveADVMode();
+					break;
+
+				case Action.CensorshipLevel:
+					{
+						int newCensorNum = MODActions.IncrementGlobalFlagWithRollover("GCensor", "GCensorMaxNum");
+						MODToaster.Show(
+							$"Censorship Level: {newCensorNum}{(newCensorNum == 2 ? " (default)" : "")}",
+							numberedSound: newCensorNum
+						);
+					}
+					break;
+
+				case Action.EffectLevel:
+					{
+						int effectLevel = MODActions.IncrementGlobalFlagWithRollover("GEffectExtend", "GEffectExtendMaxNum");
+						MODToaster.Show($"Effect Level: {effectLevel} (Not Used)", numberedSound: effectLevel);
+					}
+					break;
+
+				case Action.FlagMonitor:
+					{
+						int maxFlagMonitorValue = BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 0 ? 2 : 4;
+						int flagMonitorEnabled = MODActions.IncrementLocalFlagWithRollover("LFlagMonitor", 0, maxFlagMonitorValue);
+
+						MODMenu menu = GameSystem.Instance.MainUIController.modMenu;
+						if (menu.visible)
+						{
+							menu.Hide();
+						}
+						else
+						{
+							menu.Show();
+						}
+					}
+					break;
+
+				case Action.OpeningVideo:
+					{
+						// Loop "GVideoOpening" over the values 1-3.
+						// 0 is skipped as it represents "value not set"
+						int newVideoOpening = MODActions.IncrementGlobalFlagWithRollover("GVideoOpening", 1, 3);
+						MODToaster.Show($"OP Video: {MODActions.VideoOpeningDescription(newVideoOpening)} ({newVideoOpening})");
+					}
+					break;
+
+				case Action.ForceShowCG:
+					{
+						bool cgIsHidden = MODActions.ToggleFlagAndSave("GHideCG");
+						MODToaster.Show($"Hide CG: {(cgIsHidden ? "ON" : "OFF")}", isEnable: cgIsHidden);
+					}
+					break;
+
+
+				case Action.DebugFontSize when BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 1 || BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 2:
+					MODActions.DebugFontSizeChanger();
+					break;
+
+				case Action.AltBGM:
+					{
+						bool altBGMEnabled = MODActions.ToggleFlagAndSave("GAltBGM");
+						MODToaster.Show($"Alt BGM: {(altBGMEnabled ? "ON" : "OFF")} (Not Used)", isEnable: altBGMEnabled);
+					}
+					break;
+
+				case Action.AltBGMFlow:
+					{
+						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
+						MODToaster.Show($"Alt BGM Flow: {newAltBGMFlow} (Not Used)", numberedSound: newAltBGMFlow);
+					}
+					break;
+
+				case Action.AltSE:
+					{
+						bool seIsEnabled = MODActions.ToggleFlagAndSave("GAltSE");
+						MODToaster.Show($"Alt SE: {(seIsEnabled ? "ON" : "OFF")} (Not Used)", isEnable: seIsEnabled);
+					}
+					break;
+
+				case Action.AltSEFlow:
+					{
+						int newAltSEFlow = MODActions.IncrementGlobalFlagWithRollover("GAltSEflow", "GAltSEflowMaxNum");
+						MODToaster.Show($"Alt SE Flow: {newAltSEFlow} (Not Used)", numberedSound: newAltSEFlow);
+					}
+					break;
+
+				case Action.AltVoice:
+					{
+						bool altVoiceIsEnabled = MODActions.ToggleFlagAndSave("GAltVoice");
+						MODToaster.Show($"Alt Voice: {(altVoiceIsEnabled ? "ON" : "OFF")} (Not Used)", isEnable: altVoiceIsEnabled);
+					}
+					break;
+
+				case Action.AltVoicePriority:
+					{
+						bool altVoicePriorityIsEnabled = MODActions.ToggleFlagAndSave("GAltVoicePriority");
+						MODToaster.Show($"Alt Priority: {(altVoicePriorityIsEnabled ? "ON" : "OFF")} (Not Used)", isEnable: altVoicePriorityIsEnabled);
+					}
+					break;
+
+				case Action.LipSync:
+					{
+						bool lipSyncIsEnabled = MODActions.ToggleFlagAndSave("GLipSync");
+						MODToaster.Show($"Lip Sync: {(lipSyncIsEnabled ? "ON" : "OFF")}", isEnable: lipSyncIsEnabled);
+					}
+					break;
+
+				case Action.VoiceVolumeUp:
+					MODActions.AdjustVoiceVolumeRelative(5);
+					break;
+
+				case Action.VoiceVolumeDown:
+					MODActions.AdjustVoiceVolumeRelative(-5);
+					break;
+
+				case Action.VoiceVolumeMax:
+					MODActions.AdjustVoiceVolumeAbsolute(100);
+					break;
+
+				case Action.VoiceVolumeMin:
+					MODActions.AdjustVoiceVolumeAbsolute(0);
+					break;
+
+				case Action.ToggleArtStyle:
+					MOD.Scripts.Core.MODSystem.instance.modTextureController.ToggleArtStyle();
+					break;
+
+				// Enable debug mode, which shows an extra 2 panels of info in the flag menu
+				// Note that if your debug mode is 0, there is no way to enable debug mode unless you manually set the flag value in the game script
+				case Action.DebugMode when BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() != 0:
+					{
+						int debugMode = MODActions.IncrementGlobalFlagWithRollover("GMOD_DEBUG_MODE", 1, 2);
+						MODToaster.Show($"Debug Mode: {debugMode}", numberedSound: debugMode);
+					}
+					break;
+
+				// Restore game settings
+				case Action.RestoreSettings:
+					{
+						int restoreGameSettingsNum = MODActions.IncrementGlobalFlagWithRollover("GMOD_SETTING_LOADER", 0, 3);
+						MODToaster.Show($"Reset Settings: {restoreGameSettingsNum} (see F10 menu)", numberedSound: restoreGameSettingsNum);
+					}
+					break;
+
+				case Action.StretchBackgrounds:
+					{
+						bool shouldStretchBackgrounds = MODActions.ToggleFlagAndSave("GStretchBackgrounds");
+						GameSystem.Instance.SceneController.ReloadAllImages();
+						MODToaster.Show($"Background Stretching: {(shouldStretchBackgrounds ? "ON" : "OFF")}", isEnable: shouldStretchBackgrounds);
+					}
+					break;
+
+				default:
+					Assets.Scripts.Core.Logger.Log($"Warning: Unknown mod action {action} was requested to be executed");
+					break;
+			}
+		}
+
+		/// <summary>
+		/// Handles mod inputs. Call from Update function.
+		/// </summary>
+		/// <returns>Currently the return value is not used for anything</returns>
+		public static bool ModInputHandler()
+		{
+			if (GetUserAction() is Action action)
+			{
+				if (!ModInputHandlingAllowed())
+				{
+					MODToaster.Show($"Please let animation finish first");
+				}
+				else
+				{
+					ModHandleUserAction(action);
+				}
+			}
+
+			return true;
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -76,11 +76,7 @@ namespace MOD.Scripts.UI
 			// These take priority over the non-shift key buttons
 			if (Input.GetKey(KeyCode.LeftShift))
 			{
-				if (Input.GetKeyDown(KeyCode.F9))
-				{
-					return Action.RestoreSettings;
-				}
-				else if (Input.GetKeyDown(KeyCode.F10))
+				if (Input.GetKeyDown(KeyCode.F10))
 				{
 					return Action.FlagMonitor;
 				}

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -84,6 +84,22 @@ namespace MOD.Scripts.UI
 
 		private static int NVLADVModeFontID;
 
+		// Ryukishi Mode Settings, with default values
+		private static string RyukishiModeNameFormat = "";
+		private static int RyukishiModeWindowPosX = 0;
+		private static int RyukishiModeWindowPosY = 10;
+		private static int RyukishiModeWindowSizeX = 1024;
+		private static int RyukishiModeWindowSizeY = 768;
+		private static int RyukishiModeWindowMarginLeft = 60;
+		private static int RyukishiModeWindowMarginTop = 30;
+		private static int RyukishiModeWindowMarginRight = 50;
+		private static int RyukishiModeWindowMarginBottom = 30;
+		private static int RyukishiModeFontID = 1;
+		private static int RyukishiModeCharSpacing = 0;
+		private static int RyukishiModeLineSpacing = 8;
+		private static int RyukishiModeFontSize = 34;
+
+
 		public void ADVModeSettingLoad(string name, int posx, int posy, int sizex, int sizey, int mleft, int mtop, int mright, int mbottom, int font, int cspace, int lspace, int fsize)
 		{
 			ADVModeNameFormat = name;
@@ -143,6 +159,30 @@ namespace MOD.Scripts.UI
 			NVLADVModeCharSpacing = cspace;
 			NVLADVModeLineSpacing = lspace;
 			NVLADVModeFontSize = fsize;
+		}
+
+		public void RyukishiModeSettingLoad(string name, int posx, int posy, int sizex, int sizey, int mleft, int mtop, int mright, int mbottom, int font, int cspace, int lspace, int fsize)
+		{
+			RyukishiModeNameFormat = name;
+			RyukishiModeWindowPosX = posx;
+			RyukishiModeWindowPosY = posy;
+			RyukishiModeWindowSizeX = sizex;
+			RyukishiModeWindowSizeY = sizey;
+			RyukishiModeWindowMarginLeft = mleft;
+			RyukishiModeWindowMarginTop = mtop;
+			RyukishiModeWindowMarginRight = mright;
+			RyukishiModeWindowMarginBottom = mbottom;
+			RyukishiModeFontID = font;
+			RyukishiModeCharSpacing = cspace;
+			RyukishiModeLineSpacing = lspace;
+			RyukishiModeFontSize = fsize;
+
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				// Set NVL Line Mode
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
+				RyukishiModeSettingStore();
+			}
 		}
 
 		public void ADVModeSettingStore()
@@ -218,6 +258,31 @@ namespace MOD.Scripts.UI
 			GameSystem.Instance.MainUIController.SetCharSpacing(nVLADVModeCharSpacing);
 			GameSystem.Instance.MainUIController.SetLineSpacing(nVLADVModeLineSpacing);
 			GameSystem.Instance.MainUIController.SetFontSize(nVLADVModeFontSize);
+		}
+
+		public void RyukishiModeSettingStore()
+		{
+			string ryukishiModeNameFormat = RyukishiModeNameFormat;
+			int ryukishiModeWindowPosX = RyukishiModeWindowPosX;
+			int ryukishiModeWindowPosY = RyukishiModeWindowPosY;
+			int ryukishiModeWindowSizeX = RyukishiModeWindowSizeX;
+			int ryukishiModeWindowSizeY = RyukishiModeWindowSizeY;
+			int ryukishiModeWindowMarginLeft = RyukishiModeWindowMarginLeft;
+			int ryukishiModeWindowMarginTop = RyukishiModeWindowMarginTop;
+			int ryukishiModeWindowMarginRight = RyukishiModeWindowMarginRight;
+			int ryukishiModeWindowMarginBottom = RyukishiModeWindowMarginBottom;
+			int ryukishiModeFontID = RyukishiModeFontID;
+			int ryukishiModeCharSpacing = RyukishiModeCharSpacing;
+			int ryukishiModeLineSpacing = RyukishiModeLineSpacing;
+			int ryukishiModeFontSize = RyukishiModeFontSize;
+			GameSystem.Instance.TextController.NameFormat = ryukishiModeNameFormat;
+			GameSystem.Instance.MainUIController.SetWindowPos(ryukishiModeWindowPosX, ryukishiModeWindowPosY);
+			GameSystem.Instance.MainUIController.SetWindowSize(ryukishiModeWindowSizeX, ryukishiModeWindowSizeY);
+			GameSystem.Instance.MainUIController.SetWindowMargins(ryukishiModeWindowMarginLeft, ryukishiModeWindowMarginTop, ryukishiModeWindowMarginRight, ryukishiModeWindowMarginBottom);
+			GameSystem.Instance.MainUIController.ChangeFontId(ryukishiModeFontID);
+			GameSystem.Instance.MainUIController.SetCharSpacing(ryukishiModeCharSpacing);
+			GameSystem.Instance.MainUIController.SetLineSpacing(ryukishiModeLineSpacing);
+			GameSystem.Instance.MainUIController.SetFontSize(ryukishiModeFontSize);
 		}
 
 		public void DebugFontChangerSettingStore()

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -105,6 +105,23 @@ namespace MOD.Scripts.UI
 		private static int RyukishiModeGuiPosX = 0;
 		private static int RyukishiModeGuiPosY = 0;
 
+		private void StoreRyukishiModeIfFlagSet()
+		{
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2); // Set NVL Line Mode
+				RyukishiModeSettingStore();
+			}
+		}
+
+		private void StoreRyukishiGuiPositionIfFlagSet()
+		{
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				RyukishiModeSettingStore();
+			}
+		}
+
 		public void WideGuiPositionLoad(int posx, int posy)
 		{
 			WideModeGuiPosX = posx;
@@ -113,16 +130,16 @@ namespace MOD.Scripts.UI
 			{
 				WideGuiPositionStore();
 			}
+
+			// This ensures scripts without a "ModRyukishiSetGuiPosition" will still initialize using the default values. Can be moved elsewhere (must be before reaching normal gameplay)
+			StoreRyukishiGuiPositionIfFlagSet();
 		}
 
 		public void RyukishiGuiPositionLoad(int posx, int posy)
 		{
 			RyukishiModeGuiPosX = posx;
 			RyukishiModeGuiPosY = posy;
-			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
-			{
-				RyukishiModeSettingStore();
-			}
+			StoreRyukishiGuiPositionIfFlagSet();
 		}
 
 		public void WideGuiPositionStore()
@@ -177,6 +194,9 @@ namespace MOD.Scripts.UI
 				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
 				NVLModeSettingStore();
 			}
+
+			// This ensures scripts without a "ModRyukishiModeSettingLoad" will still initialize using the default values. Can be moved elsewhere (must be before reaching normal gameplay)
+			StoreRyukishiModeIfFlagSet();
 		}
 
 		public void NVLADVModeSettingLoad(string name, int posx, int posy, int sizex, int sizey, int mleft, int mtop, int mright, int mbottom, int font, int cspace, int lspace, int fsize)
@@ -212,12 +232,7 @@ namespace MOD.Scripts.UI
 			RyukishiModeLineSpacing = lspace;
 			RyukishiModeFontSize = fsize;
 
-			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
-			{
-				// Set NVL Line Mode
-				BurikoMemory.Instance.SetGlobalFlag("GLinemodeSp", 2);
-				RyukishiModeSettingStore();
-			}
+			StoreRyukishiModeIfFlagSet();
 		}
 
 		public void ADVModeSettingStore()

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -99,6 +99,41 @@ namespace MOD.Scripts.UI
 		private static int RyukishiModeLineSpacing = 8;
 		private static int RyukishiModeFontSize = 34;
 
+		// Wide Mode/Ryukishi Mode Window Settings, with default values
+		private static int WideModeGuiPosX = 0;
+		private static int WideModeGuiPosY = 0;
+		private static int RyukishiModeGuiPosX = 0;
+		private static int RyukishiModeGuiPosY = 0;
+
+		public void WideGuiPositionLoad(int posx, int posy)
+		{
+			WideModeGuiPosX = posx;
+			WideModeGuiPosY = posy;
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() != 1)
+			{
+				WideGuiPositionStore();
+			}
+		}
+
+		public void RyukishiGuiPositionLoad(int posx, int posy)
+		{
+			RyukishiModeGuiPosX = posx;
+			RyukishiModeGuiPosY = posy;
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				RyukishiModeSettingStore();
+			}
+		}
+
+		public void WideGuiPositionStore()
+		{
+			GameSystem.Instance.MainUIController.UpdateGuiPosition(WideModeGuiPosX, WideModeGuiPosY);
+		}
+
+		public void RyukishiGuiPositionStore()
+		{
+			GameSystem.Instance.MainUIController.UpdateGuiPosition(RyukishiModeGuiPosX, RyukishiModeGuiPosY);
+		}
 
 		public void ADVModeSettingLoad(string name, int posx, int posy, int sizex, int sizey, int mleft, int mtop, int mright, int mbottom, int font, int cspace, int lspace, int fsize)
 		{

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -195,7 +195,8 @@ Sets the script censorship level
 				new GUIContent("Default BGs", "Use the default backgrounds for the current artset"),
 				new GUIContent("Console BGs", "Force Console backgrounds, regardless of the artset"),
 				new GUIContent("Original BGs", "Force Original/Ryukishi backgrounds, regardless of the artset"),
-				new GUIContent("Original Stretched", "Force Original/Ryukishi backgrounds, stretched to fit, regardless of the artset"),
+				new GUIContent("Original Stretched", "Force Original/Ryukishi backgrounds, stretched to fit, regardless of the artset\n\n" +
+				"WARNING: When using this option, you should have ADV/NVL mode selected, otherwise sprites will be cut off, and UI will appear in the wrong place"),
 			}, styleManager, itemsPerRow: 2);
 
 			// Start the watchdog timer as soon as possible, so it starts from "when the game started"

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -1,0 +1,367 @@
+﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.Buriko;
+using Assets.Scripts.Core.State;
+using MOD.Scripts.Core.State;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODRadio
+	{
+		string label;
+		private GUIContent[] radioContents;
+		MODStyleManager styleManager;
+		int itemsPerRow;
+
+		public MODRadio(string label, GUIContent[] radioContents, MODStyleManager styleManager, int itemsPerRow=0) //Action<int> onRadioChange, 
+		{
+			this.label = label;
+			this.radioContents = radioContents;
+			this.itemsPerRow = itemsPerRow == 0 ? radioContents.Length : itemsPerRow;
+			this.styleManager = styleManager;
+		}
+
+		/// <summary>
+		/// NOTE: only call this function within OnGUI()
+		/// Displays the radio, calling onRadioChange when the user clicks on a different radio value.
+		/// </summary>
+		/// <param name="displayedRadio">Sets the currently displayed radio. Use "-1" for "None selected"</param>
+		/// <returns>If radio did not change value, null is returned, otherwise the new value is returned.</returns>
+		public int? OnGUIFragment(int displayedRadio)
+		{
+			GUILayout.Label(this.label);
+			int i = GUILayout.SelectionGrid(displayedRadio, radioContents, itemsPerRow, styleManager.modSelectorStyle);
+			if (i != displayedRadio)
+			{
+				return i;
+			}
+
+			return null;
+		}
+	}
+
+	public class MODMenu
+	{
+		private readonly MODStyleManager styleManager;
+		private readonly MODRadio radioCensorshipLevel;
+		private readonly MODRadio radioLipSync;
+		private readonly MODRadio radioOpenings;
+		private readonly MODRadio radioHideCG;
+		private readonly MODRadio radioStretchBackgrounds;
+		private readonly GameSystem gameSystem;
+		public bool visible;
+		private MODSimpleTimer defaultToolTipTimer;
+
+		string lastToolTip = String.Empty;
+		string defaultTooltip = @"Hover over a button on the left panel for its description.
+
+[Vanilla Hotkeys]
+Enter,Return,RightArrow,PageDown : Advance Text
+LeftArrow,Pageup : See Backlog
+ESC : Open Menu
+Ctrl : Hold Skip Mode
+A : Auto Mode
+S : Toggle Skip Mode
+F : FullScreen
+Space : Hide Text
+L : Swap Language
+P : Swap Sprites
+
+[MOD Hotkeys]
+F1 : ADV-NVL MODE
+F2 : Voice Matching Level
+F3 : Effect Level (Not Used)
+F5 : QuickSave
+F7 : QuickLoad
+F10 : Setting Monitor
+M : Increase Voice Volume
+N : Decrease Voice Volume
+7 : Lip-Sync
+LShift + F9 : Restore Settings
+LShift + M : Voice Volume MAX
+LShift + N : Voice Volume MIN";
+
+		public MODMenu(GameSystem gameSystem, MODStyleManager styleManager)
+		{
+			this.gameSystem = gameSystem;
+			this.styleManager = styleManager;
+			this.visible = false;
+			this.defaultToolTipTimer = new MODSimpleTimer();
+
+			string baseCensorshipDescription = @"
+
+Sets the script censorship level
+- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.
+- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.
+  - 5: Full PS3 script fully voiced (most censored)
+  - 2: Default - most balanced option
+  - 0: Original PC Script with voices where it fits (least uncensored), but uncensored scenes may be missing voices";
+
+
+			this.radioCensorshipLevel = new MODRadio("Voice Matching Level", new GUIContent[] {
+				new GUIContent("0", "Censorship level 0 - Equivalent to PC" + baseCensorshipDescription),
+				new GUIContent("1", "Censorship level 1" + baseCensorshipDescription),
+				new GUIContent("2*", "Censorship level 2 (this is the default/recommneded value)" + baseCensorshipDescription),
+				new GUIContent("3", "Censorship level 3" + baseCensorshipDescription),
+				new GUIContent("4", "Censorship level 4" + baseCensorshipDescription),
+				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
+				}, styleManager);
+
+			this.radioLipSync = new MODRadio("Lip Sync for Console Sprites", new GUIContent[]
+			{
+				new GUIContent("Lip Sync Off", "Disables Lip Sync for Console Sprites"),
+				new GUIContent("Lip Sync On", "Enables Lip Sync for Console Sprites"),
+			}, styleManager);
+
+			this.radioOpenings = new MODRadio("Opening Movies", new GUIContent[]
+			{
+				new GUIContent("Disabled", "Disables all opening videos"),
+				new GUIContent("In-Game Only", "Enables opening videos which play during the story"),
+				new GUIContent("Launch + In-Game", "Opening videos will play just after game launches, and also during the story"),
+			}, styleManager);
+
+			this.radioHideCG = new MODRadio("CG Show/Hide", new GUIContent[]
+			{
+				new GUIContent("Show CGs", "Shows CGs (You probably want this enabled for Console ADV/NVL mode)"),
+				new GUIContent("Hide CGs", "Disables all CGs (mainly for use with the Original/Ryukishi preset)"),
+			}, styleManager);
+
+			this.radioStretchBackgrounds = new MODRadio("Stretch Backgrounds", new GUIContent[]
+			{
+				new GUIContent("Normal Backgrounds", "NOTE: This only starts working on the next background transition!\n" +
+				"Displays backgrounds at their original aspect ratio"),
+				new GUIContent("Stretch Backgrounds", "NOTE: This only starts working on the next background transition!\n" +
+				"Stretches backgrounds to the game's 16:9 aspect ratio (mainly for use with the Original/Ryukishi backgrounds)"),
+			}, styleManager);
+		}
+
+		public void Update()
+		{
+			defaultToolTipTimer.Update();
+		}
+
+		private void OnGUIPresetsFragment()
+		{
+			GUILayout.Label("Load ADV/NVL/Original Presets");
+
+			GUILayout.BeginHorizontal();
+			if (GUILayout.Button(new GUIContent("ADV", "This preset:\n" +
+				"- Makes text show at the bottom of the screen in a textbox\n" +
+				"- Shows the name of the current character on the textbox\n" +
+				"- Uses the console sprites and backgrounds\n" +
+				"- Displays in 16:9 widescreen\n\n")))
+			{
+				MODActions.SetAndSaveADV(MODActions.ModPreset.ADV);
+			}
+			else if (GUILayout.Button(new GUIContent("NVL", "This preset:\n" +
+				"- Makes text show across the whole screen\n" +
+				"- Uses the console sprites and backgrounds\n" +
+				"- Displays in 16:9 widescreen\n\n")))
+			{
+				MODActions.SetAndSaveADV(MODActions.ModPreset.NVL);
+			}
+			else if (GUILayout.Button(new GUIContent("Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
+				"- Displays in 4:3 'standard' aspect\n" +
+				"- CGs are disabled\n" +
+				"- Switches to original sprites and backgrounds\n\n")))
+			{
+				MODActions.SetAndSaveADV(MODActions.ModPreset.OG);
+			}
+			GUILayout.EndHorizontal();
+		}
+
+		private void OnGUIRestoreSettings()
+		{
+			GUILayout.Label($"Restore Settings {(GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <Restart Pending>")}");
+
+			GUILayout.BeginHorizontal();
+			if (GetGlobal("GMOD_SETTING_LOADER") == 3)
+			{
+				if (GUILayout.Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
+					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
+				{
+					SetGlobal("GMOD_SETTING_LOADER", 0);
+				}
+				else if (GUILayout.Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
+					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
+				{
+					SetGlobal("GMOD_SETTING_LOADER", 1);
+				}
+				else if (GUILayout.Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
+					"NOTE: Requires a relaunch to come into effect. After this, uninstall the mod.")))
+				{
+					SetGlobal("GMOD_SETTING_LOADER", 2);
+				}
+			}
+			else
+			{
+				if (GUILayout.Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
+				{
+					SetGlobal("GMOD_SETTING_LOADER", 3);
+				}
+			}
+			GUILayout.EndHorizontal();
+		}
+
+		/// <summary>
+		/// Must be called from an OnGUI()
+		/// </summary>
+		public void OnGUIFragment()
+		{
+			if (this.visible)
+			{
+				float areaWidth = 400;
+				float toolTipWidth = 350;
+				float totalAreaWidth = areaWidth + toolTipWidth;
+				float areaHeight = 500;
+
+				float areaPosX = Screen.width / 2 - totalAreaWidth / 2;
+				float areaPosY = Screen.height / 2 - areaHeight / 2;
+
+				float toolTipPosX = areaPosX + areaWidth;
+
+				float exitButtonWidth = toolTipWidth * .1f;
+				float exitButtonHeight = toolTipWidth * .05f;
+
+				// Radio buttons
+				GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modGUIStyle);
+					this.OnGUIPresetsFragment();
+
+					if(this.radioCensorshipLevel.OnGUIFragment(GetGlobal("GCensor")) is int censorLevel)
+					{
+						SetGlobal("GCensor", censorLevel);
+					};
+
+					if(this.radioLipSync.OnGUIFragment(GetGlobal("GLipSync")) is int lipSyncEnabled)
+					{
+						SetGlobal("GLipSync", lipSyncEnabled);
+					};
+
+					if(this.radioOpenings.OnGUIFragment(GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
+					{
+						SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
+					};
+
+					if(this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
+					{
+						SetGlobal("GHideCG", hideCG);
+					};
+
+					if(this.radioStretchBackgrounds.OnGUIFragment(GetGlobal("GStretchBackgrounds")) is int stretchBackgrounds)
+					{
+						SetGlobal("GStretchBackgrounds", stretchBackgrounds);
+					};
+
+					//TODO: reset settings
+					OnGUIRestoreSettings();
+				GUILayout.EndArea();
+
+				// Descriptions for each button are shown on hover, like a tooltip
+				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modGUIStyle);
+				GUILayout.Space(exitButtonHeight);
+
+				string displayedToolTip;
+				if (GUI.tooltip == String.Empty)
+				{
+					if (defaultToolTipTimer.Finished())
+					{
+						displayedToolTip = defaultTooltip;
+					}
+					else
+					{
+						displayedToolTip = lastToolTip;
+					}
+				}
+				else
+				{
+					lastToolTip = GUI.tooltip;
+					displayedToolTip = GUI.tooltip;
+					defaultToolTipTimer.Start(.2f);
+				}
+				// MUST pass in MinHeight option, otherwise Unity will get confused and assume
+				// label is one line high on first draw, and subsquent changes will truncate
+				// label to one line even if it is multiple lines tall.
+				GUILayout.Label(displayedToolTip, GUILayout.MinHeight(areaHeight));
+				GUILayout.EndArea();
+
+				// Exit button
+				GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth, areaPosY, exitButtonWidth, exitButtonHeight));
+					if(GUILayout.Button("X"))
+					{
+						this.Hide();
+					}
+				GUILayout.EndArea();
+			}
+		}
+
+		public void Show()
+		{
+			this.visible = true;
+			DisableGameInput();
+		}
+
+		public void Hide()
+		{
+			this.visible = false;
+			EnableGameInput();
+		}
+
+		// These functions disable input to the game, while still letting
+		// the mod menu receive inputs.
+		/// <summary>
+		/// Calling this while game input is already disabled should be fine
+		/// as we only do this if there isn't already a DisableInput state on the stack
+		/// </summary>
+		private void DisableGameInput()
+		{
+			if (gameSystem.GameState != GameState.MODDisableInput)
+			{
+				ModChangeState(new MODStateDisableInput());
+				gameSystem.HideUIControls();
+			}
+		}
+
+		/// <summary>
+		/// Calling this while game input is already enabled should be fine
+		/// as we only do this if there is a DisableInput state available to pop
+		/// </summary>
+		private void EnableGameInput()
+		{
+			if (gameSystem.GameState == GameState.MODDisableInput)
+			{
+				gameSystem.PopStateStack();
+				gameSystem.ShowUIControls();
+			}
+		}
+
+		// This is a modified version of GameSystem.OnApplicationQuit()
+		private void ModChangeState(IGameState newState)
+		{
+			if (gameSystem.GameState == GameState.ConfigScreen)
+			{
+				gameSystem.RegisterAction(delegate
+				{
+					gameSystem.LeaveConfigScreen(delegate
+					{
+						gameSystem.PushStateObject(newState);
+					});
+				});
+				gameSystem.ExecuteActions();
+			}
+			else
+			{
+				gameSystem.RegisterAction(delegate
+				{
+					gameSystem.PushStateObject(newState);
+				});
+				gameSystem.ExecuteActions();
+			}
+		}
+
+		private int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
+		private void SetGlobal(string flagName, int flagValue) => BurikoMemory.Instance.SetGlobalFlag(flagName, flagValue);
+	}
+}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -141,6 +141,14 @@ Sets the script censorship level
 			defaultToolTipTimer.Update();
 		}
 
+		public void LateUpdate()
+		{
+			if (Input.GetMouseButtonDown(1))
+			{
+				this.Hide();
+			}
+		}
+
 		private void OnGUIPresetsFragment()
 		{
 			GUILayout.Label("Load ADV/NVL/Original Presets");

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -303,6 +303,7 @@ Sets the script censorship level
 					// Note: GUILayout.Height is adjusted to be slightly smaller, otherwise not all content is visible/scroll bar is slightly cut off.
 					scrollPosition = GUILayout.BeginScrollView(scrollPosition, GUILayout.Width(areaWidth), GUILayout.Height(areaHeight-10));
 
+					HeadingLabel("Basic Options");
 
 					if (this.radioADVNVLOriginal.OnGUIFragment(this.GetModeFromFlags()) is int newMode)
 					{
@@ -339,11 +340,7 @@ Sets the script censorship level
 						SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
 					};
 
-					GUILayout.BeginHorizontal();
-					GUILayout.FlexibleSpace();
-					Label("Advanced Options");
-					GUILayout.FlexibleSpace();
-					GUILayout.EndHorizontal();
+					HeadingLabel("Advanced Options");
 
 					if (this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
 					{
@@ -424,13 +421,16 @@ Sets the script censorship level
 						if (Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
 						if (Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
 						if (Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
-						if (Button(new GUIContent("Full", "Toggle Fullscreen")))
+						if (gameSystem.IsFullscreen)
 						{
-							if (gameSystem.IsFullscreen)
+							if (Button(new GUIContent("Windowed", "Toggle Fullscreen")))
 							{
 								GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
 							}
-							else
+						}
+						else
+						{
+							if (Button(new GUIContent("Fullscreen", "Toggle Fullscreen")))
 							{
 								gameSystem.GoFullscreen();
 							}
@@ -468,11 +468,8 @@ Sets the script censorship level
 
 				// Descriptions for each button are shown on hover, like a tooltip
 				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modMenuAreaStyle);
-				GUILayout.BeginHorizontal();
-				GUILayout.FlexibleSpace();
-				Label("Mod Options Menu");
-				GUILayout.FlexibleSpace();
-				GUILayout.EndHorizontal();
+				HeadingLabel("Mod Options Menu");
+				GUILayout.Space(10);
 
 				GUIStyle toolTipStyle = styleManager.Group.label;
 				string displayedToolTip;
@@ -619,6 +616,11 @@ Sets the script censorship level
 		private void Label(string label)
 		{
 			GUILayout.Label(label, styleManager.Group.label);
+		}
+
+		private void HeadingLabel(string label)
+		{
+			GUILayout.Label(label, styleManager.Group.headingLabel);
 		}
 
 		private int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -1,9 +1,11 @@
 ﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
 using MOD.Scripts.Core.State;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -20,7 +22,11 @@ namespace MOD.Scripts.UI
 		{
 			this.label = label;
 			this.radioContents = radioContents;
-			this.itemsPerRow = itemsPerRow == 0 ? radioContents.Length : itemsPerRow;
+			this.itemsPerRow = radioContents.Length == 0 ? 1 : radioContents.Length;
+			if(itemsPerRow != 0)
+			{
+				this.itemsPerRow = itemsPerRow;
+			}
 			this.styleManager = styleManager;
 		}
 
@@ -51,6 +57,8 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioOpenings;
 		private readonly MODRadio radioHideCG;
 		private readonly MODRadio radioStretchBackgrounds;
+		private readonly MODRadio radioBackgrounds;
+		private readonly MODRadio radioArtSet;
 		private readonly GameSystem gameSystem;
 		public bool visible;
 		private MODSimpleTimer defaultToolTipTimer;
@@ -133,6 +141,18 @@ Sets the script censorship level
 			{
 				new GUIContent("Normal Backgrounds", "Displays backgrounds at their original aspect ratio"),
 				new GUIContent("Stretch Backgrounds", "Stretches backgrounds to the game's 16:9 aspect ratio (mainly for use with the Original/Ryukishi backgrounds)"),
+			}, styleManager);
+
+			this.radioArtSet = new MODRadio("Choose Art Set", new GUIContent[] {
+				new GUIContent("Console", "Use the Console sprites and backgrounds"),
+				new GUIContent("Remake", "Use Mangagmer's remake sprites with Console backgrounds"),
+				new GUIContent("Original/Remake", "USe Original/Ryukishi sprites and backgrounds"),
+			}, styleManager);
+
+			this.radioBackgrounds = new MODRadio("Override Backgrounds", new GUIContent[]{
+				new GUIContent("Use Artset", "Use the default sprites on the given artset"),
+				new GUIContent("Force Console", "Force Console backgrounds, regardless of the artset"),
+				new GUIContent("Force Original", "Force Original/Ryukishi backgrounds, regardless of the artset"),
 			}, styleManager);
 		}
 
@@ -222,7 +242,7 @@ Sets the script censorship level
 				float areaWidth = 400;
 				float toolTipWidth = 350;
 				float totalAreaWidth = areaWidth + toolTipWidth;
-				float areaHeight = 500;
+				float areaHeight = 550;
 
 				float areaPosX = Screen.width / 2 - totalAreaWidth / 2;
 				float areaPosY = Screen.height / 2 - areaHeight / 2;
@@ -262,8 +282,20 @@ Sets the script censorship level
 						GameSystem.Instance.SceneController.ReloadAllImages();
 					};
 
-					//TODO: reset settings
-					OnGUIRestoreSettings();
+					if (this.radioArtSet.OnGUIFragment(Core.MODSystem.instance.modTextureController.GetArtStyle()) is int artStyle)
+					{
+						Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle);
+					}
+
+					if (this.radioBackgrounds.OnGUIFragment(GetGlobal("GBackgroundSet")) is int backgroundSet)
+					{
+						SetGlobal("GBackgroundSet", backgroundSet);
+						GameSystem.Instance.SceneController.ReloadAllImages();
+					}
+
+				//TODO: reset settings
+				GUILayout.Space(5);
+				OnGUIRestoreSettings();
 				GUILayout.EndArea();
 
 				// Descriptions for each button are shown on hover, like a tooltip

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -69,6 +69,8 @@ namespace MOD.Scripts.UI
 		private MODSimpleTimer defaultToolTipTimer;
 		private MODSimpleTimer startupWatchdogTimer;
 		private bool startupFailed;
+		private string screenWidthString;
+		private string screenHeightString;
 
 		string lastToolTip = String.Empty;
 		string defaultTooltip = @"Hover over a button on the left panel for its description.
@@ -80,7 +82,7 @@ ESC : Open Menu
 Ctrl : Hold Skip Mode
 A : Auto Mode
 S : Toggle Skip Mode
-F : FullScreen
+F, Alt-Enter : FullScreen
 Space : Hide Text
 L : Swap Language
 P : Swap Sprites
@@ -123,6 +125,8 @@ If they do not not work, click the button below to open the support page";
 			this.defaultToolTipTimer = new MODSimpleTimer();
 			this.startupWatchdogTimer = new MODSimpleTimer();
 			this.startupFailed = false;
+			this.screenWidthString = String.Empty;
+			this.screenHeightString = String.Empty;
 
 			this.radioADVNVLOriginal = new MODRadio("Set ADV/NVL/Original Mode", new GUIContent[]
 			{
@@ -292,12 +296,6 @@ Sets the script censorship level
 				{
 					GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modGUIStyle);
 
-					GUILayout.BeginHorizontal();
-					GUILayout.FlexibleSpace();
-					GUILayout.Label("Mod Options Menu");
-					GUILayout.FlexibleSpace();
-					GUILayout.EndHorizontal();
-
 					if (this.radioADVNVLOriginal.OnGUIFragment(this.GetModeFromFlags()) is int newMode)
 					{
 						if (newMode == 0)
@@ -333,7 +331,6 @@ Sets the script censorship level
 						SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
 					};
 
-					GUILayout.Space(10);
 					GUILayout.BeginHorizontal();
 					GUILayout.FlexibleSpace();
 					GUILayout.Label("Advanced Options");
@@ -412,13 +409,57 @@ Sets the script censorship level
 						Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
 					}
 
+					{
+						GUILayout.BeginHorizontal();
+						GUILayout.Label("Custom Resolution");
+						screenWidthString = GUILayout.TextField(screenWidthString);
+						screenHeightString = GUILayout.TextField(screenHeightString);
+						if(GUILayout.Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.")))
+						{
+							if(int.TryParse(screenWidthString, out int new_width))
+							{
+								if(int.TryParse(screenHeightString, out int new_height))
+								{
+									if(new_width < 800)
+									{
+										MODToaster.Show("Width too small - must be at least 800 pixels");
+										new_width = 800;
+									}
+									else if(new_width > 15360)
+									{
+										MODToaster.Show("Width too big - must be at least 15360 pixels");
+										new_width = 15360;
+									}
+									if (new_height < 650)
+									{
+										MODToaster.Show("Height too small - must be at least 650 pixels");
+										new_height = 650;
+									}
+									else if(new_height > 8640)
+									{
+										MODToaster.Show("Height too large - must be at least 8640 pixels");
+										new_height = 8640;
+									}
+									screenWidthString = $"{new_width}";
+									screenHeightString = $"{new_height}";
+									Screen.SetResolution(new_width, new_height, Screen.fullScreen);
+								}
+							}
+						}
+						GUILayout.EndHorizontal();
+					}
+
 
 					GUILayout.EndArea();
 				}
 
 				// Descriptions for each button are shown on hover, like a tooltip
 				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modGUIStyle);
-				GUILayout.Space(Mathf.Round(exitButtonHeight)); //Round as non-integer space may cause blurred text
+				GUILayout.BeginHorizontal();
+				GUILayout.FlexibleSpace();
+				GUILayout.Label("Mod Options Menu");
+				GUILayout.FlexibleSpace();
+				GUILayout.EndHorizontal();
 
 				GUIStyle toolTipStyle = GUI.skin.label;
 				string displayedToolTip;
@@ -476,6 +517,9 @@ Sets the script censorship level
 				}
 			}
 			this.radioArtSet.SetContents(descriptions);
+
+			this.screenWidthString = $"{Screen.width}";
+			this.screenHeightString = $"{Screen.height}";
 
 			this.visible = true;
 			DisableGameInput();

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -258,8 +258,10 @@ Sets the script censorship level
 				float exitButtonHeight = toolTipWidth * .05f;
 
 				// Radio buttons
-				GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modGUIStyle);
-					if(this.radioADVNVLOriginal.OnGUIFragment(this.GetModeFromFlags()) is int newMode)
+				{
+					GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modGUIStyle);
+
+					if (this.radioADVNVLOriginal.OnGUIFragment(this.GetModeFromFlags()) is int newMode)
 					{
 						if (newMode == 0)
 						{
@@ -283,17 +285,17 @@ Sets the script censorship level
 						}
 					}
 
-					if(this.radioCensorshipLevel.OnGUIFragment(GetGlobal("GCensor")) is int censorLevel)
+					if (this.radioCensorshipLevel.OnGUIFragment(GetGlobal("GCensor")) is int censorLevel)
 					{
 						SetGlobal("GCensor", censorLevel);
 					};
 
-					if(this.radioLipSync.OnGUIFragment(GetGlobal("GLipSync")) is int lipSyncEnabled)
+					if (this.radioLipSync.OnGUIFragment(GetGlobal("GLipSync")) is int lipSyncEnabled)
 					{
 						SetGlobal("GLipSync", lipSyncEnabled);
 					};
 
-					if(this.radioOpenings.OnGUIFragment(GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
+					if (this.radioOpenings.OnGUIFragment(GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
 					{
 						SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
 					};
@@ -304,7 +306,7 @@ Sets the script censorship level
 					GUILayout.FlexibleSpace();
 					GUILayout.EndHorizontal();
 
-					if(this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
+					if (this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
 					{
 						SetGlobal("GHideCG", hideCG);
 					};
@@ -320,10 +322,12 @@ Sets the script censorship level
 						GameSystem.Instance.SceneController.ReloadAllImages();
 					}
 
-				//TODO: reset settings
-				GUILayout.Space(5);
-				OnGUIRestoreSettings();
-				GUILayout.EndArea();
+					//TODO: reset settings
+					GUILayout.Space(5);
+					OnGUIRestoreSettings();
+
+					GUILayout.EndArea();
+				}
 
 				// Descriptions for each button are shown on hover, like a tooltip
 				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modGUIStyle);

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -247,7 +247,7 @@ Sets the script censorship level
 				float areaWidth = 400;
 				float toolTipWidth = 350;
 				float totalAreaWidth = areaWidth + toolTipWidth;
-				float areaHeight = 550;
+				float areaHeight = 600;
 
 				float areaPosX = Screen.width / 2 - totalAreaWidth / 2;
 				float areaPosY = Screen.height / 2 - areaHeight / 2;
@@ -347,6 +347,32 @@ Sets the script censorship level
 
 					GUILayout.Space(10);
 					OnGUIRestoreSettings();
+
+					GUILayout.Label("Save and Log Files");
+					{
+						GUILayout.BeginHorizontal();
+						if (GUILayout.Button(new GUIContent("Show output_log.txt / Player.log",
+							"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
+							"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
+							"- This file records errors that occur during gameplay, and during game startup\n" +
+							"- This file helps when the game fails start, for example\n" +
+							"  - a corrupted save file\n" +
+							"  - the wrong UI (sharedassets0.assets) file\n" +
+							"- Note that each time the game starts up, the current log file is replaced")))
+						{
+							MODActions.ShowLogFolder();
+						}
+
+						if (GUILayout.Button(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
+							"- NOTE: Steam sync will restore your saves if you manually delete them! Therefore, remember to disable steam sync, otherwise your saves will magically reappear!\n" +
+							"- The 'global.dat' file stores your global unlock process and mod flags\n" +
+							"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
+							"- It's recommended to take a backup of all your saves before you modify them")))
+						{
+							MODActions.ShowSaveFolder();
+						}
+						GUILayout.EndHorizontal();
+					}
 
 					GUILayout.EndArea();
 				}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -131,10 +131,8 @@ Sets the script censorship level
 
 			this.radioStretchBackgrounds = new MODRadio("Stretch Backgrounds", new GUIContent[]
 			{
-				new GUIContent("Normal Backgrounds", "NOTE: This only starts working on the next background transition!\n" +
-				"Displays backgrounds at their original aspect ratio"),
-				new GUIContent("Stretch Backgrounds", "NOTE: This only starts working on the next background transition!\n" +
-				"Stretches backgrounds to the game's 16:9 aspect ratio (mainly for use with the Original/Ryukishi backgrounds)"),
+				new GUIContent("Normal Backgrounds", "Displays backgrounds at their original aspect ratio"),
+				new GUIContent("Stretch Backgrounds", "Stretches backgrounds to the game's 16:9 aspect ratio (mainly for use with the Original/Ryukishi backgrounds)"),
 			}, styleManager);
 		}
 
@@ -253,6 +251,7 @@ Sets the script censorship level
 					if(this.radioStretchBackgrounds.OnGUIFragment(GetGlobal("GStretchBackgrounds")) is int stretchBackgrounds)
 					{
 						SetGlobal("GStretchBackgrounds", stretchBackgrounds);
+						GameSystem.Instance.SceneController.ReloadAllImages();
 					};
 
 					//TODO: reset settings

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -168,8 +168,12 @@ Sets the script censorship level
 			this.radioOpenings = new MODRadio("Opening Movies", new GUIContent[]
 			{
 				new GUIContent("Disabled", "Disables all opening videos"),
-				new GUIContent("In-Game Only", "Enables opening videos which play during the story"),
-				new GUIContent("Launch + In-Game", "Opening videos will play just after game launches, and also during the story"),
+				new GUIContent("Enabled", "Enables opening videos\n\n" +
+				"NOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\n" +
+				"We have setup openings this way to avoid spoilers."),
+				new GUIContent("Launch + In-Game", "WARNING: There is usually no need to set this manually.\n\n" +
+				"If openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\n" +
+				"That is, after the opening is played the first time, from then on openings will play every time the game launches"),
 			}, styleManager);
 
 			this.radioHideCG = new MODRadio("Show/Hide CGs", new GUIContent[]

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -47,6 +47,11 @@ namespace MOD.Scripts.UI
 
 			return null;
 		}
+
+		public void SetContents(GUIContent[] content)
+		{
+			this.radioContents = content;
+		}
 	}
 
 	public class MODMenu
@@ -91,6 +96,13 @@ N : Decrease Voice Volume
 LShift + F9 : Restore Settings
 LShift + M : Voice Volume MAX
 LShift + N : Voice Volume MIN";
+
+		GUIContent[] defaultArtsetDescriptions = new GUIContent[] {
+			new GUIContent("Console", "Use the Console sprites and backgrounds"),
+			new GUIContent("Remake", "Use Mangagmer's remake sprites with Console backgrounds"),
+			new GUIContent("Original/Remake", "Use Original/Ryukishi sprites and backgrounds\n" +
+			"Warning: Most users should just enable Original/Ryukishi mode at the top of this menu!"),
+		};
 
 		public MODMenu(GameSystem gameSystem, MODStyleManager styleManager)
 		{
@@ -153,12 +165,7 @@ Sets the script censorship level
 				new GUIContent("Hide CGs", "Disables all CGs (mainly for use with the Original/Ryukishi preset)"),
 			}, styleManager);
 
-			this.radioArtSet = new MODRadio("Choose Art Set", new GUIContent[] {
-				new GUIContent("Console", "Use the Console sprites and backgrounds"),
-				new GUIContent("Remake", "Use Mangagmer's remake sprites with Console backgrounds"),
-				new GUIContent("Original/Remake", "Use Original/Ryukishi sprites and backgrounds\n" +
-				"Warning: Most users should just enable Original/Ryukishi mode at the top of this menu!"),
-			}, styleManager);
+			this.radioArtSet = new MODRadio("Choose Art Set", defaultArtsetDescriptions, styleManager, itemsPerRow: 3);
 
 			this.radioBackgrounds = new MODRadio("Override Art Set Backgrounds", new GUIContent[]{
 				new GUIContent("Default BGs", "Use the default backgrounds for the current artset"),
@@ -384,6 +391,18 @@ Sets the script censorship level
 
 		public void Show()
 		{
+			// Update the artset radio buttons/descriptions, as these are set by ModAddArtset() calls in init.txt at runtime
+			// Technically only need to do this once after init.txt has been called, but it's easier to just do it each time menu is opened
+			GUIContent[] descriptions = Core.MODSystem.instance.modTextureController.GetArtStyleDescriptions();
+			for(int i = 0; i < descriptions.Count(); i++)
+			{
+				if(i < this.defaultArtsetDescriptions.Count())
+				{
+					descriptions[i] = this.defaultArtsetDescriptions[i];
+				}
+			}
+			this.radioArtSet.SetContents(descriptions);
+
 			this.visible = true;
 			DisableGameInput();
 		}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -74,6 +74,7 @@ namespace MOD.Scripts.UI
 		private string screenHeightString;
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
+		private static Vector2 emergencyMenuScrollPosition;
 
 		string lastToolTip = String.Empty;
 		string defaultTooltip = @"Hover over a button on the left panel for its description.
@@ -382,37 +383,7 @@ Sets the script censorship level
 					OnGUIRestoreSettings();
 
 					Label("Save and Log Files");
-					{
-						GUILayout.BeginHorizontal();
-						if (Button(new GUIContent("Show output_log.txt / Player.log",
-							"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
-							"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
-							"- This file records errors that occur during gameplay, and during game startup\n" +
-							"- This file helps when the game fails start, for example\n" +
-							"  - a corrupted save file\n" +
-							"  - the wrong UI (sharedassets0.assets) file\n" +
-							"- Note that each time the game starts up, the current log file is replaced")))
-						{
-							MODActions.ShowLogFolder();
-						}
-
-						if (Button(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
-							"- NOTE: Steam sync will restore your saves if you manually delete them! Therefore, remember to disable steam sync, otherwise your saves will magically reappear!\n" +
-							"- The 'global.dat' file stores your global unlock process and mod flags\n" +
-							"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
-							"- It's recommended to take a backup of all your saves before you modify them")))
-						{
-							MODActions.ShowSaveFolder();
-						}
-
-						GUILayout.EndHorizontal();
-					}
-
-					if (Button(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
-						"There are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly")))
-					{
-						Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
-					}
+					ShowSupportButtons(content => Button(content));
 
 					Label("Resolution Settings");
 					{
@@ -644,5 +615,61 @@ Sets the script censorship level
 			PlayerPrefs.SetInt("width", width);
 			PlayerPrefs.SetInt("height", height);
 		}
+
+		/// <summary>
+		/// This function draws an emergency mod menu in case of a critcal game error
+		/// (for example, corrupted game save)
+		///
+		/// Please do null checks/try catch for gamesystem etc. if used in this function as it may be called
+		/// during an error condition where gamesystem and other core system parts are not initialized yet
+		/// </summary>
+		/// <param name="errorMessage"></param>
+		public static void EmergencyModMenu(string shortErrorMessage, string longErrorMessage)
+		{
+			emergencyMenuScrollPosition = GUILayout.BeginScrollView(emergencyMenuScrollPosition);
+			GUILayout.Label(shortErrorMessage);
+			GUILayout.Label(longErrorMessage);
+
+			ShowSupportButtons(content => GUILayout.Button(content));
+
+			GUILayout.Label(GUI.tooltip == "" ? "Please hover over a button for more information" : GUI.tooltip, GUI.skin.textArea, GUILayout.MinHeight(210));
+
+			GUILayout.EndScrollView();
+		}
+
+		private static void ShowSupportButtons(Func<GUIContent, bool> buttonRenderer)
+		{
+			{
+				GUILayout.BeginHorizontal();
+				if (buttonRenderer(new GUIContent("Show output_log.txt / Player.log",
+					"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
+					"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
+					"- This file records errors that occur during gameplay, and during game startup\n" +
+					"- This file helps when the game fails start, for example\n" +
+					"  - a corrupted save file\n" +
+					"  - the wrong UI (sharedassets0.assets) file\n" +
+					"- Note that each time the game starts up, the current log file is replaced")))
+				{
+					MODActions.ShowLogFolder();
+				}
+
+				if (buttonRenderer(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
+					"- WARNING: Steam sync will restore your saves if you manually delete them! Therefore, remember to disable steam sync, otherwise your saves will magically reappear!\n" +
+					"- The 'global.dat' file stores your global unlock process and mod flags\n" +
+					"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
+					"- It's recommended to take a backup of all your saves before you modify them")))
+				{
+					MODActions.ShowSaveFolder();
+				}
+				GUILayout.EndHorizontal();
+			}
+
+			if (buttonRenderer(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
+				"There are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly")))
+			{
+				Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
+			}
+		}
+
 	}
 }

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -13,6 +13,7 @@ namespace MOD.Scripts.UI
 {
 	class MODRadio
 	{
+		public static bool anyRadioPressed;
 		string label;
 		private GUIContent[] radioContents;
 		MODStyleManager styleManager;
@@ -42,6 +43,7 @@ namespace MOD.Scripts.UI
 			int i = GUILayout.SelectionGrid(displayedRadio, radioContents, itemsPerRow, styleManager.modSelectorStyle);
 			if (i != displayedRadio)
 			{
+				MODRadio.anyRadioPressed = true;
 				return i;
 			}
 
@@ -71,6 +73,7 @@ namespace MOD.Scripts.UI
 		private bool startupFailed;
 		private string screenWidthString;
 		private string screenHeightString;
+		private bool anyButtonPressed;
 
 		string lastToolTip = String.Empty;
 		string defaultTooltip = @"Hover over a button on the left panel for its description.
@@ -236,17 +239,17 @@ Sets the script censorship level
 			GUILayout.BeginHorizontal();
 			if (GetGlobal("GMOD_SETTING_LOADER") == 3)
 			{
-				if (GUILayout.Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
+				if (Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
 					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 0);
 				}
-				else if (GUILayout.Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
+				else if (Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
 					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 1);
 				}
-				else if (GUILayout.Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
+				else if (Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
 					"NOTE: Requires a relaunch to come into effect. After this, uninstall the mod.")))
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 2);
@@ -254,7 +257,7 @@ Sets the script censorship level
 			}
 			else
 			{
-				if (GUILayout.Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
+				if (Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 3);
 				}
@@ -379,7 +382,7 @@ Sets the script censorship level
 					GUILayout.Label("Save and Log Files");
 					{
 						GUILayout.BeginHorizontal();
-						if (GUILayout.Button(new GUIContent("Show output_log.txt / Player.log",
+						if (Button(new GUIContent("Show output_log.txt / Player.log",
 							"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
 							"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
 							"- This file records errors that occur during gameplay, and during game startup\n" +
@@ -391,7 +394,7 @@ Sets the script censorship level
 							MODActions.ShowLogFolder();
 						}
 
-						if (GUILayout.Button(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
+						if (Button(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
 							"- NOTE: Steam sync will restore your saves if you manually delete them! Therefore, remember to disable steam sync, otherwise your saves will magically reappear!\n" +
 							"- The 'global.dat' file stores your global unlock process and mod flags\n" +
 							"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
@@ -403,7 +406,7 @@ Sets the script censorship level
 						GUILayout.EndHorizontal();
 					}
 
-					if (GUILayout.Button(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
+					if (Button(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
 						"There are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly")))
 					{
 						Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
@@ -414,7 +417,7 @@ Sets the script censorship level
 						GUILayout.Label("Custom Resolution");
 						screenWidthString = GUILayout.TextField(screenWidthString);
 						screenHeightString = GUILayout.TextField(screenHeightString);
-						if(GUILayout.Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.")))
+						if(Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.")))
 						{
 							if(int.TryParse(screenWidthString, out int new_width))
 							{
@@ -496,11 +499,18 @@ Sets the script censorship level
 
 				// Exit button
 				GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth, areaPosY, exitButtonWidth, exitButtonHeight));
-					if(GUILayout.Button("X"))
+					if(Button(new GUIContent("X", "Close the Mod menu")))
 					{
 						this.Hide();
 					}
 				GUILayout.EndArea();
+
+				if(MODRadio.anyRadioPressed || anyButtonPressed)
+				{
+					GameSystem.Instance.AudioController.PlaySystemSound(MODSound.GetSoundPathFromEnum(GUISound.Click));
+					MODRadio.anyRadioPressed = false;
+					anyButtonPressed = false;
+				}
 			}
 		}
 
@@ -580,6 +590,19 @@ Sets the script censorship level
 					gameSystem.PushStateObject(newState);
 				});
 				gameSystem.ExecuteActions();
+			}
+		}
+
+		private bool Button(GUIContent guiContent)
+		{
+			if(GUILayout.Button(guiContent))
+			{
+				anyButtonPressed = true;
+				return true;
+			}
+			else
+			{
+				return false;
 			}
 		}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -332,19 +332,19 @@ Sets the script censorship level
 					{
 						if (newMode == 0)
 						{
-							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV);
+							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
 						}
 						else if (newMode == 1)
 						{
-							MODActions.SetAndSaveADV(MODActions.ModPreset.NVL);
+							MODActions.SetAndSaveADV(MODActions.ModPreset.NVL, showInfoToast: false);
 						}
 						else if (newMode == 2)
 						{
-							MODActions.SetAndSaveADV(MODActions.ModPreset.OG);
+							MODActions.SetAndSaveADV(MODActions.ModPreset.OG, showInfoToast: false);
 						}
 						else
 						{
-							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV);
+							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
 						}
 					}
 
@@ -373,7 +373,7 @@ Sets the script censorship level
 					if (this.radioArtSet.OnGUIFragment(Core.MODSystem.instance.modTextureController.GetArtStyle()) is int artStyle)
 					{
 						SetGlobal("GStretchBackgrounds", 0);
-						Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle);
+						Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle, showInfoToast: false);
 					}
 
 					{

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -122,7 +122,7 @@ You can try the following yourself to fix the issue.
 		GUIContent[] defaultArtsetDescriptions = new GUIContent[] {
 			new GUIContent("Console", "Use the Console sprites and backgrounds"),
 			new GUIContent("Remake", "Use Mangagamer's remake sprites with Console backgrounds"),
-			new GUIContent("Original/Remake", "Use Original/Ryukishi sprites and backgrounds\n" +
+			new GUIContent("Original", "Use Original/Ryukishi sprites and backgrounds (if available - OG backgrounds not available for Console Arcs)\n\n" +
 			"Warning: Most users should use the Original/Ryukishi preset at the top of this menu!"),
 		};
 
@@ -332,7 +332,8 @@ Sets the script censorship level
 						"- Makes text show at the bottom of the screen in a textbox\n" +
 						"- Shows the name of the current character on the textbox\n" +
 						"- Uses the console sprites and backgrounds\n" +
-						"- Displays in 16:9 widescreen\n\n"), selected: advNVLRyukishiMode == 0))
+						"- Displays in 16:9 widescreen\n\n" +
+						"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 0))
 						{
 							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
 						}
@@ -340,15 +341,17 @@ Sets the script censorship level
 						if (this.Button(new GUIContent(advNVLRyukishiMode == 1 && presetModified ? "NVL (custom)" : "NVL", "This preset:\n" +
 							"- Makes text show across the whole screen\n" +
 							"- Uses the console sprites and backgrounds\n" +
-							"- Displays in 16:9 widescreen\n\n"), selected: advNVLRyukishiMode == 1))
+							"- Displays in 16:9 widescreen\n\n" +
+							"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 1))
 						{
 							MODActions.SetAndSaveADV(MODActions.ModPreset.NVL, showInfoToast: false);
 						}
 
 						if (this.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
-							"- Displays in 4:3 'standard' aspect\n" +
-							"- CGs are disabled\n" +
-							"- Switches to original sprites and backgrounds\n\n"), selected: advNVLRyukishiMode == 2))
+							"- Displays backgrounds in 4:3 'standard' aspect\n" +
+							"- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n" +
+							"- Switches to original sprites and backgrounds\n\n" +
+							"Note that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 2))
 						{
 							MODActions.SetAndSaveADV(MODActions.ModPreset.OG, showInfoToast: false);
 						}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -90,7 +90,6 @@ S : Toggle Skip Mode
 F, Alt-Enter : FullScreen
 Space : Hide Text
 L : Swap Language
-P : Swap Sprites
 
 [MOD Hotkeys]
 F1 : ADV-NVL MODE
@@ -101,8 +100,8 @@ F7 : QuickLoad
 F10 : Mod Menu
 M : Increase Voice Volume
 N : Decrease Voice Volume
+P : Cycle through art styles
 7 : Lip-Sync
-LShift + F9 : Restore Settings
 LShift + M : Voice Volume MAX
 LShift + N : Voice Volume MIN";
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -110,10 +110,15 @@ LShift + N : Voice Volume MIN";
 
 Please send the developers your log file (output_log.txt or Player.log).
 
-If the log indicates you have corrupt save files, you may wish to delete the offending save file (or all of them).
+You can try the following yourself to fix the issue.
 
-Use the buttons under 'Save and Log files' on the bottom left to show your save and log files.
-If they do not not work, click the button below to open the support page";
+  1. Use the buttons under 'Troubleshooting' on the bottom left to show your save files, log files, and compiled scripts.
+
+  2. If the log indicates you have corrupt save files, you may wish to delete the offending save file (or all of them).
+
+  3. You can try to clear your compiled script files, then restart the game.
+
+  4. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.";
 
 		GUIContent[] defaultArtsetDescriptions = new GUIContent[] {
 			new GUIContent("Console", "Use the Console sprites and backgrounds"),

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -75,6 +75,7 @@ namespace MOD.Scripts.UI
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
 		private static Vector2 emergencyMenuScrollPosition;
+		private bool hasOGBackgrounds;
 
 		string lastToolTip = String.Empty;
 		string defaultTooltip = @"Hover over a button on the left panel for its description.
@@ -136,6 +137,7 @@ You can try the following yourself to fix the issue.
 			this.startupWatchdogTimer = new MODSimpleTimer();
 			this.startupFailed = false;
 			this.screenHeightString = String.Empty;
+			this.hasOGBackgrounds = MODActions.HasOGBackgrounds();
 
 			string baseCensorshipDescription = @"
 
@@ -347,7 +349,8 @@ Sets the script censorship level
 							MODActions.SetAndSaveADV(MODActions.ModPreset.NVL, showInfoToast: false);
 						}
 
-						if (this.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
+						if (this.hasOGBackgrounds &&
+							this.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
 							"- Displays backgrounds in 4:3 'standard' aspect\n" +
 							"- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n" +
 							"- Switches to original sprites and backgrounds\n\n" +
@@ -387,6 +390,7 @@ Sets the script censorship level
 						Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle, showInfoToast: false);
 					}
 
+					if(this.hasOGBackgrounds)
 					{
 						int currentBackground = GetGlobal("GBackgroundSet");
 						if(currentBackground == 2)

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -427,9 +427,6 @@ Sets the script censorship level
 					GUILayout.Space(10);
 					OnGUIRestoreSettings();
 
-					Label("Save and Log Files");
-					ShowSupportButtons(content => Button(content));
-
 					Label("Resolution Settings");
 					{
 						GUILayout.BeginHorizontal();
@@ -477,6 +474,10 @@ Sets the script censorship level
 						}
 						GUILayout.EndHorizontal();
 					}
+
+					HeadingLabel("Troubleshooting");
+					Label("Save Files and Log Files");
+					ShowSupportButtons(content => Button(content));
 
 					GUILayout.EndScrollView();
 					GUILayout.EndArea();
@@ -673,6 +674,15 @@ Sets the script censorship level
 				{
 					MODActions.ShowSaveFolder();
 				}
+
+				if (buttonRenderer(new GUIContent("Show Compiled Scripts", "Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\n" +
+					"You can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\n" +
+					"Please be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.")))
+				{
+					Application.OpenURL(System.IO.Path.Combine(Application.streamingAssetsPath, "CompiledUpdateScripts"));
+				}
+
+
 				GUILayout.EndHorizontal();
 			}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -151,7 +151,7 @@ Sets the script censorship level
 			this.radioCensorshipLevel = new MODRadio("Voice Matching Level", new GUIContent[] {
 				new GUIContent("0", "Censorship level 0 - Equivalent to PC" + baseCensorshipDescription),
 				new GUIContent("1", "Censorship level 1" + baseCensorshipDescription),
-				new GUIContent("2*", "Censorship level 2 (this is the default/recommneded value)" + baseCensorshipDescription),
+				new GUIContent("2*", "Censorship level 2 (this is the default/recommended value)" + baseCensorshipDescription),
 				new GUIContent("3", "Censorship level 3" + baseCensorshipDescription),
 				new GUIContent("4", "Censorship level 4" + baseCensorshipDescription),
 				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
@@ -508,7 +508,7 @@ Sets the script censorship level
 					defaultToolTipTimer.Start(.2f);
 				}
 				// MUST pass in MinHeight option, otherwise Unity will get confused and assume
-				// label is one line high on first draw, and subsquent changes will truncate
+				// label is one line high on first draw, and subsequent changes will truncate
 				// label to one line even if it is multiple lines tall.
 				GUILayout.Label(displayedToolTip, toolTipStyle, GUILayout.MinHeight(areaHeight));
 				GUILayout.EndArea();
@@ -622,7 +622,7 @@ Sets the script censorship level
 		}
 
 		/// <summary>
-		/// This function draws an emergency mod menu in case of a critcal game error
+		/// This function draws an emergency mod menu in case of a critical game error
 		/// (for example, corrupted game save)
 		///
 		/// Please do null checks/try catch for gamesystem etc. if used in this function as it may be called

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -59,7 +59,6 @@ namespace MOD.Scripts.UI
 	public class MODMenu
 	{
 		private readonly MODStyleManager styleManager;
-		private readonly MODRadio radioADVNVLOriginal;
 		private readonly MODRadio radioCensorshipLevel;
 		private readonly MODRadio radioLipSync;
 		private readonly MODRadio radioOpenings;
@@ -124,7 +123,7 @@ You can try the following yourself to fix the issue.
 			new GUIContent("Console", "Use the Console sprites and backgrounds"),
 			new GUIContent("Remake", "Use Mangagamer's remake sprites with Console backgrounds"),
 			new GUIContent("Original/Remake", "Use Original/Ryukishi sprites and backgrounds\n" +
-			"Warning: Most users should just enable Original/Ryukishi mode at the top of this menu!"),
+			"Warning: Most users should use the Original/Ryukishi preset at the top of this menu!"),
 		};
 
 		public MODMenu(GameSystem gameSystem, MODStyleManager styleManager)
@@ -137,23 +136,6 @@ You can try the following yourself to fix the issue.
 			this.startupWatchdogTimer = new MODSimpleTimer();
 			this.startupFailed = false;
 			this.screenHeightString = String.Empty;
-
-			this.radioADVNVLOriginal = new MODRadio("Set ADV/NVL/Original Mode", new GUIContent[]
-			{
-				new GUIContent("ADV", "This preset:\n" +
-				"- Makes text show at the bottom of the screen in a textbox\n" +
-				"- Shows the name of the current character on the textbox\n" +
-				"- Uses the console sprites and backgrounds\n" +
-				"- Displays in 16:9 widescreen\n\n"),
-				new GUIContent("NVL", "This preset:\n" +
-				"- Makes text show across the whole screen\n" +
-				"- Uses the console sprites and backgrounds\n" +
-				"- Displays in 16:9 widescreen\n\n"),
-				new GUIContent("Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
-				"- Displays in 4:3 'standard' aspect\n" +
-				"- CGs are disabled\n" +
-				"- Switches to original sprites and backgrounds\n\n")
-			}, styleManager);
 
 			string baseCensorshipDescription = @"
 
@@ -221,22 +203,6 @@ Sets the script censorship level
 			if (Input.GetMouseButtonDown(1))
 			{
 				this.Hide();
-			}
-		}
-
-		private int GetModeFromFlags()
-		{
-			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
-			{
-				return 2;
-			}
-			else if (BurikoMemory.Instance.GetGlobalFlag("GADVMode").IntValue() == 1)
-			{
-				return 0;
-			}
-			else
-			{
-				return 1;
 			}
 		}
 
@@ -356,24 +322,38 @@ Sets the script censorship level
 
 					HeadingLabel("Basic Options");
 
-					if (this.radioADVNVLOriginal.OnGUIFragment(this.GetModeFromFlags()) is int newMode)
+					Label("Graphics Presets");
 					{
-						if (newMode == 0)
+						GUILayout.BeginHorizontal();
+
+						int advNVLRyukishiMode = MODActions.GetADVNVLRyukishiModeFromFlags(out bool presetModified);
+
+						if (this.Button(new GUIContent(advNVLRyukishiMode == 0 && presetModified ? "ADV (custom)" : "ADV", "This preset:\n" +
+						"- Makes text show at the bottom of the screen in a textbox\n" +
+						"- Shows the name of the current character on the textbox\n" +
+						"- Uses the console sprites and backgrounds\n" +
+						"- Displays in 16:9 widescreen\n\n"), selected: advNVLRyukishiMode == 0))
 						{
 							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
 						}
-						else if (newMode == 1)
+
+						if (this.Button(new GUIContent(advNVLRyukishiMode == 1 && presetModified ? "NVL (custom)" : "NVL", "This preset:\n" +
+							"- Makes text show across the whole screen\n" +
+							"- Uses the console sprites and backgrounds\n" +
+							"- Displays in 16:9 widescreen\n\n"), selected: advNVLRyukishiMode == 1))
 						{
 							MODActions.SetAndSaveADV(MODActions.ModPreset.NVL, showInfoToast: false);
 						}
-						else if (newMode == 2)
+
+						if (this.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
+							"- Displays in 4:3 'standard' aspect\n" +
+							"- CGs are disabled\n" +
+							"- Switches to original sprites and backgrounds\n\n"), selected: advNVLRyukishiMode == 2))
 						{
 							MODActions.SetAndSaveADV(MODActions.ModPreset.OG, showInfoToast: false);
 						}
-						else
-						{
-							MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
-						}
+
+						GUILayout.EndHorizontal();
 					}
 
 					if (this.radioCensorshipLevel.OnGUIFragment(GetGlobal("GCensor")) is int censorLevel)
@@ -589,9 +569,9 @@ Sets the script censorship level
 			}
 		}
 
-		private bool Button(GUIContent guiContent)
+		private bool Button(GUIContent guiContent, bool selected=false)
 		{
-			if(GUILayout.Button(guiContent, styleManager.Group.button))
+			if(GUILayout.Button(guiContent, selected ? styleManager.Group.selectedButton : styleManager.Group.button))
 			{
 				anyButtonPressed = true;
 				return true;

--- a/MOD.Scripts.UI/MODSimpleTimer.cs
+++ b/MOD.Scripts.UI/MODSimpleTimer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODSimpleTimer
+	{
+		public float timeLeft;
+
+		public MODSimpleTimer()
+		{
+			this.timeLeft = 0;
+		}
+
+		public void Start(float duration)
+		{
+			this.timeLeft = duration;
+		}
+
+		public void Update()
+		{
+			// Update the timer, making sure it doesn't go below 0
+			timeLeft = Math.Max(0, timeLeft - Time.deltaTime);
+		}
+
+		public bool Finished()
+		{
+			return this.timeLeft == 0;
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODSimpleTimer.cs
+++ b/MOD.Scripts.UI/MODSimpleTimer.cs
@@ -8,26 +8,60 @@ namespace MOD.Scripts.UI
 	class MODSimpleTimer
 	{
 		public float timeLeft;
+		public bool started;
 
 		public MODSimpleTimer()
 		{
 			this.timeLeft = 0;
+			this.started = false;
 		}
 
+		/// <summary>
+		/// Start a timer with the given duration
+		/// </summary>
+		/// <param name="duration"></param>
 		public void Start(float duration)
 		{
 			this.timeLeft = duration;
+			this.started = true;
 		}
 
+		/// <summary>
+		/// Causes the timer to count down as time passes. Call exactly once in unity's Update() loop
+		/// </summary>
 		public void Update()
 		{
 			// Update the timer, making sure it doesn't go below 0
-			timeLeft = Math.Max(0, timeLeft - Time.deltaTime);
+			if (this.started)
+			{
+				timeLeft = Math.Max(0, timeLeft - Time.deltaTime);
+			}
 		}
 
+		/// <summary>
+		/// Indicates if timer was previously started and has now expired
+		/// </summary>
+		/// <returns></returns>
 		public bool Finished()
 		{
-			return this.timeLeft == 0;
+			return this.started && this.timeLeft == 0;
+		}
+
+		/// <summary>
+		/// Indicates if the timer is counting down
+		/// </summary>
+		/// <returns></returns>
+		public bool Running()
+		{
+			return this.started && this.timeLeft != 0;
+		}
+
+		/// <summary>
+		/// Cancels the timer - causes Finished() to return false, and stops timer counting down
+		/// </summary>
+		public void Cancel()
+		{
+			this.started = false;
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODSound.cs
+++ b/MOD.Scripts.UI/MODSound.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MOD.Scripts.UI
+{
+	public enum GUISound
+	{
+		Click,
+		LoudBang,
+		Disable,
+		Enable,
+		Pluck0,
+		Pluck1,
+		Pluck2,
+		Pluck3,
+		Pluck4,
+		Pluck5,
+	}
+
+	class MODSound
+	{
+		public static string GetSoundPathFromEnum(GUISound sound)
+		{
+			switch (sound)
+			{
+				case GUISound.Click:
+					return "wa_038.ogg";
+				case GUISound.LoudBang:
+					return "wa_040.ogg";
+				case GUISound.Disable:
+					return "switchsound/disable.ogg";
+				case GUISound.Enable:
+					return "switchsound/enable.ogg";
+				case GUISound.Pluck0:
+					return "switchsound/0.ogg";
+				case GUISound.Pluck1:
+					return "switchsound/1.ogg";
+				case GUISound.Pluck2:
+					return "switchsound/2.ogg";
+				case GUISound.Pluck3:
+					return "switchsound/3.ogg";
+				case GUISound.Pluck4:
+					return "switchsound/4.ogg";
+				case GUISound.Pluck5:
+					return "switchsound/5.ogg";
+			}
+
+			return "wa_038.ogg";
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -11,6 +11,7 @@ namespace MOD.Scripts.UI
 		public GUIStyle smallLabelStyle;
 		public GUIStyle modGUIStyle;
 		public GUIStyle modSelectorStyle;
+		public GUIStyle errorLabelStyle;
 		public Texture2D modGUIBackgroundTexture;
 
 		/// <summary>
@@ -57,6 +58,12 @@ namespace MOD.Scripts.UI
 				{
 					fontSize = 20,
 				};
+			}
+
+			if (errorLabelStyle == null)
+			{
+				errorLabelStyle = new GUIStyle(GUI.skin.label);
+				errorLabelStyle.normal.textColor = Color.red;
 			}
 		}
 

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -7,12 +7,45 @@ namespace MOD.Scripts.UI
 {
 	public class MODStyleManager
 	{
-		public GUIStyle labelStyle;
-		public GUIStyle smallLabelStyle;
-		public GUIStyle modGUIStyle;
-		public GUIStyle modSelectorStyle;
-		public GUIStyle errorLabelStyle;
+		public class StyleGroup
+		{
+			public int menuHeight;
+			public int menuWidth;
+			public GUIStyle modMenuSelectionGrid;   // Used for SelectionGrid widgets
+			public GUIStyle errorLabel;
+			public GUIStyle button;
+			public GUIStyle label;             //Used for normal Label widgets
+		}
+
+		// Styles used for Toasts
+		public GUIStyle bigToastLabelStyle;
+		public GUIStyle smallToastLabelStyle;
+
+		// Styles used for the Mod menu
+		public GUIStyle modMenuAreaStyle;		//Used for Area widgets
+
 		public Texture2D modGUIBackgroundTexture;
+
+		StyleGroup style480;
+		StyleGroup style720;
+		StyleGroup style1080;
+		public StyleGroup Group
+		{
+			get {
+				if (Screen.height >= 1080)
+				{
+					return style1080;
+				}
+				else if (Screen.height >= 720)
+				{
+					return style720;
+				}
+
+				return style480;
+			}
+		}
+
+		public float baseFontSize = 14;
 
 		/// <summary>
 		/// Note that this static construct is automatically created
@@ -30,9 +63,32 @@ namespace MOD.Scripts.UI
 			modGUIBackgroundTexture.SetPixels(pix);
 			modGUIBackgroundTexture.Apply();
 
+			style480 = GenerateWidgetStyles(
+				menuWidth: 850,
+				menuHeight: 480,
+				guiScale: .9f,
+				margin: new RectOffset(0, 0, 0, 0),
+				padding: new RectOffset(0, 0, 0, 0)
+			);
+
+			style720 = GenerateWidgetStyles(
+				menuWidth: 1200,
+				menuHeight: 660,
+				guiScale: 1f,
+				margin: new RectOffset(1, 1, 1, 1),
+				padding: new RectOffset(1, 1, 1, 1)
+			);
+
+			style1080 = GenerateWidgetStyles(
+				menuWidth: 1200,
+				menuHeight: 800,
+				guiScale: 1.25f,
+				margin: new RectOffset(2, 2, 2, 2),
+				padding: new RectOffset(2, 2, 2, 2)
+			);
+
 			OnGUIGetLabelStyle();
 			OnGUIGetModStyle();
-			OnGUIGetSelectorStyle();
 		}
 
 		// This sets up the style of the toast notification (mostly to make the font bigger and the text anchor location)
@@ -40,62 +96,72 @@ namespace MOD.Scripts.UI
 		// GUI.skin.label will not be defined, so please do not move this part elsewhere without testing it.
 		private void OnGUIGetLabelStyle()
 		{
-			if (labelStyle == null)
+			bigToastLabelStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
 			{
-				labelStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
-				{
-					alignment = TextAnchor.UpperCenter,
-					fontSize = 40,
-					fontStyle = FontStyle.Bold,
-				};
-				labelStyle.normal.background = modGUIBackgroundTexture;
-				labelStyle.normal.textColor = Color.white;
-			}
+				alignment = TextAnchor.UpperCenter,
+				fontSize = 40,
+				fontStyle = FontStyle.Bold,
+			};
+			bigToastLabelStyle.normal.background = modGUIBackgroundTexture;
+			bigToastLabelStyle.normal.textColor = Color.white;
 
-			if (smallLabelStyle == null)
+			smallToastLabelStyle = new GUIStyle(bigToastLabelStyle)
 			{
-				smallLabelStyle = new GUIStyle(labelStyle)
-				{
-					fontSize = 20,
-				};
-			}
-
-			if (errorLabelStyle == null)
-			{
-				errorLabelStyle = new GUIStyle(GUI.skin.label);
-				errorLabelStyle.normal.textColor = Color.red;
-			}
+				fontSize = 20,
+			};
 		}
 
 		private void OnGUIGetModStyle()
 		{
-			if (modGUIStyle == null)
+			modMenuAreaStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
 			{
-				modGUIStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
-				{
-					//alignment = TextAnchor.UpperCenter,
-					//fontSize = 40,
-					//fontStyle = FontStyle.Bold,
-				};
-				modGUIStyle.normal.background = modGUIBackgroundTexture;
-				modGUIStyle.normal.textColor = Color.white;
-				modGUIStyle.wordWrap = true;
-			}
+				//alignment = TextAnchor.UpperCenter,
+				//fontSize = 40,
+				//fontStyle = FontStyle.Bold,
+			};
+			modMenuAreaStyle.normal.background = modGUIBackgroundTexture;
+			modMenuAreaStyle.normal.textColor = Color.white;
+			modMenuAreaStyle.wordWrap = true;
 		}
 
-		private void OnGUIGetSelectorStyle()
+		private StyleGroup GenerateWidgetStyles(int menuWidth, int menuHeight, float guiScale, RectOffset margin, RectOffset padding)
 		{
-			if (modSelectorStyle == null)
+			// Button style
+			GUIStyle buttonStyle = new GUIStyle(GUI.skin.button);
+			buttonStyle.fontSize = Mathf.RoundToInt(guiScale * baseFontSize);
+
+			// Label style
+			GUIStyle labelStyle = new GUIStyle(GUI.skin.label)
 			{
-				modSelectorStyle = new GUIStyle(GUI.skin.button) //Copy the default style for 'box' as a base
-				{
-					//alignment = TextAnchor.UpperCenter,
-					//fontSize = 40,
-					//fontStyle = FontStyle.Bold,
-				};
-				modSelectorStyle.onHover.textColor = Color.green;
-				modSelectorStyle.onNormal.textColor = Color.green; // Color of a selected option
-			}
+				fontSize = Mathf.RoundToInt(guiScale * baseFontSize),
+				margin = margin,
+				padding = padding,
+			};
+
+			// Menu selection grid/radio
+			GUIStyle modMenuSelectionGrid = new GUIStyle(GUI.skin.button) //Copy the default style for 'box' as a base
+			{
+				//alignment = TextAnchor.UpperCenter,
+				fontSize = Mathf.RoundToInt(guiScale * baseFontSize),
+				//fontStyle = FontStyle.Bold,
+			};
+			modMenuSelectionGrid.onHover.textColor = Color.green;
+			modMenuSelectionGrid.onNormal.textColor = Color.green; // Color of a selected option
+
+			// Error label (this is used for the description on the right hand side if the game encounters an error
+			GUIStyle errorLabelStyle = new GUIStyle(GUI.skin.label);
+			errorLabelStyle.normal.textColor = Color.red;
+			errorLabelStyle.fontSize = Mathf.RoundToInt(guiScale * baseFontSize);
+
+			return new StyleGroup()
+			{
+				menuWidth = menuWidth,
+				menuHeight = menuHeight,
+				modMenuSelectionGrid = modMenuSelectionGrid,
+				errorLabel = errorLabelStyle,
+				button = buttonStyle,
+				label = labelStyle,
+			};
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -15,6 +15,7 @@ namespace MOD.Scripts.UI
 			public GUIStyle errorLabel;
 			public GUIStyle button;
 			public GUIStyle label;             //Used for normal Label widgets
+			public GUIStyle headingLabel;
 		}
 
 		// Styles used for Toasts
@@ -72,9 +73,9 @@ namespace MOD.Scripts.UI
 			);
 
 			style720 = GenerateWidgetStyles(
-				menuWidth: 1200,
+				menuWidth: 1000,
 				menuHeight: 660,
-				guiScale: 1f,
+				guiScale: 1.1f,
 				margin: new RectOffset(1, 1, 1, 1),
 				padding: new RectOffset(1, 1, 1, 1)
 			);
@@ -138,12 +139,19 @@ namespace MOD.Scripts.UI
 				padding = padding,
 			};
 
+			// Heading text style
+			GUIStyle headingLabelStyle = new GUIStyle(labelStyle)
+			{
+				fontStyle = FontStyle.Bold,
+				alignment = TextAnchor.LowerCenter,
+			};
+			headingLabelStyle.padding.top *= 5;
+
 			// Menu selection grid/radio
 			GUIStyle modMenuSelectionGrid = new GUIStyle(GUI.skin.button) //Copy the default style for 'box' as a base
 			{
 				//alignment = TextAnchor.UpperCenter,
 				fontSize = Mathf.RoundToInt(guiScale * baseFontSize),
-				//fontStyle = FontStyle.Bold,
 			};
 			modMenuSelectionGrid.onHover.textColor = Color.green;
 			modMenuSelectionGrid.onNormal.textColor = Color.green; // Color of a selected option
@@ -161,6 +169,7 @@ namespace MOD.Scripts.UI
 				errorLabel = errorLabelStyle,
 				button = buttonStyle,
 				label = labelStyle,
+				headingLabel = headingLabelStyle,
 			};
 		}
 	}

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	public class MODStyleManager
+	{
+		public GUIStyle labelStyle;
+		public GUIStyle smallLabelStyle;
+		public GUIStyle modGUIStyle;
+		public GUIStyle modSelectorStyle;
+		public Texture2D modGUIBackgroundTexture;
+
+		/// <summary>
+		/// Note that this static construct is automatically created
+		/// </summary>
+		public MODStyleManager()
+		{
+			int width = 1;
+			int height = 1;
+			Color[] pix = new Color[width * height];
+			for (int i = 0; i < pix.Length; i++)
+			{
+				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.9f);
+			}
+			modGUIBackgroundTexture = new Texture2D(width, height);
+			modGUIBackgroundTexture.SetPixels(pix);
+			modGUIBackgroundTexture.Apply();
+
+			OnGUIGetLabelStyle();
+			OnGUIGetModStyle();
+			OnGUIGetSelectorStyle();
+		}
+
+		// This sets up the style of the toast notification (mostly to make the font bigger and the text anchor location)
+		// From what I've read, The GUIStyle must be initialized in OnGUI(), otherwise
+		// GUI.skin.label will not be defined, so please do not move this part elsewhere without testing it.
+		private void OnGUIGetLabelStyle()
+		{
+			if (labelStyle == null)
+			{
+				labelStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
+				{
+					alignment = TextAnchor.UpperCenter,
+					fontSize = 40,
+					fontStyle = FontStyle.Bold,
+				};
+				labelStyle.normal.background = modGUIBackgroundTexture;
+				labelStyle.normal.textColor = Color.white;
+			}
+
+			if (smallLabelStyle == null)
+			{
+				smallLabelStyle = new GUIStyle(labelStyle)
+				{
+					fontSize = 20,
+				};
+			}
+		}
+
+		private void OnGUIGetModStyle()
+		{
+			if (modGUIStyle == null)
+			{
+				modGUIStyle = new GUIStyle(GUI.skin.box) //Copy the default style for 'box' as a base
+				{
+					//alignment = TextAnchor.UpperCenter,
+					//fontSize = 40,
+					//fontStyle = FontStyle.Bold,
+				};
+				modGUIStyle.normal.background = modGUIBackgroundTexture;
+				modGUIStyle.normal.textColor = Color.white;
+				modGUIStyle.wordWrap = true;
+			}
+		}
+
+		private void OnGUIGetSelectorStyle()
+		{
+			if (modSelectorStyle == null)
+			{
+				modSelectorStyle = new GUIStyle(GUI.skin.button) //Copy the default style for 'box' as a base
+				{
+					//alignment = TextAnchor.UpperCenter,
+					//fontSize = 40,
+					//fontStyle = FontStyle.Bold,
+				};
+				modSelectorStyle.onHover.textColor = Color.green;
+				modSelectorStyle.onNormal.textColor = Color.green; // Color of a selected option
+			}
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -14,6 +14,7 @@ namespace MOD.Scripts.UI
 			public GUIStyle modMenuSelectionGrid;   // Used for SelectionGrid widgets
 			public GUIStyle errorLabel;
 			public GUIStyle button;
+			public GUIStyle selectedButton;
 			public GUIStyle label;             //Used for normal Label widgets
 			public GUIStyle headingLabel;
 		}
@@ -131,6 +132,11 @@ namespace MOD.Scripts.UI
 			GUIStyle buttonStyle = new GUIStyle(GUI.skin.button);
 			buttonStyle.fontSize = Mathf.RoundToInt(guiScale * baseFontSize);
 
+			// Selected button style (to show if a the option a button represents is activated)
+			GUIStyle selectedButtonStyle = new GUIStyle(buttonStyle);
+			selectedButtonStyle.normal.textColor = Color.green;
+			selectedButtonStyle.hover.textColor = Color.green;
+
 			// Label style
 			GUIStyle labelStyle = new GUIStyle(GUI.skin.label)
 			{
@@ -168,6 +174,7 @@ namespace MOD.Scripts.UI
 				modMenuSelectionGrid = modMenuSelectionGrid,
 				errorLabel = errorLabelStyle,
 				button = buttonStyle,
+				selectedButton = selectedButtonStyle,
 				label = labelStyle,
 				headingLabel = headingLabelStyle,
 			};

--- a/MOD.Scripts.UI/MODToaster.cs
+++ b/MOD.Scripts.UI/MODToaster.cs
@@ -32,7 +32,7 @@ namespace MOD.Scripts.UI
 
 		public void OnGUIFragment()
 		{
-			if (!toastNotificationTimer.Finished())
+			if (toastNotificationTimer.Running())
 			{
 				// This scrolls the toast notification off the window when it's nearly finished
 				float toastYPosition = Math.Min(50f, 200f * toastNotificationTimer.timeLeft - 50f);

--- a/MOD.Scripts.UI/MODToaster.cs
+++ b/MOD.Scripts.UI/MODToaster.cs
@@ -39,7 +39,7 @@ namespace MOD.Scripts.UI
 				float toastWidth = 700f;
 				float toastXPosition = (Screen.width - toastWidth) / 2.0f;
 				GUILayout.BeginArea(new Rect(toastXPosition, toastYPosition, 700f, 200f));
-				GUILayout.Box(toastText, toastText.Length > 30 ? styleManager.smallLabelStyle : styleManager.labelStyle);
+				GUILayout.Box(toastText, toastText.Length > 30 ? styleManager.smallToastLabelStyle : styleManager.bigToastLabelStyle);
 				GUILayout.EndArea();
 			}
 		}

--- a/MOD.Scripts.UI/MODToaster.cs
+++ b/MOD.Scripts.UI/MODToaster.cs
@@ -1,0 +1,102 @@
+﻿using Assets.Scripts.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	/// <summary>
+	/// This class is responsible for showing toast noficiations
+	/// </summary>
+	class MODToaster
+	{
+		static MODToaster Instance;
+		private MODStyleManager styleManager;
+		string toastText;
+		MODSimpleTimer toastNotificationTimer;
+
+		public MODToaster(MODStyleManager styleManager)
+		{
+			this.styleManager = styleManager;
+			this.toastText = "";
+			this.toastNotificationTimer = new MODSimpleTimer();
+
+			Instance = this;
+		}
+
+		public void Update()
+		{
+			toastNotificationTimer.Update();
+		}
+
+		public void OnGUIFragment()
+		{
+			if (!toastNotificationTimer.Finished())
+			{
+				// This scrolls the toast notification off the window when it's nearly finished
+				float toastYPosition = Math.Min(50f, 200f * toastNotificationTimer.timeLeft - 50f);
+				float toastWidth = 700f;
+				float toastXPosition = (Screen.width - toastWidth) / 2.0f;
+				GUILayout.BeginArea(new Rect(toastXPosition, toastYPosition, 700f, 200f));
+				GUILayout.Box(toastText, toastText.Length > 30 ? styleManager.smallLabelStyle : styleManager.labelStyle);
+				GUILayout.EndArea();
+			}
+		}
+
+		/// <summary>
+		/// Displays a toast notification. It will appear ontop of everything else on the screen.
+		/// </summary>
+		/// <param name="toastText">The text to display in the toast</param>
+		/// <param name="toastDuration">The duration the toast will be shown for.
+		/// The toast will slide off the screen for the last part of this duration.</param>
+		public static void Show(string toastText, GUISound? maybeSound = GUISound.Click, float toastDuration = 3)
+		{
+			if(Instance == null)
+			{
+				return;
+			}
+
+			Instance.toastText = toastText;
+			Instance.toastNotificationTimer.Start(toastDuration);
+			if (maybeSound is GUISound sound)
+			{
+				GameSystem.Instance.AudioController.PlaySystemSound(MODSound.GetSoundPathFromEnum(sound));
+			}
+		}
+
+		public static void Show(string toastText, bool isEnable, float toastDuration = 3)
+		{
+			Show(toastText, isEnable ? GUISound.Enable : GUISound.Disable, toastDuration);
+		}
+
+		public static void Show(string toastText, int numberedSound, float toastDuration = 3)
+		{
+			GUISound sound = GUISound.Click;
+			switch (numberedSound)
+			{
+				case 0:
+					sound = GUISound.Pluck0;
+					break;
+				case 1:
+					sound = GUISound.Pluck1;
+					break;
+				case 2:
+					sound = GUISound.Pluck2;
+					break;
+				case 3:
+					sound = GUISound.Pluck3;
+					break;
+				case 4:
+					sound = GUISound.Pluck4;
+					break;
+				case 5:
+					sound = GUISound.Pluck5;
+					break;
+			}
+
+			Show(toastText, sound, toastDuration);
+		}
+
+	}
+}

--- a/MOD.Scripts.UI/MODToaster.cs
+++ b/MOD.Scripts.UI/MODToaster.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace MOD.Scripts.UI
 {
 	/// <summary>
-	/// This class is responsible for showing toast noficiations
+	/// This class is responsible for showing toast notifications
 	/// </summary>
 	class MODToaster
 	{
@@ -45,7 +45,7 @@ namespace MOD.Scripts.UI
 		}
 
 		/// <summary>
-		/// Displays a toast notification. It will appear ontop of everything else on the screen.
+		/// Displays a toast notification. It will appear on top of everything else on the screen.
 		/// </summary>
 		/// <param name="toastText">The text to display in the toast</param>
 		/// <param name="toastDuration">The duration the toast will be shown for.


### PR DESCRIPTION
So, I got a bit carried away and included many fixes all in this one branch. There is also some refactoring of existing code (related to the mod toggles and keyboard inputs).

I've already did merges against all the other branches (to check it could merge reasonably).

To allow the DLLs to be tested, I've added them to the installer as an option (the very latest commit with the "quitaftercompile" command line argument is not in the DLL though). That's probably the easiest way to check these changes out.

One thing of note is that in the code I have used the word "Ryukishi" for original mode, rather than the word "Original". But the mod menu text still says "Ryukishi/Original" mode on the user facing side so it's more clear.

Please don't merge this PR until the new DLL has been tested for a while.

## Mod Menu

- Add an in-game mod menu
- Add changing the opening movie flag in the menu
- Add ability to select any combination of assets
  - You can toggle between ADV, NVL, and OG mode
  - You can also set which artset to use
  - Finally, you can override the current background used, regardless of artset
  - Using combinations of these three options, you can set any combination of backgrounds, sprites, and text display/image cropping
- Add buttons to show the log folder, save folder, and CompiledUpdateScripts folder, and open the 07th-mod support page
- Add option to set custom (16:9) resolutions
- Add Mod menu resolution scaling (tested from 480p to 1440p)
- Fix clicks passing through the mod menu
- Add ability to open menu via button on the "config" page, as well as the F10 key
- Add ability to close menu with F10, the 'X' button, or right clicking

## Misc

- Add playback of an example voice file when the voice volume is adjusted via keyboard, so it's easier to check how loud you've set it
- Add toast notification when changing an option using a keyboard shortcut (so it's clear when an option has been changed)
- Fix crash if image asset is missing (in certain cases), by returning dumy texture instead 134d369d60c4723496b8efd9d3defdef5617d1b1
- Add error menu/error message shown if the game fails to start up 1aa7e4886f55942059484d82376f41f716232d05, or saves are corrupted 4e22c90eb347c369fd114c8db5222de3c30c7809 (rather than a black screen as previously)

## Developer

- Refactor mod hotkey handling so that can detect if a button was pressed, but no action could be taken due to the game being in the middle of animating
- Add "quitaftercompile" function so that game can be used for automated script compilation 6c08d94eafa6254130f1322be02a1ef8ac5f16fc
  - if "quitaftercompile" is passed as command line argument, game will quit after compilation is finished
  - will also write out the file "higu_script_compile_status.txt" to current directory to differentiate between the game crashing and scripts finishing to compile

## Original/Ryukishi Mode

- Display in 4:3 aspect instead of 16:9 (with exceptions, see below)
- Crop sprites if they extend beyond 4:3 (any images in the sprites folder drawn with bustshot command) 
  - 42da17ed2d570b3b81ef8d40996efe145ec2a680
  - 3a486754c88e6a5c1dd43cac238d3e4eff092422
  - b9e26ccc1f9389268081b8004ef6c7791a4a9612
- Add option to skip CGs, enabled by default when OG mode is enabled
- Display any background images which are still 16:9 in 16:9. This is done so that any text assets will still be readable even if we don't resize them.
- Add option to stretch backgrounds, disabled by default

## (Optional) Script functions added

The following functions were added, but are not necessary (current scripts will still work even without these functions called, using the hardcoded default values). They are usually called from `init.txt` and mirror the existing functions with similar names.

- ModRyukishiSetGuiPosition - This mirrors the existing SetGuiPosition script function. It sets the GUI position when in Original/Ryukishi mode
- ModRyukishiModeSettingLoad - This mirrors the existing ModADVModeSettingLoad. It sets the window position etc. for Original/Ryukishi mode
