### PR TITLE
Switchable BGM/SE support

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -243,6 +243,7 @@
     <Compile Include="MOD.Scripts.UI\MODMainUIController.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenu.cs" />
     <Compile Include="MOD.Scripts.UI\MODActions.cs" />
+    <Compile Include="MOD.Scripts.UI\MODRadio.cs" />
     <Compile Include="MOD.Scripts.UI\MODSimpleTimer.cs" />
     <Compile Include="MOD.Scripts.UI\MODSound.cs" />
     <Compile Include="MOD.Scripts.UI\MODStyleManager.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -243,6 +243,11 @@
     <Compile Include="MOD.Scripts.UI\MODMainUIController.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenu.cs" />
     <Compile Include="MOD.Scripts.UI\MODActions.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuSupport.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuModuleInterface.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuNormal.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuResolution.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuCommon.cs" />
     <Compile Include="MOD.Scripts.UI\MODRadio.cs" />
     <Compile Include="MOD.Scripts.UI\MODSimpleTimer.cs" />
     <Compile Include="MOD.Scripts.UI\MODSound.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Assets.Scripts.Core.Audio\AudioInfo.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioLayerUnity.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioType.cs" />
+    <Compile Include="MOD.Scripts.Core.Audio\MODAudioSet.cs" />
     <Compile Include="MOD.Scripts.Core.Audio\MODAudioTracking.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\OnFinishLoad.cs" />
     <Compile Include="Assets.Scripts.Core.Buriko.Util\BurikoObjectConverter.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -243,6 +243,8 @@
     <Compile Include="MOD.Scripts.UI\MODMainUIController.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenu.cs" />
     <Compile Include="MOD.Scripts.UI\MODActions.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuAudioOptions.cs" />
+    <Compile Include="MOD.Scripts.UI\MODMenuAudioSetup.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuSupport.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuModuleInterface.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuNormal.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -71,7 +71,7 @@
     <Compile Include="Assets.Scripts.Core.Audio\AudioInfo.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioLayerUnity.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioType.cs" />
-    <Compile Include="MOD.Scripts.Core.Audio\MODAudio.cs" />
+    <Compile Include="MOD.Scripts.Core.Audio\MODAudioTracking.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\OnFinishLoad.cs" />
     <Compile Include="Assets.Scripts.Core.Buriko.Util\BurikoObjectConverter.cs" />
     <Compile Include="Assets.Scripts.Core.Buriko.Util\BurikoReference.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Assets.Scripts.Core.Audio\AudioInfo.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioLayerUnity.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioType.cs" />
+    <Compile Include="MOD.Scripts.Core.Audio\MODAudio.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\OnFinishLoad.cs" />
     <Compile Include="Assets.Scripts.Core.Buriko.Util\BurikoObjectConverter.cs" />
     <Compile Include="Assets.Scripts.Core.Buriko.Util\BurikoReference.cs" />
@@ -594,5 +595,6 @@
     <Compile Include="UIWidgetContainer.cs" />
     <Compile Include="UIWrapContent.cs" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -366,14 +366,14 @@ namespace Assets.Scripts.Core.AssetManagement
 			return texture2D;
 		}
 
-		public string getAssetUsingFlagAndCascade(string filename, int flag, List<PathCascadeList> cascades, out bool exists)
+		public string getAssetUsingFlagAndCascade(string filename, MODUtility.OneBasedFlag flag, List<PathCascadeList> cascades, out bool exists)
 		{
 			exists = false;
 
 			PathCascadeList cascade = cascades[0];
-			if(flag < cascades.Count)
+			if(flag.ZeroBased < cascades.Count)
 			{
-				cascade = cascades[flag];
+				cascade = cascades[flag.ZeroBased];
 			}
 
 			// Use the first file that exists. If none exist, return the last one.
@@ -396,11 +396,11 @@ namespace Assets.Scripts.Core.AssetManagement
 			switch (type)
 			{
 				case Audio.AudioType.BGM:
-					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue(), BGMCascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, new MODUtility.OneBasedFlag(BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue()), BGMCascades, out ok);
 
 				case Audio.AudioType.SE:
 				case Audio.AudioType.System:
-					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue(), SECascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, new MODUtility.OneBasedFlag(BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue()), SECascades, out ok);
 
 				case Audio.AudioType.Voice:
 					int voiceFlag = BurikoMemory.Instance.GetGlobalFlag("GAltVoicePriority").IntValue();
@@ -408,7 +408,7 @@ namespace Assets.Scripts.Core.AssetManagement
 					{
 						voiceFlag = 0;
 					}
-					return getAssetUsingFlagAndCascade(filename, voiceFlag, voiceCascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, new MODUtility.OneBasedFlag(voiceFlag), voiceCascades, out ok);
 
 				default:
 					Debug.Log($"_GetAudioFilePath(): Cannot play '{filename}' due to unknown AudioType '{type}' - ignoring this file");

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -366,14 +366,14 @@ namespace Assets.Scripts.Core.AssetManagement
 			return texture2D;
 		}
 
-		public string getAssetUsingFlagAndCascade(string filename, MODUtility.OneBasedFlag flag, List<PathCascadeList> cascades, out bool exists)
+		public string getAssetUsingFlagAndCascade(string filename, int flag, List<PathCascadeList> cascades, out bool exists)
 		{
 			exists = false;
 
 			PathCascadeList cascade = cascades[0];
-			if(flag.ZeroBased < cascades.Count)
+			if(flag < cascades.Count)
 			{
-				cascade = cascades[flag.ZeroBased];
+				cascade = cascades[flag];
 			}
 
 			// Use the first file that exists. If none exist, return the last one.
@@ -396,11 +396,11 @@ namespace Assets.Scripts.Core.AssetManagement
 			switch (type)
 			{
 				case Audio.AudioType.BGM:
-					return getAssetUsingFlagAndCascade(filename, new MODUtility.OneBasedFlag(BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue()), BGMCascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue(), BGMCascades, out ok);
 
 				case Audio.AudioType.SE:
 				case Audio.AudioType.System:
-					return getAssetUsingFlagAndCascade(filename, new MODUtility.OneBasedFlag(BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue()), SECascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue(), SECascades, out ok);
 
 				case Audio.AudioType.Voice:
 					int voiceFlag = BurikoMemory.Instance.GetGlobalFlag("GAltVoicePriority").IntValue();
@@ -408,7 +408,7 @@ namespace Assets.Scripts.Core.AssetManagement
 					{
 						voiceFlag = 0;
 					}
-					return getAssetUsingFlagAndCascade(filename, new MODUtility.OneBasedFlag(voiceFlag), voiceCascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, voiceFlag, voiceCascades, out ok);
 
 				default:
 					Debug.Log($"_GetAudioFilePath(): Cannot play '{filename}' due to unknown AudioType '{type}' - ignoring this file");

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -25,6 +25,28 @@ namespace Assets.Scripts.Core.AssetManagement
 			this.nameJP = nameJP;
 			this.paths = paths;
 		}
+
+		public bool PrimaryFolder(out string primaryFolder)
+		{
+			if(paths.Length == 0)
+			{
+				primaryFolder = "";
+				return false;
+			}
+
+			primaryFolder = paths[0];
+			return true;
+		}
+
+		public bool IsInstalled(string rootPath)
+		{
+			if (!PrimaryFolder(out string primaryFolder))
+			{
+				return false;
+			}
+
+			return Directory.Exists(Path.Combine(rootPath, primaryFolder));
+		}
 	}
 
 	public class AssetManager {

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -1,6 +1,7 @@
 using Assets.Scripts.Core.Audio;
 using Assets.Scripts.Core.Buriko;
 using BGICompiler.Compiler;
+using MOD.Scripts.Core.Audio;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -50,23 +51,9 @@ namespace Assets.Scripts.Core.AssetManagement
 		public string debugLastVoice { get; private set; } = "No voice played yet";
 		public string debugLastOtherAudio { get; private set; } = "No other audio played yet";
 
-		public List<PathCascadeList> BGMCascades = new List<PathCascadeList>()
-		{
-			new PathCascadeList("April Update", "April Update", new string[] { "BGM" }),
-			new PathCascadeList("Original", "Original", new string[] { "OGBGM" , "BGM" }),
-		};
-
-		public List<PathCascadeList> SECascades = new List<PathCascadeList>()
-		{
-			new PathCascadeList("April Update", "April Update", new string[] { "SE" }),
-			new PathCascadeList("Original", "Original", new string[] { "OGSE" , "SE" }),
-		};
-
-		public List<PathCascadeList> voiceCascades = new List<PathCascadeList>()
-		{
-			new PathCascadeList("PS3", "PS3", new string[] { "voice" }),
-		};
-
+		PathCascadeList defaultBGMCascade = new PathCascadeList("April Update", "April Update", new string[] { "BGM" });
+		PathCascadeList defaultSECascade = new PathCascadeList("April Update", "April Update", new string[] { "SE" });
+		PathCascadeList defaultVoiceCascade = new PathCascadeList("PS3", "PS3", new string[] { "voice" });
 
 		/// <summary>
 		/// Get the artset at the given index
@@ -366,11 +353,11 @@ namespace Assets.Scripts.Core.AssetManagement
 			return texture2D;
 		}
 
-		public string getAssetUsingFlagAndCascade(string filename, int flag, List<PathCascadeList> cascades, out bool exists)
+		public string getAssetUsingFlagAndCascade(string filename, int flag, List<PathCascadeList> cascades, PathCascadeList defaultCascade, out bool exists)
 		{
 			exists = false;
 
-			PathCascadeList cascade = cascades[0];
+			PathCascadeList cascade = defaultCascade;
 			if(flag < cascades.Count)
 			{
 				cascade = cascades[flag];
@@ -396,11 +383,11 @@ namespace Assets.Scripts.Core.AssetManagement
 			switch (type)
 			{
 				case Audio.AudioType.BGM:
-					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue(), BGMCascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue(), MODAudioSet.Instance.BGMCascades, defaultBGMCascade, out ok);
 
 				case Audio.AudioType.SE:
 				case Audio.AudioType.System:
-					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue(), SECascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue(), MODAudioSet.Instance.SECascades, defaultSECascade, out ok);
 
 				case Audio.AudioType.Voice:
 					int voiceFlag = BurikoMemory.Instance.GetGlobalFlag("GAltVoicePriority").IntValue();
@@ -408,7 +395,7 @@ namespace Assets.Scripts.Core.AssetManagement
 					{
 						voiceFlag = 0;
 					}
-					return getAssetUsingFlagAndCascade(filename, voiceFlag, voiceCascades, out ok);
+					return getAssetUsingFlagAndCascade(filename, voiceFlag, MODAudioSet.Instance.voiceCascades, defaultVoiceCascade, out ok);
 
 				default:
 					Debug.Log($"_GetAudioFilePath(): Cannot play '{filename}' due to unknown AudioType '{type}' - ignoring this file");

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -12,7 +12,7 @@ namespace Assets.Scripts.Core.AssetManagement
 {
 
 	/// <summary>
-	/// Stores an ordered list of paths for the engine to check when trying to find a cg
+	/// Stores an ordered list of paths for the engine to check when trying to find an asset
 	/// </summary>
 	public class PathCascadeList {
 		public readonly string nameEN;
@@ -44,6 +44,29 @@ namespace Assets.Scripts.Core.AssetManagement
 		private List<string> scriptList = new List<string>();
 
 		public static AssetManager Instance => _instance ?? (_instance = GameSystem.Instance.AssetManager);
+
+		public string debugLastBGM { get; private set; } = "No BGM played yet";
+		public string debugLastSE { get; private set; } = "No SE played yet";
+		public string debugLastVoice { get; private set; } = "No voice played yet";
+		public string debugLastOtherAudio { get; private set; } = "No other audio played yet";
+
+		public List<PathCascadeList> BGMCascades = new List<PathCascadeList>()
+		{
+			new PathCascadeList("April Update", "April Update", new string[] { "BGM" }),
+			new PathCascadeList("Original", "Original", new string[] { "OGBGM" , "BGM" }),
+		};
+
+		public List<PathCascadeList> SECascades = new List<PathCascadeList>()
+		{
+			new PathCascadeList("April Update", "April Update", new string[] { "SE" }),
+			new PathCascadeList("Original", "Original", new string[] { "OGSE" , "SE" }),
+		};
+
+		public List<PathCascadeList> voiceCascades = new List<PathCascadeList>()
+		{
+			new PathCascadeList("PS3", "PS3", new string[] { "voice" }),
+		};
+
 
 		/// <summary>
 		/// Get the artset at the given index
@@ -343,56 +366,78 @@ namespace Assets.Scripts.Core.AssetManagement
 			return texture2D;
 		}
 
-		public string GetAudioFilePath(string filename, Audio.AudioType type)
+		public string getAssetUsingFlagAndCascade(string filename, int flag, List<PathCascadeList> cascades, out bool exists)
 		{
-			string archiveNameByAudioType = GetArchiveNameByAudioType(type);
-			string text = null;
-			string text2 = Path.Combine(assetPath, archiveNameByAudioType + "/" + filename.ToLower());
-			string text3 = Path.Combine(assetPath, archiveNameByAudioType + "Alt/" + filename.ToLower());
-			switch (archiveNameByAudioType)
+			exists = false;
+
+			PathCascadeList cascade = cascades[0];
+			if(flag < cascades.Count)
 			{
-				case "BGM":
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue() != 0)
-					{
-						if (File.Exists(text3))
-						{
-							return text3;
-						}
-						break;
-					}
-					goto default;
-				case "SE":
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue() != 0)
-					{
-						if (File.Exists(text3))
-						{
-							return text3;
-						}
-						break;
-					}
-					goto default;
-				case "voice":
+				cascade = cascades[flag];
+			}
+
+			// Use the first file that exists. If none exist, return the last one.
+			string relativePath = "INVALID ASSET PATH";
+			foreach (string assetSubFolder in cascade.paths)
+			{
+				relativePath = Path.Combine(assetSubFolder, filename);
+				if (File.Exists(Path.Combine(assetPath, relativePath)))
+				{
+					exists = true;
+					break;
+				}
+			}
+
+			return relativePath;
+		}
+
+		public string _GetAudioFilePath(string filename, Audio.AudioType type, out bool ok)
+		{
+			switch (type)
+			{
+				case Audio.AudioType.BGM:
+					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltBGM").IntValue(), BGMCascades, out ok);
+
+				case Audio.AudioType.SE:
+				case Audio.AudioType.System:
+					return getAssetUsingFlagAndCascade(filename, BurikoMemory.Instance.GetGlobalFlag("GAltSE").IntValue(), SECascades, out ok);
+
+				case Audio.AudioType.Voice:
+					int voiceFlag = BurikoMemory.Instance.GetGlobalFlag("GAltVoicePriority").IntValue();
 					if (BurikoMemory.Instance.GetGlobalFlag("GAltVoice").IntValue() == 0)
 					{
-						break;
+						voiceFlag = 0;
 					}
-					if (BurikoMemory.Instance.GetGlobalFlag("GAltVoicePriority").IntValue() != 0)
-					{
-						if (File.Exists(text3))
-						{
-							return text3;
-						}
-						break;
-					}
-					goto default;
+					return getAssetUsingFlagAndCascade(filename, voiceFlag, voiceCascades, out ok);
+
 				default:
-					if (!File.Exists(text2))
-					{
-						return text3;
-					}
+					Debug.Log($"_GetAudioFilePath(): Cannot play '{filename}' due to unknown AudioType '{type}' - ignoring this file");
+					ok = false;
+					return "";
+			}
+		}
+
+		public string GetAudioFilePath(string filename, Audio.AudioType type)
+		{
+			string relativePath = _GetAudioFilePath(filename, type, out bool ok);
+			string debugRelativePath = $"{relativePath} ({(ok ? "OK" : "FAILED to load")})";
+			// Record the last played BGM and SE only for debugging purposes
+			switch (type)
+			{
+				case Audio.AudioType.BGM:
+					debugLastBGM = debugRelativePath;
+					break;
+				case Audio.AudioType.SE:
+					debugLastSE = debugRelativePath;
+					break;
+				case Audio.AudioType.Voice:
+					debugLastVoice = debugRelativePath;
+					break;
+				default:
+					debugLastOtherAudio = debugRelativePath;
 					break;
 			}
-			return text2;
+			return Path.Combine(assetPath, relativePath);
 		}
 
 		public byte[] GetAudioFile(string filename, Assets.Scripts.Core.Audio.AudioType type)

--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -223,7 +223,7 @@ namespace Assets.Scripts.Core.Audio
 		{
 			if (!noBGMTracking)
 			{
-				MODAudio.Instance.MODForgetLastBGM(channel);
+				MODAudioTracking.Instance.ForgetLastBGM(channel);
 			}
 			float num = (float)time / 1000f;
 			int channelByTypeChannel = GetChannelByTypeChannel(AudioType.BGM, channel);
@@ -243,7 +243,7 @@ namespace Assets.Scripts.Core.Audio
 		{
 			if (!noBGMTracking)
 			{
-				MODAudio.Instance.MODForgetLastBGM(channel);
+				MODAudioTracking.Instance.ForgetLastBGM(channel);
 			}
 			AudioLayerUnity audioLayerUnity = channelDictionary[channel];
 			audioLayerUnity.StopAudio();
@@ -257,7 +257,7 @@ namespace Assets.Scripts.Core.Audio
 		{
 			for (int i = channelstart; i <= channelend; i++)
 			{
-				MODAudio.Instance.MODForgetLastBGM(i);
+				MODAudioTracking.Instance.ForgetLastBGM(i);
 				FadeOutBGM(i, time, waitForFade);
 			}
 		}
@@ -389,7 +389,7 @@ namespace Assets.Scripts.Core.Audio
 		{
 			for (int i = 0; i < 6; i++)
 			{
-				MODAudio.Instance.MODForgetLastBGM(i);
+				MODAudioTracking.Instance.ForgetLastBGM(i);
 				AudioLayerUnity audioLayerUnity = channelDictionary[GetChannelByTypeChannel(AudioType.BGM, i)];
 				if (audioLayerUnity.IsPlaying())
 				{
@@ -432,7 +432,7 @@ namespace Assets.Scripts.Core.Audio
 			{
 				if (!noBGMTracking)
 				{
-					MODAudio.Instance.MODSaveLastBGM(new AudioInfo(volume, filename, channel));
+					MODAudioTracking.Instance.SaveLastBGM(new AudioInfo(volume, filename, channel));
 				}
 
 				if (currentAudio[AudioType.BGM].ContainsKey(channel))

--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -1,4 +1,5 @@
 using MOD.Scripts.Core;
+using MOD.Scripts.Core.Audio;
 using MOD.Scripts.Core.TextWindow;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
@@ -218,8 +219,12 @@ namespace Assets.Scripts.Core.Audio
 			audioLayerUnity.StartVolumeFade(volume, time2);
 		}
 
-		public void FadeOutBGM(int channel, int time, bool waitForFade)
+		public void FadeOutBGM(int channel, int time, bool waitForFade, bool noBGMTracking = false)
 		{
+			if (!noBGMTracking)
+			{
+				MODAudio.Instance.MODForgetLastBGM(channel);
+			}
 			float num = (float)time / 1000f;
 			int channelByTypeChannel = GetChannelByTypeChannel(AudioType.BGM, channel);
 			AudioLayerUnity audioLayerUnity = channelDictionary[channelByTypeChannel];
@@ -234,8 +239,12 @@ namespace Assets.Scripts.Core.Audio
 			}
 		}
 
-		public void StopBGM(int channel)
+		public void StopBGM(int channel, bool noBGMTracking = false)
 		{
+			if (!noBGMTracking)
+			{
+				MODAudio.Instance.MODForgetLastBGM(channel);
+			}
 			AudioLayerUnity audioLayerUnity = channelDictionary[channel];
 			audioLayerUnity.StopAudio();
 			if (currentAudio[AudioType.BGM].ContainsKey(channel))
@@ -248,6 +257,7 @@ namespace Assets.Scripts.Core.Audio
 		{
 			for (int i = channelstart; i <= channelend; i++)
 			{
+				MODAudio.Instance.MODForgetLastBGM(i);
 				FadeOutBGM(i, time, waitForFade);
 			}
 		}
@@ -379,6 +389,7 @@ namespace Assets.Scripts.Core.Audio
 		{
 			for (int i = 0; i < 6; i++)
 			{
+				MODAudio.Instance.MODForgetLastBGM(i);
 				AudioLayerUnity audioLayerUnity = channelDictionary[GetChannelByTypeChannel(AudioType.BGM, i)];
 				if (audioLayerUnity.IsPlaying())
 				{
@@ -403,7 +414,7 @@ namespace Assets.Scripts.Core.Audio
 			}
 		}
 
-		public void PlayAudio(string filename, AudioType type, int channel, float volume, float fadeintime = 0)
+		public void PlayAudio(string filename, AudioType type, int channel, float volume, float fadeintime = 0, bool noBGMTracking = false)
 		{
 			float startvolume = volume;
 			if (fadeintime > 0f)
@@ -419,6 +430,11 @@ namespace Assets.Scripts.Core.Audio
 			bool loop = type == AudioType.BGM;
 			if (type == AudioType.BGM)
 			{
+				if (!noBGMTracking)
+				{
+					MODAudio.Instance.MODSaveLastBGM(new AudioInfo(volume, filename, channel));
+				}
+
 				if (currentAudio[AudioType.BGM].ContainsKey(channel))
 				{
 					currentAudio[AudioType.BGM].Remove(channel);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -1,6 +1,7 @@
 using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Buriko.Util;
 using Assets.Scripts.Core.Buriko.VarTypes;
+using MOD.Scripts.Core.Audio;
 using MOD.Scripts.Core.Scene;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
@@ -394,6 +395,7 @@ namespace Assets.Scripts.Core.Buriko
 			// Save extra variables that aren't in vanilla games into places where they'll be ignored by vanilla games
 			// In this case, the variable list seemed like a good spot (with a name that's not a valid Buriko variable name)
 			serializeToSave("$layerFilters", MODSceneController.serializableLayerFilters);
+			serializeToSave("$audioTracking", MODAudioTracking.Instance.SerializeableState());
 			if (AssetManager.Instance.ShouldSerializeArtsets)
 			{
 				serializeToSave("$artsets", AssetManager.Instance.Artsets);
@@ -429,6 +431,7 @@ namespace Assets.Scripts.Core.Buriko
 			{
 				memorylist.Remove("$layerFilters");
 				memorylist.Remove("$artsets");
+				memorylist.Remove("$audioTracking");
 			}
 		}
 
@@ -475,6 +478,10 @@ namespace Assets.Scripts.Core.Buriko
 				AssetManager.Instance.Artsets = artsets;
 				AssetManager.Instance.ShouldSerializeArtsets = true;
 				Debug.Log("Loaded " + artsets.Count + " artsets: " + string.Join(", ", artsets.Select(x => x.ToString()).ToArray()));
+			}
+			if(tryDeserializeFromSave<Dictionary<int, Audio.AudioInfo>[]>("$audioTracking", out var audioTracking))
+			{
+				MODAudioTracking.Instance.QueueState(audioTracking);
 			}
 			using (BsonReader reader = new BsonReader(ms) { CloseInput = false })
 			{

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -109,6 +109,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GRyukishiMode", 526);
 			variableReference.Add("GStretchBackgrounds", 527);
 			variableReference.Add("GBackgroundSet", 528);
+			variableReference.Add("GAudioSet", 529);
 
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -147,5 +147,8 @@ namespace Assets.Scripts.Core.Buriko
 		ModRyukishiSetGuiPosition,
 		ModPlayBGM,
 		ModFadeOutBGM,
+		ModAddBGMset,
+		ModAddSEset,
+		ModAddAudioset,
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -150,5 +150,6 @@ namespace Assets.Scripts.Core.Buriko
 		ModAddBGMset,
 		ModAddSEset,
 		ModAddAudioset,
+		ModGenericCall,
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoOperations.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoOperations.cs
@@ -145,5 +145,7 @@ namespace Assets.Scripts.Core.Buriko
 		ModClearArtsets,
 		ModRyukishiModeSettingLoad,
 		ModRyukishiSetGuiPosition,
+		ModPlayBGM,
+		ModFadeOutBGM,
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2234,6 +2234,12 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODPlayBGM();
 			case BurikoOperations.ModFadeOutBGM:
 				return OperationMODFadeOutBGM();
+			case BurikoOperations.ModAddBGMset:
+				return OperationMODAddBGMset();
+			case BurikoOperations.ModAddSEset:
+				return OperationMODAddSEset();
+			case BurikoOperations.ModAddAudioset:
+				return OperationMODAddAudioset();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;
@@ -2694,13 +2700,46 @@ namespace Assets.Scripts.Core.Buriko
 			return BurikoVariable.Null;
 		}
 
-		public BurikoVariable OperationMODAddArtset()
+		private PathCascadeList ReadPathCascadeFromArgs()
 		{
-			SetOperationType("MODAddArtset");
 			string nameEN = ReadVariable().StringValue();
 			string nameJP = ReadVariable().StringValue();
 			string[] paths = ReadVariable().StringValue().Split(':');
-			AssetManager.Instance.AddArtset(new PathCascadeList(nameEN, nameJP, paths));
+			return new PathCascadeList(nameEN, nameJP, paths);
+		}
+
+		public BurikoVariable OperationMODAddArtset()
+		{
+			SetOperationType("MODAddArtset");
+			AssetManager.Instance.AddArtset(ReadPathCascadeFromArgs());
+			return BurikoVariable.Null;
+		}
+
+		public BurikoVariable OperationMODAddBGMset()
+		{
+			SetOperationType("MODAddBGMset");
+			MODAudioSet.Instance.AddBGMSet(ReadPathCascadeFromArgs());
+			return BurikoVariable.Null;
+		}
+
+		public BurikoVariable OperationMODAddSEset()
+		{
+			SetOperationType("MODAddSEset");
+			MODAudioSet.Instance.AddSESet(ReadPathCascadeFromArgs());
+			return BurikoVariable.Null;
+		}
+
+		public BurikoVariable OperationMODAddAudioset()
+		{
+			SetOperationType("MODAddAudioSet");
+			string nameEN = ReadVariable().StringValue();
+			string nameJP = ReadVariable().StringValue();
+			int altBGM = ReadVariable().IntValue();
+			int altBGMflow = ReadVariable().IntValue();
+			int altSE = ReadVariable().IntValue();
+			int altSEFlow = ReadVariable().IntValue();
+			MODAudioSet.Instance.AddAudioSet(new AudioSet(nameEN, nameJP, altBGM, altBGMflow, altSE, altSEFlow));
+
 			return BurikoVariable.Null;
 		}
 

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2240,6 +2240,8 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODAddSEset();
 			case BurikoOperations.ModAddAudioset:
 				return OperationMODAddAudioset();
+			case BurikoOperations.ModGenericCall:
+				return OperationMODGenericCall();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;
@@ -2748,6 +2750,24 @@ namespace Assets.Scripts.Core.Buriko
 			SetOperationType("MODClearArtsets");
 			AssetManager.Instance.ClearArtsets();
 			AssetManager.Instance.ShouldSerializeArtsets = true;
+			return BurikoVariable.Null;
+		}
+
+		public BurikoVariable OperationMODGenericCall()
+		{
+			SetOperationType("MODGenericCall");
+			string callID = ReadVariable().StringValue();
+			string callParameters = ReadVariable().StringValue();
+			switch(callID)
+			{
+				case "ShowAudioSetupMenu":
+					GameSystem.Instance.MainUIController.modMenu.Show(ModMenuMode.AudioSetup);
+					break;
+
+				default:
+					Logger.Log($"WARNING: Unknown ModGenericCall ID '{callID}'");
+					break;
+			}
 			return BurikoVariable.Null;
 		}
 	}

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2761,7 +2761,8 @@ namespace Assets.Scripts.Core.Buriko
 			switch(callID)
 			{
 				case "ShowAudioSetupMenu":
-					GameSystem.Instance.MainUIController.modMenu.Show(ModMenuMode.AudioSetup);
+					GameSystem.Instance.MainUIController.modMenu.SetMode(ModMenuMode.AudioSetup);
+					GameSystem.Instance.MainUIController.modMenu.Show();
 					break;
 
 				default:

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2767,7 +2767,7 @@ namespace Assets.Scripts.Core.Buriko
 			switch(callID)
 			{
 				case "ShowAudioSetupMenu":
-					if(MODAudioSet.Instance.HasAudioSets())
+					if(MODAudioSet.Instance.HasAudioSetsDefined())
 					{
 						GameSystem.Instance.MainUIController.modMenu.SetMode(ModMenuMode.AudioSetup);
 						GameSystem.Instance.MainUIController.modMenu.Show();

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2761,8 +2761,11 @@ namespace Assets.Scripts.Core.Buriko
 			switch(callID)
 			{
 				case "ShowAudioSetupMenu":
-					GameSystem.Instance.MainUIController.modMenu.SetMode(ModMenuMode.AudioSetup);
-					GameSystem.Instance.MainUIController.modMenu.Show();
+					if(MODAudioSet.Instance.HasAudioSets())
+					{
+						GameSystem.Instance.MainUIController.modMenu.SetMode(ModMenuMode.AudioSetup);
+						GameSystem.Instance.MainUIController.modMenu.Show();
+					}
 					break;
 
 				default:

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2767,7 +2767,7 @@ namespace Assets.Scripts.Core.Buriko
 			switch(callID)
 			{
 				case "ShowAudioSetupMenu":
-					if(MODAudioSet.Instance.HasAudioSetsDefined())
+					if(MODAudioSet.Instance.HasAudioSetsDefined() && !MODAudioSet.Instance.GetCurrentAudioSet(out _))
 					{
 						GameSystem.Instance.MainUIController.modMenu.SetMode(ModMenuMode.AudioSetup);
 						GameSystem.Instance.MainUIController.modMenu.Show();

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -466,7 +466,7 @@ namespace Assets.Scripts.Core.Buriko
 			// OperationMODPlayBGM accepts one extra argument - the GAltBGMflow setting where this bgm should be played
 			int targetBGMFlow = ReadVariable().IntValue();
 
-			MODAudioTracking.Instance.SaveLastAltBGM(targetBGMFlow, new AudioInfo(volume, filename, channel));
+			MODAudioTracking.Instance.SaveLastAltBGM(new MODUtility.OneBasedFlag(targetBGMFlow), new AudioInfo(volume, filename, channel));
 
 			if(BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
 			{
@@ -521,7 +521,7 @@ namespace Assets.Scripts.Core.Buriko
 			FadeBGMCommon(out int channel, out int time, out bool waitForFade);
 			int targetBGMFlow = ReadVariable().IntValue();
 
-			MODAudioTracking.Instance.ForgetLastAltBGM(targetBGMFlow, channel);
+			MODAudioTracking.Instance.ForgetLastAltBGM(new MODUtility.OneBasedFlag(targetBGMFlow), channel);
 
 			if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
 			{

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2766,7 +2766,7 @@ namespace Assets.Scripts.Core.Buriko
 			string callParameters = ReadVariable().StringValue();
 			switch(callID)
 			{
-				case "ShowAudioSetupMenu":
+				case "ShowSetupMenuIfRequired":
 					if(MODAudioSet.Instance.HasAudioSetsDefined() && !MODAudioSet.Instance.GetCurrentAudioSet(out _))
 					{
 						GameSystem.Instance.MainUIController.modMenu.SetMode(ModMenuMode.AudioSetup);

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -466,7 +466,7 @@ namespace Assets.Scripts.Core.Buriko
 			// OperationMODPlayBGM accepts one extra argument - the GAltBGMflow setting where this bgm should be played
 			int targetBGMFlow = ReadVariable().IntValue();
 
-			MODAudioTracking.Instance.SaveLastAltBGM(new MODUtility.OneBasedFlag(targetBGMFlow), new AudioInfo(volume, filename, channel));
+			MODAudioTracking.Instance.SaveLastAltBGM(targetBGMFlow, new AudioInfo(volume, filename, channel));
 
 			if(BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
 			{
@@ -521,7 +521,7 @@ namespace Assets.Scripts.Core.Buriko
 			FadeBGMCommon(out int channel, out int time, out bool waitForFade);
 			int targetBGMFlow = ReadVariable().IntValue();
 
-			MODAudioTracking.Instance.ForgetLastAltBGM(new MODUtility.OneBasedFlag(targetBGMFlow), channel);
+			MODAudioTracking.Instance.ForgetLastAltBGM(targetBGMFlow, channel);
 
 			if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
 			{

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2731,16 +2731,22 @@ namespace Assets.Scripts.Core.Buriko
 			return BurikoVariable.Null;
 		}
 
+		/// <summary>
+		/// Note: Tabs are not supported for descriptions and will be stripped out.
+		/// This is so that you can write multiple line strings in the game script without tabs appearing in the output.
+		/// </summary>
 		public BurikoVariable OperationMODAddAudioset()
 		{
 			SetOperationType("MODAddAudioSet");
 			string nameEN = ReadVariable().StringValue();
+			string descriptionEN = ReadVariable().StringValue();
 			string nameJP = ReadVariable().StringValue();
+			string descriptionJP = ReadVariable().StringValue();
 			int altBGM = ReadVariable().IntValue();
 			int altBGMflow = ReadVariable().IntValue();
 			int altSE = ReadVariable().IntValue();
 			int altSEFlow = ReadVariable().IntValue();
-			MODAudioSet.Instance.AddAudioSet(new AudioSet(nameEN, nameJP, altBGM, altBGMflow, altSE, altSEFlow));
+			MODAudioSet.Instance.AddAudioSet(new AudioSet(nameEN, nameJP, MODUtility.StripTabs(descriptionEN), MODUtility.StripTabs(descriptionJP), altBGM, altBGMflow, altSE, altSEFlow));
 
 			return BurikoVariable.Null;
 		}

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -6,6 +6,7 @@ using Assets.Scripts.Core.Scene;
 using Assets.Scripts.Core.State;
 using Assets.Scripts.UI.Prompt;
 using MOD.Scripts.Core;
+using MOD.Scripts.Core.Audio;
 using MOD.Scripts.Core.Scene;
 using MOD.Scripts.Core.State;
 using MOD.Scripts.UI;
@@ -443,15 +444,35 @@ namespace Assets.Scripts.Core.Buriko
 			return BurikoVariable.Null;
 		}
 
-		private BurikoVariable OperationPlayBGM()
+		private void PlayBGMCommon(out string filename, out int channel, out float volume, out float fadeInTime)
 		{
 			SetOperationType("PlayBGM");
-			int channel = ReadVariable().IntValue();
-			string filename = ReadVariable().StringValue() + ".ogg";
-			int num = ReadVariable().IntValue();
-			int num2 = ReadVariable().IntValue();
-			float volume = (float)num / 128f;
-			AudioController.Instance.PlayAudio(filename, Assets.Scripts.Core.Audio.AudioType.BGM, channel, volume, (float)num2);
+			channel = ReadVariable().IntValue();
+			filename = ReadVariable().StringValue() + ".ogg";
+			volume = (float)ReadVariable().IntValue() / 128f;
+			fadeInTime = (float)ReadVariable().IntValue();
+		}
+
+		private BurikoVariable OperationPlayBGM()
+		{
+			PlayBGMCommon(out string filename, out int channel, out float volume, out float fadeInTime);
+			AudioController.Instance.PlayAudio(filename, Assets.Scripts.Core.Audio.AudioType.BGM, channel, volume, fadeInTime);
+			return BurikoVariable.Null;
+		}
+		private BurikoVariable OperationMODPlayBGM()
+		{
+			PlayBGMCommon(out string filename, out int channel, out float volume, out float fadeInTime);
+
+			// OperationMODPlayBGM accepts one extra argument - the GAltBGMflow setting where this bgm should be played
+			int targetBGMFlow = ReadVariable().IntValue();
+
+			MODAudio.Instance.MODSaveLastAltBGM(targetBGMFlow, new AudioInfo(volume, filename, channel));
+
+			if(BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
+			{
+				AudioController.Instance.PlayAudio(filename, Assets.Scripts.Core.Audio.AudioType.BGM, channel, volume, fadeInTime, noBGMTracking: true);
+			}
+
 			return BurikoVariable.Null;
 		}
 
@@ -473,12 +494,17 @@ namespace Assets.Scripts.Core.Buriko
 			return BurikoVariable.Null;
 		}
 
-		private BurikoVariable OperationFadeOutBGM()
+		private void FadeBGMCommon(out int channel, out int time, out bool waitForFade)
 		{
 			SetOperationType("FadeOutBGM");
-			int channel = ReadVariable().IntValue();
-			int time = ReadVariable().IntValue();
-			bool waitForFade = ReadVariable().BoolValue();
+			channel = ReadVariable().IntValue();
+			time = ReadVariable().IntValue();
+			waitForFade = ReadVariable().BoolValue();
+		}
+
+		private BurikoVariable OperationFadeOutBGM()
+		{
+			FadeBGMCommon(out int channel, out int time, out bool waitForFade);
 			if (gameSystem.IsSkipping)
 			{
 				AudioController.Instance.StopBGM(channel);
@@ -486,6 +512,27 @@ namespace Assets.Scripts.Core.Buriko
 			else
 			{
 				AudioController.Instance.FadeOutBGM(channel, time, waitForFade);
+			}
+			return BurikoVariable.Null;
+		}
+
+		private BurikoVariable OperationMODFadeOutBGM()
+		{
+			FadeBGMCommon(out int channel, out int time, out bool waitForFade);
+			int targetBGMFlow = ReadVariable().IntValue();
+
+			MODAudio.Instance.MODForgetLastAltBGM(targetBGMFlow, channel);
+
+			if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
+			{
+				if (gameSystem.IsSkipping)
+				{
+					AudioController.Instance.StopBGM(channel, noBGMTracking: true);
+				}
+				else
+				{
+					AudioController.Instance.FadeOutBGM(channel, time, waitForFade, noBGMTracking: true);
+				}
 			}
 			return BurikoVariable.Null;
 		}
@@ -2183,6 +2230,10 @@ namespace Assets.Scripts.Core.Buriko
 				return OperationMODRyukishiModeSettingLoad();
 			case BurikoOperations.ModRyukishiSetGuiPosition:
 				return OperationSetRyukishiGuiPosition();
+			case BurikoOperations.ModPlayBGM:
+				return OperationMODPlayBGM();
+			case BurikoOperations.ModFadeOutBGM:
+				return OperationMODFadeOutBGM();
 			default:
 				ScriptError("Unhandled Operation : " + op);
 				return BurikoVariable.Null;

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -466,7 +466,7 @@ namespace Assets.Scripts.Core.Buriko
 			// OperationMODPlayBGM accepts one extra argument - the GAltBGMflow setting where this bgm should be played
 			int targetBGMFlow = ReadVariable().IntValue();
 
-			MODAudio.Instance.MODSaveLastAltBGM(targetBGMFlow, new AudioInfo(volume, filename, channel));
+			MODAudioTracking.Instance.SaveLastAltBGM(targetBGMFlow, new AudioInfo(volume, filename, channel));
 
 			if(BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
 			{
@@ -521,7 +521,7 @@ namespace Assets.Scripts.Core.Buriko
 			FadeBGMCommon(out int channel, out int time, out bool waitForFade);
 			int targetBGMFlow = ReadVariable().IntValue();
 
-			MODAudio.Instance.MODForgetLastAltBGM(targetBGMFlow, channel);
+			MODAudioTracking.Instance.ForgetLastAltBGM(targetBGMFlow, channel);
 
 			if (BurikoMemory.Instance.GetGlobalFlag("GAltBGMflow").IntValue() == targetBGMFlow)
 			{

--- a/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
@@ -1,6 +1,7 @@
 using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Audio;
 using Assets.Scripts.Core.Interfaces;
+using MOD.Scripts.Core.Audio;
 using MOD.Scripts.UI;
 using System;
 using System.Collections.Generic;
@@ -410,6 +411,8 @@ namespace Assets.Scripts.Core.Buriko
 						currentScript.JumpToLineNum(linenum2);
 						memoryManager.LoadMemory(memoryStream);
 						AudioController.Instance.DeSerializeCurrentAudio(memoryStream);
+						// Restoring mod audio state done here to avoid changes being overwritten by above DeSerializeCurrentAudio() call
+						MODAudioTracking.Instance.RestoreState();
 						GameSystem.Instance.SceneController.DeSerializeScene(memoryStream);
 						GameSystem.Instance.ForceReturnNormalState();
 						GameSystem.Instance.CloseChoiceIfExists();

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -521,7 +521,7 @@ namespace Assets.Scripts.UI
 		{
 			if(BurikoSaveManager.lastSaveError != null)
 			{
-				MODMenu.EmergencyModMenu("Error loading save file! Please backup your saves, DISABLE STEAM SYNC, then delete the following save file:", BurikoSaveManager.lastSaveError);
+				MODMenuSupport.EmergencyModMenu("Error loading save file! Please backup your saves, DISABLE STEAM SYNC, then delete the following save file:", BurikoSaveManager.lastSaveError);
 				return;
 			}
 

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -53,7 +53,6 @@ namespace Assets.Scripts.UI
 		private Vector3 unscaledPosition;
 
 		// While this timer is > 0, the current toast will be displayed (in seconds)
-		private MODStyleManager styleManager;
 		public MODMenu modMenu;
 		private MODToaster toaster;
 
@@ -531,19 +530,14 @@ namespace Assets.Scripts.UI
 				return;
 			}
 
-			if(this.styleManager == null)
-			{
-				this.styleManager = new MODStyleManager();
-			}
-
 			if (this.toaster == null)
 			{
-				this.toaster = new MODToaster(this.styleManager);
+				this.toaster = new MODToaster();
 			}
 
 			if (this.modMenu == null)
 			{
-				this.modMenu = new MODMenu(this.gameSystem, this.styleManager);
+				this.modMenu = new MODMenu(this.gameSystem);
 			}
 
 			modMenu.OnGUIFragment();

--- a/Assets.Scripts.UI/MainUIController.cs
+++ b/Assets.Scripts.UI/MainUIController.cs
@@ -787,7 +787,7 @@ namespace Assets.Scripts.UI
 
 		void OnApplicationQuit()
 		{
-			this.modMenu.Hide();
+			this.modMenu.UserHide();
 		}
 
 		/// <summary>

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -177,7 +177,7 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModFadeOutBGM", new OpType(BurikoOperations.ModFadeOutBGM, "iibi"));
 			paramLookup.Add("ModAddBGMset", new OpType(BurikoOperations.ModAddBGMset, "sss"));
 			paramLookup.Add("ModAddSEset", new OpType(BurikoOperations.ModAddSEset, "sss"));
-			paramLookup.Add("ModAddAudioset", new OpType(BurikoOperations.ModAddAudioset, "ssiiii"));
+			paramLookup.Add("ModAddAudioset", new OpType(BurikoOperations.ModAddAudioset, "ssssiiii"));
 			paramLookup.Add("ModGenericCall", new OpType(BurikoOperations.ModGenericCall, "ss"));
 		}
 

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -178,6 +178,7 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModAddBGMset", new OpType(BurikoOperations.ModAddBGMset, "sss"));
 			paramLookup.Add("ModAddSEset", new OpType(BurikoOperations.ModAddSEset, "sss"));
 			paramLookup.Add("ModAddAudioset", new OpType(BurikoOperations.ModAddAudioset, "ssiiii"));
+			paramLookup.Add("ModGenericCall", new OpType(BurikoOperations.ModGenericCall, "ss"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -175,6 +175,9 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModRyukishiSetGuiPosition", new OpType(BurikoOperations.ModRyukishiSetGuiPosition, "ii"));
 			paramLookup.Add("ModPlayBGM", new OpType(BurikoOperations.ModPlayBGM, "isiii"));
 			paramLookup.Add("ModFadeOutBGM", new OpType(BurikoOperations.ModFadeOutBGM, "iibi"));
+			paramLookup.Add("ModAddBGMset", new OpType(BurikoOperations.ModAddBGMset, "sss"));
+			paramLookup.Add("ModAddSEset", new OpType(BurikoOperations.ModAddSEset, "sss"));
+			paramLookup.Add("ModAddAudioset", new OpType(BurikoOperations.ModAddAudioset, "ssiiii"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -173,6 +173,8 @@ namespace BGICompiler.Compiler
 			paramLookup.Add("ModClearArtsets", new OpType(BurikoOperations.ModClearArtsets, string.Empty));
 			paramLookup.Add("ModRyukishiModeSettingLoad", new OpType(BurikoOperations.ModRyukishiModeSettingLoad, "siiiiiiiiiiii"));
 			paramLookup.Add("ModRyukishiSetGuiPosition", new OpType(BurikoOperations.ModRyukishiSetGuiPosition, "ii"));
+			paramLookup.Add("ModPlayBGM", new OpType(BurikoOperations.ModPlayBGM, "isiii"));
+			paramLookup.Add("ModFadeOutBGM", new OpType(BurikoOperations.ModFadeOutBGM, "iibi"));
 		}
 
 		public void ParamCheck(string op, BGIParameters param)

--- a/MOD.Scripts.Core.Audio/MODAudio.cs
+++ b/MOD.Scripts.Core.Audio/MODAudio.cs
@@ -1,0 +1,97 @@
+﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.Audio;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MOD.Scripts.Core.Audio
+{
+	public class MODAudio
+	{
+		private static MODAudio _instance;
+		public static MODAudio Instance => _instance ?? (_instance = new MODAudio());
+
+		// Dictionary of BGMFlow setting -> (Dictionary of channel -> last audio played on that channel by  MODPlayBGM functions))
+		private Dictionary<int, AudioInfo>[] lastAltBGM;
+
+		public bool LoggingEnabled { get; set; } = false;
+
+		private void Log(string text)
+		{
+			if(LoggingEnabled)
+			{
+				Logger.Log(text);
+			}
+		}
+
+		public MODAudio()
+		{
+			lastAltBGM = new Dictionary<int, AudioInfo>[8];
+			for (int i = 0; i < lastAltBGM.Length; i++)
+			{
+				lastAltBGM[i] = new Dictionary<int, AudioInfo>();
+			}
+		}
+
+		private bool flowInRange(int flow) => flow < lastAltBGM.Length;
+
+		public void MODSaveLastBGM(AudioInfo info)
+		{
+			Log($"Saving bgm {info.Filename} channel {info.Channel} all flows");
+			foreach (Dictionary<int, AudioInfo> channelDict in lastAltBGM)
+			{
+				channelDict[info.Channel] = info;
+			}
+		}
+
+		public void MODForgetLastBGM(int channel)
+		{
+			Log($"Forgetting channel {channel} all flows");
+			foreach (Dictionary<int, AudioInfo> channelDict in lastAltBGM)
+			{
+				channelDict.Remove(channel);
+			}
+		}
+
+		public void MODSaveLastAltBGM(int altBGMFlow, AudioInfo info)
+		{
+			Log($"Saving bgm {info.Filename} channel {info.Channel} flow {altBGMFlow}");
+			if (flowInRange(altBGMFlow))
+			{
+				lastAltBGM[altBGMFlow][info.Channel] = info;
+			}
+		}
+
+		public void MODForgetLastAltBGM(int altBGMFlow, int channel)
+		{
+			Log($"Forgetting channel {channel} flow {altBGMFlow}");
+			if (flowInRange(altBGMFlow))
+			{
+				lastAltBGM[altBGMFlow].Remove(channel);
+			}
+		}
+
+		public void MODRestoreBGM(int oldBGMFlow, int newBGMFlow)
+		{
+			Log($"Begin BGM restore...");
+			if (!flowInRange(oldBGMFlow) || !flowInRange(newBGMFlow))
+			{
+				return;
+			}
+
+			// Stop all audio at the current bgm flow
+			foreach (int channel in lastAltBGM[oldBGMFlow].Keys)
+			{
+				Log($"Stop channel {channel}");
+				AudioController.Instance.FadeOutBGM(channel, 500, false, noBGMTracking: true);
+			}
+
+			// Start all audio at the new bgm flow
+			foreach (AudioInfo info in lastAltBGM[newBGMFlow].Values)
+			{
+				Log($"Start channel {info.Channel} file {info.Filename}");
+				AudioController.Instance.PlayAudio(info.Filename, AudioType.BGM, info.Channel, info.Volume, 500, noBGMTracking: true);
+			}
+		}
+	}
+}

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using UnityEngine;
 
 namespace MOD.Scripts.Core.Audio
 {
@@ -56,7 +55,8 @@ namespace MOD.Scripts.Core.Audio
 				return false;
 			}
 
-			bool audioSetInstalled = seCascade.IsInstalled(Application.streamingAssetsPath) && bgmCascade.IsInstalled(Application.streamingAssetsPath);
+			string streamingAssetsPath = UnityEngine.Application.streamingAssetsPath;
+			bool audioSetInstalled = seCascade.IsInstalled(streamingAssetsPath) && bgmCascade.IsInstalled(streamingAssetsPath);
 			isInstalled = audioSetInstalled;
 			return audioSetInstalled;
 		}

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -7,27 +7,28 @@ using System.Text;
 
 namespace MOD.Scripts.Core.Audio
 {
+	class AudioSet
+	{
+		public readonly string nameEN;
+		public readonly string nameJP;
+		public readonly int altBGM;
+		public readonly int altBGMFlow;
+		public readonly int altSE;
+		public readonly int altSEFlow;
+
+		public AudioSet(string nameEN, string nameJP, int altBGM, int altBGMFlow, int altSE, int altSEFlow)
+		{
+			this.nameEN = nameEN;
+			this.nameJP = nameJP;
+			this.altBGM = altBGM;
+			this.altBGMFlow = altBGMFlow;
+			this.altSE = altSE;
+			this.altSEFlow = altSEFlow;
+		}
+	}
+
 	class MODAudioSet
 	{
-		class AudioSet
-		{
-			public readonly string nameEN;
-			public readonly string nameJP;
-			public readonly int altBGM;
-			public readonly int altBGMFlow;
-			public readonly int altSE;
-			public readonly int altSEFlow;
-
-			public AudioSet(string nameEN, string nameJP, int altBGM, int altBGMFlow, int altSE, int altSEFlow)
-			{
-				this.nameEN = nameEN;
-				this.nameJP = nameJP;
-				this.altBGM = altBGM;
-				this.altBGMFlow = altBGMFlow;
-				this.altSE = altSE;
-				this.altSEFlow = altSEFlow;
-			}
-		}
 
 		private static MODAudioSet _instance;
 		public static MODAudioSet Instance => _instance ?? (_instance = new MODAudioSet());
@@ -41,16 +42,11 @@ namespace MOD.Scripts.Core.Audio
 		// This is indexed by the altBGM flag
 		public List<PathCascadeList> BGMCascades { get; private set; } = new List<PathCascadeList>()
 		{
-			new PathCascadeList("April Update", "April Update", new string[] { "BGM" }),
-			new PathCascadeList("Original", "Original", new string[] { "OGBGM" , "BGM" }),
-			new PathCascadeList("Italo", "Italo", new string[] {"ItaloBGM", "OGBGM" , "BGM" }),
 		};
 
 		// This is indexed by the altSE flag
 		public List<PathCascadeList> SECascades { get; private set; } = new List<PathCascadeList>()
 		{
-			new PathCascadeList("April Update", "April Update", new string[] { "SE" }),
-			new PathCascadeList("Original", "Original", new string[] { "OGSE" , "SE" }),
 		};
 
 		public List<PathCascadeList> voiceCascades { get; private set; } = new List<PathCascadeList>()
@@ -58,32 +54,8 @@ namespace MOD.Scripts.Core.Audio
 			new PathCascadeList("PS3", "PS3", new string[] { "voice" }),
 		};
 
-		List<AudioSet> audioSetList = new List<AudioSet>
+		List<AudioSet> audioSets = new List<AudioSet>
 		{
-			new AudioSet(
-				"New BGM/SE",
-				"New BGM/SE",
-				0, //altBGM
-				0, //altBGMFlow
-				0, //altSE
-				0  //altSEFlow
-			),
-			new AudioSet(
-				"Original BGM/SE",
-				"Original BGM/SE",
-				1, //altBGM
-				1, //altBGMFlow
-				1, //altSE
-				1 //altSEFlow
-			),
-			new AudioSet(
-				"Italo BGM Remake",
-				"Italo BGM Remake",
-				2, //altBGM
-				1, //altBGMFlow
-				1, //altSE
-				1  //altSEFlow
-			),
 		};
 
 		public void SetFromZeroBasedIndex(int zeroBasedIndex)
@@ -94,15 +66,15 @@ namespace MOD.Scripts.Core.Audio
 
 		public void Toggle()
 		{
-			int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAudioSet", 1, audioSetList.Count);
+			int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAudioSet", 1, audioSets.Count);
 			ReloadBGMSE(OneToZeroIndexed(newAltBGMFlow));
 		}
 
 		public void ReloadBGMSE(int zeroBasedIndex)
 		{
-			if(zeroBasedIndex < audioSetList.Count)
+			if(zeroBasedIndex < audioSets.Count)
 			{
-				AudioSet selectedAudioSet = audioSetList[zeroBasedIndex];
+				AudioSet selectedAudioSet = audioSets[zeroBasedIndex];
 				BurikoMemory.Instance.SetGlobalFlag("GAltBGM", selectedAudioSet.altBGM);
 				BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", selectedAudioSet.altBGMFlow);
 				BurikoMemory.Instance.SetGlobalFlag("GAltSE", selectedAudioSet.altSE);
@@ -119,13 +91,17 @@ namespace MOD.Scripts.Core.Audio
 
 		public string GetAudioSetNameFromZeroIndexed(int zeroBasedIndex)
 		{
-			return zeroBasedIndex < audioSetList.Count ? audioSetList[zeroBasedIndex].nameEN : $"Unknown BGM/SE {zeroBasedIndex}";
+			return zeroBasedIndex < audioSets.Count ? audioSets[zeroBasedIndex].nameEN : $"Unknown BGM/SE {zeroBasedIndex}";
 		}
 
 		public string GetFlowName(int altBGMFlow)
 		{
 			return altBGMFlow < bgmFlowNames.Count ? bgmFlowNames[altBGMFlow] : $"Unknown BGM/SE {altBGMFlow}";
 		}
+
+		public void AddBGMSet(PathCascadeList cascade) => BGMCascades.Add(cascade);
+		public void AddSESet(PathCascadeList cascade) => SECascades.Add(cascade);
+		public void AddAudioSet(AudioSet audioset) => audioSets.Add(audioset);
 
 		private static int OneToZeroIndexed(int value) => value > 0 ? value - 1 : 0;
 	}

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -1,0 +1,132 @@
+﻿using Assets.Scripts.Core.AssetManagement;
+using Assets.Scripts.Core.Buriko;
+using MOD.Scripts.UI;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MOD.Scripts.Core.Audio
+{
+	class MODAudioSet
+	{
+		class AudioSet
+		{
+			public readonly string nameEN;
+			public readonly string nameJP;
+			public readonly int altBGM;
+			public readonly int altBGMFlow;
+			public readonly int altSE;
+			public readonly int altSEFlow;
+
+			public AudioSet(string nameEN, string nameJP, int altBGM, int altBGMFlow, int altSE, int altSEFlow)
+			{
+				this.nameEN = nameEN;
+				this.nameJP = nameJP;
+				this.altBGM = altBGM;
+				this.altBGMFlow = altBGMFlow;
+				this.altSE = altSE;
+				this.altSEFlow = altSEFlow;
+			}
+		}
+
+		private static MODAudioSet _instance;
+		public static MODAudioSet Instance => _instance ?? (_instance = new MODAudioSet());
+
+		public List<string> bgmFlowNames = new List<string>()
+		{
+			"New BGM/SE",
+			"Original BGM/SE"
+		};
+
+		// This is indexed by the altBGM flag
+		public List<PathCascadeList> BGMCascades { get; private set; } = new List<PathCascadeList>()
+		{
+			new PathCascadeList("April Update", "April Update", new string[] { "BGM" }),
+			new PathCascadeList("Original", "Original", new string[] { "OGBGM" , "BGM" }),
+			new PathCascadeList("Italo", "Italo", new string[] {"ItaloBGM", "OGBGM" , "BGM" }),
+		};
+
+		// This is indexed by the altSE flag
+		public List<PathCascadeList> SECascades { get; private set; } = new List<PathCascadeList>()
+		{
+			new PathCascadeList("April Update", "April Update", new string[] { "SE" }),
+			new PathCascadeList("Original", "Original", new string[] { "OGSE" , "SE" }),
+		};
+
+		public List<PathCascadeList> voiceCascades { get; private set; } = new List<PathCascadeList>()
+		{
+			new PathCascadeList("PS3", "PS3", new string[] { "voice" }),
+		};
+
+		List<AudioSet> audioSetList = new List<AudioSet>
+		{
+			new AudioSet(
+				"New BGM/SE",
+				"New BGM/SE",
+				0, //altBGM
+				0, //altBGMFlow
+				0, //altSE
+				0  //altSEFlow
+			),
+			new AudioSet(
+				"Original BGM/SE",
+				"Original BGM/SE",
+				1, //altBGM
+				1, //altBGMFlow
+				1, //altSE
+				1 //altSEFlow
+			),
+			new AudioSet(
+				"Italo BGM Remake",
+				"Italo BGM Remake",
+				2, //altBGM
+				1, //altBGMFlow
+				1, //altSE
+				1  //altSEFlow
+			),
+		};
+
+		public void SetFromZeroBasedIndex(int zeroBasedIndex)
+		{
+			BurikoMemory.Instance.SetGlobalFlag("GAudioSet", zeroBasedIndex +  1);
+			ReloadBGMSE(zeroBasedIndex);
+		}
+
+		public void Toggle()
+		{
+			int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAudioSet", 1, audioSetList.Count);
+			ReloadBGMSE(OneToZeroIndexed(newAltBGMFlow));
+		}
+
+		public void ReloadBGMSE(int zeroBasedIndex)
+		{
+			if(zeroBasedIndex < audioSetList.Count)
+			{
+				AudioSet selectedAudioSet = audioSetList[zeroBasedIndex];
+				BurikoMemory.Instance.SetGlobalFlag("GAltBGM", selectedAudioSet.altBGM);
+				BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", selectedAudioSet.altBGMFlow);
+				BurikoMemory.Instance.SetGlobalFlag("GAltSE", selectedAudioSet.altSE);
+				BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", selectedAudioSet.altSEFlow);
+				MODAudioTracking.Instance.RestoreBGM(selectedAudioSet.altBGMFlow);
+			}
+		}
+
+		public string GetCurrentAudioSetName(bool includeAudioSetFlag = false)
+		{
+			int audioSetFlag = BurikoMemory.Instance.GetGlobalFlag("GAudioSet").IntValue();
+			return GetAudioSetNameFromZeroIndexed(OneToZeroIndexed(audioSetFlag)) + (includeAudioSetFlag ? $" ({audioSetFlag})" : "");
+		}
+
+		public string GetAudioSetNameFromZeroIndexed(int zeroBasedIndex)
+		{
+			return zeroBasedIndex < audioSetList.Count ? audioSetList[zeroBasedIndex].nameEN : $"Unknown BGM/SE {zeroBasedIndex}";
+		}
+
+		public string GetFlowName(int altBGMFlow)
+		{
+			return altBGMFlow < bgmFlowNames.Count ? bgmFlowNames[altBGMFlow] : $"Unknown BGM/SE {altBGMFlow}";
+		}
+
+		private static int OneToZeroIndexed(int value) => value > 0 ? value - 1 : 0;
+	}
+}

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -112,5 +112,7 @@ namespace MOD.Scripts.Core.Audio
 		}
 
 		private static int OneToZeroIndexed(int value) => value > 0 ? value - 1 : 0;
+
+		public bool HasAudioSets() => audioSets.Count > 0;
 	}
 }

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -44,24 +44,23 @@ namespace MOD.Scripts.Core.Audio
 				return isInstalledBool;
 			}
 
-			// Check this audio set's BGM folder is installed
-			bool bgmInstalled = false;
-			if (MODAudioSet.Instance.GetBGMCascade(altBGM, out PathCascadeList bgmCascade))
+			if(!BGMCascade(out PathCascadeList bgmCascade))
 			{
-				bgmInstalled = MODAudioSet.CascadeInstalled(bgmCascade);
+				return false;
 			}
 
-			// Check this audio set's SE folder is installed
-			bool seInstalled = false;
-			if (MODAudioSet.Instance.GetSECascade(altSE, out PathCascadeList seCascade))
+			if(!SECascade(out PathCascadeList seCascade))
 			{
-				seInstalled = MODAudioSet.CascadeInstalled(seCascade);
+				return false;
 			}
 
-			bool audioSetInstalled = seInstalled && bgmInstalled;
+			bool audioSetInstalled = seCascade.IsInstalled(Application.streamingAssetsPath) && bgmCascade.IsInstalled(Application.streamingAssetsPath);
 			isInstalled = audioSetInstalled;
 			return audioSetInstalled;
 		}
+
+		public bool BGMCascade(out PathCascadeList bgmCascade) => MODAudioSet.Instance.GetBGMCascade(altBGM, out bgmCascade);
+		public bool SECascade(out PathCascadeList seCascade) => MODAudioSet.Instance.GetSECascade(altSE, out seCascade);
 	}
 
 	class MODAudioSet
@@ -183,18 +182,5 @@ namespace MOD.Scripts.Core.Audio
 		private static int OneToZeroIndexed(int value) => value > 0 ? value - 1 : 0;
 
 		public bool HasAudioSetsDefined() => audioSets.Count > 0;
-
-		public static bool CascadeInstalled(PathCascadeList cascade)
-		{
-			if(cascade.paths.Length == 0)
-			{
-				return false;
-			}
-
-			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, cascade.paths[0]));
-		}
-
-
-
 	}
 }

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -11,20 +11,27 @@ namespace MOD.Scripts.Core.Audio
 	{
 		public readonly string nameEN;
 		public readonly string nameJP;
+		public readonly string descriptionEN;
+		public readonly string descriptionJP;
 		public readonly int altBGM;
 		public readonly int altBGMFlow;
 		public readonly int altSE;
 		public readonly int altSEFlow;
 
-		public AudioSet(string nameEN, string nameJP, int altBGM, int altBGMFlow, int altSE, int altSEFlow)
+		public AudioSet(string nameEN, string nameJP, string descriptionEN, string descriptionJP, int altBGM, int altBGMFlow, int altSE, int altSEFlow)
 		{
 			this.nameEN = nameEN;
 			this.nameJP = nameJP;
+			this.descriptionEN = descriptionEN;
+			this.descriptionJP = descriptionJP;
 			this.altBGM = altBGM;
 			this.altBGMFlow = altBGMFlow;
 			this.altSE = altSE;
 			this.altSEFlow = altSEFlow;
 		}
+
+		public string Name(bool getJapanese) => getJapanese ? nameJP : nameEN;
+		public string Description(bool getJapanese) => getJapanese ? descriptionJP : descriptionEN;
 	}
 
 	class MODAudioSet
@@ -85,6 +92,8 @@ namespace MOD.Scripts.Core.Audio
 		{
 			return zeroBasedIndex < audioSets.Count ? audioSets[zeroBasedIndex].nameEN : $"Unknown BGM/SE {zeroBasedIndex}";
 		}
+
+		public List<AudioSet> GetAudioSets() => audioSets;
 
 		public string GetBGMFlowName(int altBGMFlow)
 		{

--- a/MOD.Scripts.Core.Audio/MODAudioSet.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioSet.cs
@@ -33,30 +33,21 @@ namespace MOD.Scripts.Core.Audio
 		private static MODAudioSet _instance;
 		public static MODAudioSet Instance => _instance ?? (_instance = new MODAudioSet());
 
-		public List<string> bgmFlowNames = new List<string>()
+		private readonly List<string> bgmFlowNames = new List<string>()
 		{
 			"New BGM/SE",
 			"Original BGM/SE"
 		};
 
-		// This is indexed by the altBGM flag
-		public List<PathCascadeList> BGMCascades { get; private set; } = new List<PathCascadeList>()
-		{
-		};
+		private readonly PathCascadeList defaultBGMCascade = new PathCascadeList("New BGM", "New BGM", new string[] { "BGM" });
+		private readonly PathCascadeList defaultSECascade = new PathCascadeList("New SE", "New SE", new string[] { "SE" });
+		private readonly PathCascadeList defaultVoiceCascade = new PathCascadeList("PS3", "PS3", new string[] { "voice" });
 
-		// This is indexed by the altSE flag
-		public List<PathCascadeList> SECascades { get; private set; } = new List<PathCascadeList>()
-		{
-		};
+		private readonly List<PathCascadeList> BGMCascades = new List<PathCascadeList>();
+		private readonly List<PathCascadeList> SECascades = new List<PathCascadeList>();
+		private readonly List<PathCascadeList> voiceCascades = new List<PathCascadeList>();
+		private readonly List<AudioSet> audioSets = new List<AudioSet>();
 
-		public List<PathCascadeList> voiceCascades { get; private set; } = new List<PathCascadeList>()
-		{
-			new PathCascadeList("PS3", "PS3", new string[] { "voice" }),
-		};
-
-		List<AudioSet> audioSets = new List<AudioSet>
-		{
-		};
 
 		public void SetFromZeroBasedIndex(int zeroBasedIndex)
 		{
@@ -86,7 +77,8 @@ namespace MOD.Scripts.Core.Audio
 		public string GetCurrentAudioSetName(bool includeAudioSetFlag = false)
 		{
 			int audioSetFlag = BurikoMemory.Instance.GetGlobalFlag("GAudioSet").IntValue();
-			return GetAudioSetNameFromZeroIndexed(OneToZeroIndexed(audioSetFlag)) + (includeAudioSetFlag ? $" ({audioSetFlag})" : "");
+			string name = audioSetFlag == 0 ? "Not Chosen!" : GetAudioSetNameFromZeroIndexed(OneToZeroIndexed(audioSetFlag));
+			return name + (includeAudioSetFlag ? $" ({audioSetFlag})" : "");
 		}
 
 		public string GetAudioSetNameFromZeroIndexed(int zeroBasedIndex)
@@ -94,7 +86,7 @@ namespace MOD.Scripts.Core.Audio
 			return zeroBasedIndex < audioSets.Count ? audioSets[zeroBasedIndex].nameEN : $"Unknown BGM/SE {zeroBasedIndex}";
 		}
 
-		public string GetFlowName(int altBGMFlow)
+		public string GetBGMFlowName(int altBGMFlow)
 		{
 			return altBGMFlow < bgmFlowNames.Count ? bgmFlowNames[altBGMFlow] : $"Unknown BGM/SE {altBGMFlow}";
 		}
@@ -102,6 +94,22 @@ namespace MOD.Scripts.Core.Audio
 		public void AddBGMSet(PathCascadeList cascade) => BGMCascades.Add(cascade);
 		public void AddSESet(PathCascadeList cascade) => SECascades.Add(cascade);
 		public void AddAudioSet(AudioSet audioset) => audioSets.Add(audioset);
+
+		public bool GetBGMCascade(int altBGM, out PathCascadeList cascade) => GetCascade(altBGM, BGMCascades, defaultBGMCascade, out cascade);
+		public bool GetSECascade(int altSE, out PathCascadeList cascade) => GetCascade(altSE, SECascades, defaultSECascade, out cascade);
+		public bool GetVoiceCascade(int altVoice, out PathCascadeList cascade) => GetCascade(altVoice, voiceCascades, defaultVoiceCascade, out cascade);
+
+		private static bool GetCascade(int i, List<PathCascadeList> inputCascades, PathCascadeList defaultCascade, out PathCascadeList cascade)
+		{
+			if(i < inputCascades.Count)
+			{
+				cascade = inputCascades[i];
+				return true;
+			}
+
+			cascade = defaultCascade;
+			return false;
+		}
 
 		private static int OneToZeroIndexed(int value) => value > 0 ? value - 1 : 0;
 	}

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -14,6 +14,7 @@ namespace MOD.Scripts.Core.Audio
 
 		// Dictionary of BGMFlow setting -> (Dictionary of channel -> last audio played on that channel by  MODPlayBGM functions))
 		private Dictionary<int, AudioInfo>[] lastAltBGM;
+		private Dictionary<int, AudioInfo>[] queuedState;
 
 		public bool LoggingEnabled { get; set; } = false;
 
@@ -23,6 +24,30 @@ namespace MOD.Scripts.Core.Audio
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
 				lastAltBGM[i] = new Dictionary<int, AudioInfo>();
+			}
+		}
+
+		public Dictionary<int, AudioInfo>[] SerializeableState()
+		{
+			return lastAltBGM;
+		}
+
+		public void QueueState(Dictionary<int, AudioInfo>[] state)
+		{
+			this.queuedState = state;
+		}
+
+		public void RestoreState()
+		{
+			if(queuedState != null)
+			{
+				for (int i = 0; i < queuedState.Length; i++)
+				{
+					if (flowInRange(i))
+					{
+						lastAltBGM[i] = queuedState[i];
+					}
+				}
 			}
 		}
 

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -20,7 +20,7 @@ namespace MOD.Scripts.Core.Audio
 
 		public MODAudioTracking()
 		{
-			lastAltBGM = new Dictionary<int, AudioInfo>[BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue()];
+			lastAltBGM = new Dictionary<int, AudioInfo>[BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue() + 1];
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
 				lastAltBGM[i] = new Dictionary<int, AudioInfo>();
@@ -79,37 +79,37 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void SaveLastAltBGM(MODUtility.OneBasedFlag altBGMFlow, AudioInfo info)
+		public void SaveLastAltBGM(int altBGMFlow, AudioInfo info)
 		{
 			Log($"Saving bgm {info.Filename} channel {info.Channel} flow {altBGMFlow}");
-			if (flowInRange(altBGMFlow.ZeroBased))
+			if (flowInRange(altBGMFlow))
 			{
-				lastAltBGM[altBGMFlow.ZeroBased][info.Channel] = info;
+				lastAltBGM[altBGMFlow][info.Channel] = info;
 			}
 		}
 
-		public void ForgetLastAltBGM(MODUtility.OneBasedFlag altBGMFlow, int channel)
+		public void ForgetLastAltBGM(int altBGMFlow, int channel)
 		{
 			Log($"Forgetting channel {channel} flow {altBGMFlow}");
-			if (flowInRange(altBGMFlow.ZeroBased))
+			if (flowInRange(altBGMFlow))
 			{
-				lastAltBGM[altBGMFlow.ZeroBased].Remove(channel);
+				lastAltBGM[altBGMFlow].Remove(channel);
 			}
 		}
 
-		public void SetAndSaveBGMSE(MODUtility.OneBasedFlag newBGMSEValue)
+		public void SetAndSaveBGMSE(int newBGMSEValue)
 		{
-			BurikoMemory.Instance.SetGlobalFlag("GAltBGM", newBGMSEValue.OneBased);
-			BurikoMemory.Instance.SetGlobalFlag("GAltSE", newBGMSEValue.OneBased);
-			BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", newBGMSEValue.OneBased);
-			BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", newBGMSEValue.OneBased);
+			BurikoMemory.Instance.SetGlobalFlag("GAltBGM", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltSE", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", newBGMSEValue);
 			RestoreBGM(newBGMSEValue);
 		}
 
-		private void RestoreBGM(MODUtility.OneBasedFlag newBGMFlow)
+		private void RestoreBGM(int newBGMFlow)
 		{
 			Log($"Begin BGM restore...");
-			if (!flowInRange(newBGMFlow.ZeroBased))
+			if (!flowInRange(newBGMFlow))
 			{
 				return;
 			}
@@ -122,19 +122,14 @@ namespace MOD.Scripts.Core.Audio
 			}
 
 			// Start all audio at the new bgm flow
-			foreach (AudioInfo info in lastAltBGM[newBGMFlow.ZeroBased].Values)
+			foreach (AudioInfo info in lastAltBGM[newBGMFlow].Values)
 			{
 				Log($"Start channel {info.Channel} file {info.Filename}");
 				AudioController.Instance.PlayAudio(info.Filename, AudioType.BGM, info.Channel, info.Volume, 500, noBGMTracking: true);
 			}
 		}
 
-		public static string GetBGMNameFromAltBGMFlag(MODUtility.OneBasedFlag altBGMFlag)
-		{
-			return GetBGMNameFromAltBGMFlag(altBGMFlag.ZeroBased);
-		}
-
-		private static string GetBGMNameFromAltBGMFlag(int altBGMFlag)
+		public static string GetBGMNameFromAltBGMFlag(int altBGMFlag)
 		{
 			switch(altBGMFlag)
 			{
@@ -154,7 +149,7 @@ namespace MOD.Scripts.Core.Audio
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
-				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} (flow = {i + 1})\n");
+				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} (flow = {i})\n");
 
 				if (lastAltBGM[i].Count == 0)
 				{

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -125,7 +125,7 @@ namespace MOD.Scripts.Core.Audio
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
-				sb.Append($"{MODAudioSet.Instance.GetFlowName(i)} (set = {i})\n");
+				sb.Append($"{MODAudioSet.Instance.GetBGMFlowName(i)} (set = {i})\n");
 
 				if (lastAltBGM[i].Count == 0)
 				{

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -97,16 +97,7 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void SetAndSaveBGMSE(int newBGMSEValue)
-		{
-			BurikoMemory.Instance.SetGlobalFlag("GAltBGM", newBGMSEValue);
-			BurikoMemory.Instance.SetGlobalFlag("GAltSE", newBGMSEValue);
-			BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", newBGMSEValue);
-			BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", newBGMSEValue);
-			RestoreBGM(newBGMSEValue);
-		}
-
-		private void RestoreBGM(int newBGMFlow)
+		public void RestoreBGM(int newBGMFlow)
 		{
 			Log($"Begin BGM restore...");
 			if (!flowInRange(newBGMFlow))
@@ -129,27 +120,12 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public static string GetBGMNameFromAltBGMFlag(int altBGMFlag)
-		{
-			switch(altBGMFlag)
-			{
-				case 0:
-					return "New BGM/SE";
-
-				case 1:
-					return "Original BGM/SE";
-
-				default:
-					return $"BGM/SE {altBGMFlag}";
-			}
-		}
-
 		public override string ToString()
 		{
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
-				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} (flow = {i})\n");
+				sb.Append($"{MODAudioSet.Instance.GetFlowName(i)} (set = {i})\n");
 
 				if (lastAltBGM[i].Count == 0)
 				{

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -20,7 +20,7 @@ namespace MOD.Scripts.Core.Audio
 
 		public MODAudioTracking()
 		{
-			lastAltBGM = new Dictionary<int, AudioInfo>[BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue() + 1];
+			lastAltBGM = new Dictionary<int, AudioInfo>[BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue()];
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
 				lastAltBGM[i] = new Dictionary<int, AudioInfo>();
@@ -79,37 +79,37 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void SaveLastAltBGM(int altBGMFlow, AudioInfo info)
+		public void SaveLastAltBGM(MODUtility.OneBasedFlag altBGMFlow, AudioInfo info)
 		{
 			Log($"Saving bgm {info.Filename} channel {info.Channel} flow {altBGMFlow}");
-			if (flowInRange(altBGMFlow))
+			if (flowInRange(altBGMFlow.ZeroBased))
 			{
-				lastAltBGM[altBGMFlow][info.Channel] = info;
+				lastAltBGM[altBGMFlow.ZeroBased][info.Channel] = info;
 			}
 		}
 
-		public void ForgetLastAltBGM(int altBGMFlow, int channel)
+		public void ForgetLastAltBGM(MODUtility.OneBasedFlag altBGMFlow, int channel)
 		{
 			Log($"Forgetting channel {channel} flow {altBGMFlow}");
-			if (flowInRange(altBGMFlow))
+			if (flowInRange(altBGMFlow.ZeroBased))
 			{
-				lastAltBGM[altBGMFlow].Remove(channel);
+				lastAltBGM[altBGMFlow.ZeroBased].Remove(channel);
 			}
 		}
 
-		public void SetAndSaveBGMSE(int newBGMSEValue)
+		public void SetAndSaveBGMSE(MODUtility.OneBasedFlag newBGMSEValue)
 		{
-			BurikoMemory.Instance.SetGlobalFlag("GAltBGM", newBGMSEValue);
-			BurikoMemory.Instance.SetGlobalFlag("GAltSE", newBGMSEValue);
-			BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", newBGMSEValue);
-			BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltBGM", newBGMSEValue.OneBased);
+			BurikoMemory.Instance.SetGlobalFlag("GAltSE", newBGMSEValue.OneBased);
+			BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", newBGMSEValue.OneBased);
+			BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", newBGMSEValue.OneBased);
 			RestoreBGM(newBGMSEValue);
 		}
 
-		private void RestoreBGM(int newBGMFlow)
+		private void RestoreBGM(MODUtility.OneBasedFlag newBGMFlow)
 		{
 			Log($"Begin BGM restore...");
-			if (!flowInRange(newBGMFlow))
+			if (!flowInRange(newBGMFlow.ZeroBased))
 			{
 				return;
 			}
@@ -122,14 +122,19 @@ namespace MOD.Scripts.Core.Audio
 			}
 
 			// Start all audio at the new bgm flow
-			foreach (AudioInfo info in lastAltBGM[newBGMFlow].Values)
+			foreach (AudioInfo info in lastAltBGM[newBGMFlow.ZeroBased].Values)
 			{
 				Log($"Start channel {info.Channel} file {info.Filename}");
 				AudioController.Instance.PlayAudio(info.Filename, AudioType.BGM, info.Channel, info.Volume, 500, noBGMTracking: true);
 			}
 		}
 
-		public static string GetBGMNameFromAltBGMFlag(int altBGMFlag)
+		public static string GetBGMNameFromAltBGMFlag(MODUtility.OneBasedFlag altBGMFlag)
+		{
+			return GetBGMNameFromAltBGMFlag(altBGMFlag.ZeroBased);
+		}
+
+		private static string GetBGMNameFromAltBGMFlag(int altBGMFlag)
 		{
 			switch(altBGMFlag)
 			{
@@ -149,7 +154,7 @@ namespace MOD.Scripts.Core.Audio
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
-				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} ({i})\n");
+				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} ({i + 1})\n");
 
 				if (lastAltBGM[i].Count == 0)
 				{

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -154,7 +154,7 @@ namespace MOD.Scripts.Core.Audio
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
-				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} ({i + 1})\n");
+				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} (flow = {i + 1})\n");
 
 				if (lastAltBGM[i].Count == 0)
 				{

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -72,19 +72,28 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void RestoreBGM(int oldBGMFlow, int newBGMFlow)
+		public void SetAndSaveBGMSE(int newBGMSEValue)
+		{
+			BurikoMemory.Instance.SetGlobalFlag("GAltBGM", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltSE", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltBGMflow", newBGMSEValue);
+			BurikoMemory.Instance.SetGlobalFlag("GAltSEflow", newBGMSEValue);
+			RestoreBGM(newBGMSEValue);
+		}
+
+		private void RestoreBGM(int newBGMFlow)
 		{
 			Log($"Begin BGM restore...");
-			if (!flowInRange(oldBGMFlow) || !flowInRange(newBGMFlow))
+			if (!flowInRange(newBGMFlow))
 			{
 				return;
 			}
 
-			// Stop all audio at the current bgm flow
-			foreach (int channel in lastAltBGM[oldBGMFlow].Keys)
+			// Stop all BGM (Currently game only uses BGM channels 0-5, see AudioController.StopAllAudio())
+			Log($"Stopping all BGM");
+			for (int i = 0; i < 6; i++)
 			{
-				Log($"Stop channel {channel}");
-				AudioController.Instance.FadeOutBGM(channel, 500, false, noBGMTracking: true);
+				AudioController.Instance.FadeOutBGM(i, 500, false, noBGMTracking: true);
 			}
 
 			// Start all audio at the new bgm flow
@@ -112,8 +121,13 @@ namespace MOD.Scripts.Core.Audio
 
 		public override string ToString()
 		{
+			if (lastAltBGM.Length == 0)
+			{
+				return " - No BGM Playing on any BGMflow";
+			}
+
 			StringBuilder sb = new StringBuilder();
-			for(int i = 0; i < lastAltBGM.Length; i++)
+			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
 				if (lastAltBGM[i].Count == 0)
 				{
@@ -123,7 +137,7 @@ namespace MOD.Scripts.Core.Audio
 				sb.Append($"{GetBGMNameFromAltBGMFlag(i)}\n");
 				foreach (KeyValuePair<int, AudioInfo> entry in lastAltBGM[i])
 				{
-					sb.Append($"    {entry.Key}: {entry.Value.Filename}\n");
+					sb.Append($"    Ch {entry.Key}: {entry.Value.Filename}\n");
 				}
 			}
 

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -121,23 +121,20 @@ namespace MOD.Scripts.Core.Audio
 
 		public override string ToString()
 		{
-			if (lastAltBGM.Length == 0)
-			{
-				return " - No BGM Playing on any BGMflow";
-			}
-
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < lastAltBGM.Length; i++)
 			{
+				sb.Append($"{GetBGMNameFromAltBGMFlag(i)} ({i})\n");
+
 				if (lastAltBGM[i].Count == 0)
 				{
+					sb.Append("    - Nothing playing\n");
 					continue;
 				}
 
-				sb.Append($"{GetBGMNameFromAltBGMFlag(i)}\n");
 				foreach (KeyValuePair<int, AudioInfo> entry in lastAltBGM[i])
 				{
-					sb.Append($"    Ch {entry.Key}: {entry.Value.Filename}\n");
+					sb.Append($"    - Ch {entry.Key}: {entry.Value.Filename}\n");
 				}
 			}
 

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -1,5 +1,6 @@
 ﻿using Assets.Scripts.Core;
 using Assets.Scripts.Core.Audio;
+using Assets.Scripts.Core.Buriko;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -16,20 +17,20 @@ namespace MOD.Scripts.Core.Audio
 
 		public bool LoggingEnabled { get; set; } = false;
 
+		public MODAudioTracking()
+		{
+			lastAltBGM = new Dictionary<int, AudioInfo>[BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue() + 1];
+			for (int i = 0; i < lastAltBGM.Length; i++)
+			{
+				lastAltBGM[i] = new Dictionary<int, AudioInfo>();
+			}
+		}
+
 		private void Log(string text)
 		{
 			if(LoggingEnabled)
 			{
-				Logger.Log(text);
-			}
-		}
-
-		public MODAudioTracking()
-		{
-			lastAltBGM = new Dictionary<int, AudioInfo>[8];
-			for (int i = 0; i < lastAltBGM.Length; i++)
-			{
-				lastAltBGM[i] = new Dictionary<int, AudioInfo>();
+				Logger.Log($"[MODAudioTracking]: {text}");
 			}
 		}
 
@@ -92,6 +93,41 @@ namespace MOD.Scripts.Core.Audio
 				Log($"Start channel {info.Channel} file {info.Filename}");
 				AudioController.Instance.PlayAudio(info.Filename, AudioType.BGM, info.Channel, info.Volume, 500, noBGMTracking: true);
 			}
+		}
+
+		public static string GetBGMNameFromAltBGMFlag(int altBGMFlag)
+		{
+			switch(altBGMFlag)
+			{
+				case 0:
+					return "New BGM/SE";
+
+				case 1:
+					return "Original BGM/SE";
+
+				default:
+					return $"BGM/SE {altBGMFlag}";
+			}
+		}
+
+		public override string ToString()
+		{
+			StringBuilder sb = new StringBuilder();
+			for(int i = 0; i < lastAltBGM.Length; i++)
+			{
+				if (lastAltBGM[i].Count == 0)
+				{
+					continue;
+				}
+
+				sb.Append($"{GetBGMNameFromAltBGMFlag(i)}\n");
+				foreach (KeyValuePair<int, AudioInfo> entry in lastAltBGM[i])
+				{
+					sb.Append($"    {entry.Key}: {entry.Value.Filename}\n");
+				}
+			}
+
+			return sb.ToString();
 		}
 	}
 }

--- a/MOD.Scripts.Core.Audio/MODAudioTracking.cs
+++ b/MOD.Scripts.Core.Audio/MODAudioTracking.cs
@@ -6,10 +6,10 @@ using System.Text;
 
 namespace MOD.Scripts.Core.Audio
 {
-	public class MODAudio
+	public class MODAudioTracking
 	{
-		private static MODAudio _instance;
-		public static MODAudio Instance => _instance ?? (_instance = new MODAudio());
+		private static MODAudioTracking _instance;
+		public static MODAudioTracking Instance => _instance ?? (_instance = new MODAudioTracking());
 
 		// Dictionary of BGMFlow setting -> (Dictionary of channel -> last audio played on that channel by  MODPlayBGM functions))
 		private Dictionary<int, AudioInfo>[] lastAltBGM;
@@ -24,7 +24,7 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public MODAudio()
+		public MODAudioTracking()
 		{
 			lastAltBGM = new Dictionary<int, AudioInfo>[8];
 			for (int i = 0; i < lastAltBGM.Length; i++)
@@ -35,7 +35,7 @@ namespace MOD.Scripts.Core.Audio
 
 		private bool flowInRange(int flow) => flow < lastAltBGM.Length;
 
-		public void MODSaveLastBGM(AudioInfo info)
+		public void SaveLastBGM(AudioInfo info)
 		{
 			Log($"Saving bgm {info.Filename} channel {info.Channel} all flows");
 			foreach (Dictionary<int, AudioInfo> channelDict in lastAltBGM)
@@ -44,7 +44,7 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void MODForgetLastBGM(int channel)
+		public void ForgetLastBGM(int channel)
 		{
 			Log($"Forgetting channel {channel} all flows");
 			foreach (Dictionary<int, AudioInfo> channelDict in lastAltBGM)
@@ -53,7 +53,7 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void MODSaveLastAltBGM(int altBGMFlow, AudioInfo info)
+		public void SaveLastAltBGM(int altBGMFlow, AudioInfo info)
 		{
 			Log($"Saving bgm {info.Filename} channel {info.Channel} flow {altBGMFlow}");
 			if (flowInRange(altBGMFlow))
@@ -62,7 +62,7 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void MODForgetLastAltBGM(int altBGMFlow, int channel)
+		public void ForgetLastAltBGM(int altBGMFlow, int channel)
 		{
 			Log($"Forgetting channel {channel} flow {altBGMFlow}");
 			if (flowInRange(altBGMFlow))
@@ -71,7 +71,7 @@ namespace MOD.Scripts.Core.Audio
 			}
 		}
 
-		public void MODRestoreBGM(int oldBGMFlow, int newBGMFlow)
+		public void RestoreBGM(int oldBGMFlow, int newBGMFlow)
 		{
 			Log($"Begin BGM restore...");
 			if (!flowInRange(oldBGMFlow) || !flowInRange(newBGMFlow))

--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -10,28 +10,6 @@ using UnityEngine;
 /// </summary>
 public static class MODUtility
 {
-	/// <summary>
-	/// Some flags use "0" to indicate the flag has not been chosen by the user, and values 1 onwards as the actual flag value.
-	/// This class helps ensure 1-based flags are used correctly though type-checking and reusable conversion functions
-	/// </summary>
-	public class OneBasedFlag
-	{
-		public int OneBased { get; }
-
-		public OneBasedFlag(int OneBased)
-		{
-			this.OneBased = OneBased;
-		}
-
-		/// <summary>
-		/// Get the value of the flag if it were a 0-based value
-		/// If the 1-based value is 0, this function just returns 0
-		/// </summary>
-		public int ZeroBased => OneBased > 0 ? OneBased - 1 : 0;
-
-		public static OneBasedFlag FromZeroBased(int zeroBased) => new OneBasedFlag(zeroBased + 1);
-	}
-
 	public enum Platform
 	{
 		Windows,

--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -10,6 +10,28 @@ using UnityEngine;
 /// </summary>
 public static class MODUtility
 {
+	/// <summary>
+	/// Some flags use "0" to indicate the flag has not been chosen by the user, and values 1 onwards as the actual flag value.
+	/// This class helps ensure 1-based flags are used correctly though type-checking and reusable conversion functions
+	/// </summary>
+	public class OneBasedFlag
+	{
+		public int OneBased { get; }
+
+		public OneBasedFlag(int OneBased)
+		{
+			this.OneBased = OneBased;
+		}
+
+		/// <summary>
+		/// Get the value of the flag if it were a 0-based value
+		/// If the 1-based value is 0, this function just returns 0
+		/// </summary>
+		public int ZeroBased => OneBased > 0 ? OneBased - 1 : 0;
+
+		public static OneBasedFlag FromZeroBased(int zeroBased) => new OneBasedFlag(zeroBased + 1);
+	}
+
 	public enum Platform
 	{
 		Windows,

--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -106,4 +106,6 @@ public static class MODUtility
 				return Platform.Windows;
 		}
 	}
+
+	public static string StripTabs(string s) => s.Replace("\t", "");
 }

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -377,10 +377,6 @@ namespace MOD.Scripts.UI
 		{
 			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, "OGBackgrounds"));
 		}
-		public static bool HasMusicToggle()
-		{
-			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, "OGBGM"));
-		}
 
 		public static void ToggleFlagMenu()
 		{

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -381,5 +381,11 @@ namespace MOD.Scripts.UI
 		{
 			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, "OGBGM"));
 		}
+
+		public static void ToggleFlagMenu()
+		{
+			int maxFlagMonitorValue = BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 0 ? 2 : 4;
+			IncrementLocalFlagWithRollover("LFlagMonitor", 0, maxFlagMonitorValue);
+		}
 	}
 }

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -377,5 +377,9 @@ namespace MOD.Scripts.UI
 		{
 			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, "OGBackgrounds"));
 		}
+		public static bool HasMusicToggle()
+		{
+			return Directory.Exists(Path.Combine(Application.streamingAssetsPath, "OGBGM"));
+		}
 	}
 }

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -217,9 +217,10 @@ namespace MOD.Scripts.UI
 
 				case Action.AltBGMFlow:
 					{
-						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
-						MODAudioTracking.Instance.SetAndSaveBGMSE(newAltBGMFlow);
-						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newAltBGMFlow)} ({newAltBGMFlow})");
+						int newBGMFlowInt = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", 1, BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue());
+						MODUtility.OneBasedFlag newBGMFlow = new MODUtility.OneBasedFlag(newBGMFlowInt);
+						MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMFlow);
+						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newBGMFlow)} ({newBGMFlow.OneBased})");
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -320,7 +320,7 @@ namespace MOD.Scripts.UI
 			{
 				if (action == Action.ModMenu)
 				{
-					GameSystem.Instance.MainUIController.modMenu.ToggleVisibility();
+					GameSystem.Instance.MainUIController.modMenu.UserToggleVisibility();
 				}
 				else
 				{

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -227,9 +227,8 @@ namespace MOD.Scripts.UI
 
 				case Action.AltBGMFlow:
 					{
-						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
-						MODAudioTracking.Instance.SetAndSaveBGMSE(newAltBGMFlow);
-						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newAltBGMFlow)} ({newAltBGMFlow})");
+						MODAudioSet.Instance.Toggle();
+						MODToaster.Show(MODAudioSet.Instance.GetCurrentAudioSetName(includeAudioSetFlag: true));
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -307,7 +307,7 @@ namespace MOD.Scripts.UI
 				case Action.ToggleAudioSet:
 					{
 						MODAudioSet.Instance.Toggle();
-						MODToaster.Show(MODAudioSet.Instance.GetCurrentAudioSetName(includeAudioSetFlag: true));
+						MODToaster.Show(MODAudioSet.Instance.GetCurrentAudioSetDisplayName(includeAudioSetFlag: true));
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -1,5 +1,6 @@
 ﻿using Assets.Scripts.Core;
 using Assets.Scripts.Core.Buriko;
+using MOD.Scripts.Core.Audio;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -217,7 +218,8 @@ namespace MOD.Scripts.UI
 				case Action.AltBGMFlow:
 					{
 						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
-						MODToaster.Show($"Alt BGM Flow: {newAltBGMFlow} (Not Used)", numberedSound: newAltBGMFlow);
+						MODAudioTracking.Instance.SetAndSaveBGMSE(newAltBGMFlow);
+						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newAltBGMFlow)} ({newAltBGMFlow})", numberedSound: newAltBGMFlow);
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -121,19 +121,23 @@ namespace MOD.Scripts.UI
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
 			{
-				return Action.AltBGM;
+				// Uncomment this if the user needs to be able to individually select AltBGM, separate from AltBGMFlow
+				// return Action.AltBGM;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
 			{
+				// TODO: make bgmflow hotkey harder to press?
 				return Action.AltBGMFlow;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3))
 			{
-				return Action.AltSE;
+				// Uncomment this if the user needs to be able to individually select AltSE, separate from AltBGMFlow
+				// return Action.AltSE;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha4) || Input.GetKeyDown(KeyCode.Keypad4))
 			{
-				return Action.AltSEFlow;
+				// Uncomment this if the user needs to be able to individually select AltSEFlow, separate from AltBGMFlow
+				// return Action.AltSEFlow;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha5) || Input.GetKeyDown(KeyCode.Keypad5))
 			{

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -227,10 +227,9 @@ namespace MOD.Scripts.UI
 
 				case Action.AltBGMFlow:
 					{
-						int newBGMFlowInt = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", 1, BurikoMemory.Instance.GetGlobalFlag("GAltBGMflowMaxNum").IntValue());
-						MODUtility.OneBasedFlag newBGMFlow = new MODUtility.OneBasedFlag(newBGMFlowInt);
-						MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMFlow);
-						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newBGMFlow)} ({newBGMFlow.OneBased})");
+						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
+						MODAudioTracking.Instance.SetAndSaveBGMSE(newAltBGMFlow);
+						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newAltBGMFlow)} ({newAltBGMFlow})");
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -71,6 +71,7 @@ namespace MOD.Scripts.UI
 			ToggleArtStyle,
 			DebugMode,
 			RestoreSettings,
+			ToggleAudioSet,
 		}
 
 		private static Action? GetUserAction()
@@ -131,8 +132,7 @@ namespace MOD.Scripts.UI
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
 			{
-				// TODO: make bgmflow hotkey harder to press?
-				return Action.AltBGMFlow;
+				return Action.ToggleAudioSet;
 			}
 			else if (Input.GetKeyDown(KeyCode.Alpha3) || Input.GetKeyDown(KeyCode.Keypad3))
 			{
@@ -227,8 +227,8 @@ namespace MOD.Scripts.UI
 
 				case Action.AltBGMFlow:
 					{
-						MODAudioSet.Instance.Toggle();
-						MODToaster.Show(MODAudioSet.Instance.GetCurrentAudioSetName(includeAudioSetFlag: true));
+						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
+						MODToaster.Show($"Alt BGM Flow: {newAltBGMFlow} (Not Used)", numberedSound: newAltBGMFlow);
 					}
 					break;
 
@@ -301,6 +301,13 @@ namespace MOD.Scripts.UI
 					{
 						int restoreGameSettingsNum = MODActions.IncrementGlobalFlagWithRollover("GMOD_SETTING_LOADER", 0, 3);
 						MODToaster.Show($"Reset Settings: {restoreGameSettingsNum} (see F10 menu)", numberedSound: restoreGameSettingsNum);
+					}
+					break;
+
+				case Action.ToggleAudioSet:
+					{
+						MODAudioSet.Instance.Toggle();
+						MODToaster.Show(MODAudioSet.Instance.GetCurrentAudioSetName(includeAudioSetFlag: true));
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -219,7 +219,7 @@ namespace MOD.Scripts.UI
 					{
 						int newAltBGMFlow = MODActions.IncrementGlobalFlagWithRollover("GAltBGMflow", "GAltBGMflowMaxNum");
 						MODAudioTracking.Instance.SetAndSaveBGMSE(newAltBGMFlow);
-						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newAltBGMFlow)} ({newAltBGMFlow})", numberedSound: newAltBGMFlow);
+						MODToaster.Show($"{MODAudioTracking.GetBGMNameFromAltBGMFlag(newAltBGMFlow)} ({newAltBGMFlow})");
 					}
 					break;
 

--- a/MOD.Scripts.UI/MODKeyboardShortcuts.cs
+++ b/MOD.Scripts.UI/MODKeyboardShortcuts.cs
@@ -52,6 +52,7 @@ namespace MOD.Scripts.UI
 			ToggleADV,
 			CensorshipLevel,
 			EffectLevel,
+			DebugMenu,
 			FlagMonitor,
 			ModMenu,
 			OpeningVideo,
@@ -77,7 +78,11 @@ namespace MOD.Scripts.UI
 			// These take priority over the non-shift key buttons
 			if (Input.GetKey(KeyCode.LeftShift))
 			{
-				if (Input.GetKeyDown(KeyCode.F10))
+				if (Input.GetKeyDown(KeyCode.F9))
+				{
+					return Action.DebugMenu;
+				}
+				else if (Input.GetKeyDown(KeyCode.F10))
 				{
 					return Action.FlagMonitor;
 				}
@@ -192,11 +197,12 @@ namespace MOD.Scripts.UI
 					}
 					break;
 
+				case Action.DebugMenu:
+					GameSystem.Instance.MainUIController.modMenu.ToggleDebugMenu();
+					break;
+
 				case Action.FlagMonitor:
-					{
-						int maxFlagMonitorValue = BurikoMemory.Instance.GetGlobalFlag("GMOD_DEBUG_MODE").IntValue() == 0 ? 2 : 4;
-						MODActions.IncrementLocalFlagWithRollover("LFlagMonitor", 0, maxFlagMonitorValue);
-					}
+					MODActions.ToggleFlagMenu();
 					break;
 
 				case Action.OpeningVideo:

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -76,7 +76,8 @@ namespace MOD.Scripts.UI
 		private string screenHeightString;
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
-		Vector2 debugScrollPosition;
+		Vector2 leftDebugColumnScrollPosition;
+		Vector2 rightDebugColumnScrollPosition;
 		private static Vector2 emergencyMenuScrollPosition;
 		private bool hasOGBackgrounds;
 		private bool hasBGMSEOptions;
@@ -261,13 +262,22 @@ Sets the script censorship level
 		{
 			if (showDebugInfo && AssetManager.Instance != null)
 			{
-				GUILayout.BeginArea(new Rect(0, 0, Screen.width, Screen.height/4), styleManager.modMenuAreaStyleLight);
-				debugScrollPosition = GUILayout.BeginScrollView(debugScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
-				GUILayout.Label($"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Path: {AssetManager.Instance.debugLastBGM}", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Path: {AssetManager.Instance.debugLastSE}", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Path: {AssetManager.Instance.debugLastVoice}", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"Other Path: {AssetManager.Instance.debugLastOtherAudio}", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"--- BGM Info ---\n{MODAudioTracking.Instance}");
+				// Left debug column
+				GUILayout.BeginArea(new Rect(0, 0, Screen.width/2, Screen.height / 4), styleManager.modMenuAreaStyleLight);
+				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
+				GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
+				GUILayout.EndScrollView();
+				GUILayout.EndArea();
+
+
+				// Right debug column
+				GUILayout.BeginArea(new Rect(Screen.width / 2, 0, Screen.width/2, Screen.height/4), styleManager.modMenuAreaStyleLight);
+				rightDebugColumnScrollPosition = GUILayout.BeginScrollView(rightDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
+				GUILayout.Label($"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Last Played Path: {AssetManager.Instance.debugLastBGM}\n" +
+					$"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Last Played Path: {AssetManager.Instance.debugLastSE}\n" +
+					$"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Last Played Path: {AssetManager.Instance.debugLastVoice}\n" +
+					$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}",
+					styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.EndScrollView();
 				GUILayout.EndArea();
 			}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -76,6 +76,7 @@ namespace MOD.Scripts.UI
 		private string screenHeightString;
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
+		Vector2 debugScrollPosition;
 		private static Vector2 emergencyMenuScrollPosition;
 		private bool hasOGBackgrounds;
 		private bool hasBGMSEOptions;
@@ -260,11 +261,14 @@ Sets the script censorship level
 		{
 			if (showDebugInfo && AssetManager.Instance != null)
 			{
-				GUILayout.BeginArea(new Rect(0, 0, Screen.width, Screen.height/7), styleManager.modMenuAreaStyleLight);
+				GUILayout.BeginArea(new Rect(0, 0, Screen.width, Screen.height/4), styleManager.modMenuAreaStyleLight);
+				debugScrollPosition = GUILayout.BeginScrollView(debugScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
 				GUILayout.Label($"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Path: {AssetManager.Instance.debugLastBGM}", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Path: {AssetManager.Instance.debugLastSE}", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Path: {AssetManager.Instance.debugLastVoice}", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"Other Path: {AssetManager.Instance.debugLastOtherAudio}", styleManager.Group.upperLeftHeadingLabel);
+				GUILayout.Label(MODAudioTracking.Instance.ToString());
+				GUILayout.EndScrollView();
 				GUILayout.EndArea();
 			}
 
@@ -510,6 +514,7 @@ Sets the script censorship level
 					if (Button(new GUIContent("Toggle debug menu", "Toggle the debug menu - mainly for developer use.")))
 					{
 						showDebugInfo = !showDebugInfo;
+						MODAudioTracking.Instance.LoggingEnabled = showDebugInfo;
 					}
 
 					GUILayout.EndScrollView();

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -104,7 +104,7 @@ You can try the following yourself to fix the issue.
 
 			if (!visible)
 			{
-				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width / 3), GUILayout.Height(Screen.height - 10));
+				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width / 3), GUILayout.Height(Screen.height*9/10));
 			}
 			GUILayout.Label($"[Audio Tracking] - indicates what would play on each BGM flow", styleManager.Group.upperLeftHeadingLabel);
 			GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
@@ -145,7 +145,7 @@ You can try the following yourself to fix the issue.
 				GUILayout.EndScrollView();
 			}
 
-			GUI.DragWindow(new Rect(0, 0, 10000, 40));
+			GUI.DragWindow(new Rect(0, 0, 10000, 10000));
 		}
 
 		/// <summary>
@@ -157,7 +157,7 @@ You can try the following yourself to fix the issue.
 
 			if (debug && AssetManager.Instance != null)
 			{
-				debugWindowRect = GUILayout.Window(DEBUG_WINDOW_ID, debugWindowRect, OnGUIDebugWindow, "Developer Debug Window", styleManager.modMenuAreaStyleLight);
+				debugWindowRect = GUILayout.Window(DEBUG_WINDOW_ID, debugWindowRect, OnGUIDebugWindow, "Developer Debug Window (click to drag)", styleManager.modMenuAreaStyleLight);
 			}
 
 			GUI.depth = 0;
@@ -177,6 +177,7 @@ You can try the following yourself to fix the issue.
 			{
 				this.startupFailed = false;
 			}
+
 			// Button to open the Mod Menu on the Config Screen
 			if (gameSystem.GameState == GameState.ConfigScreen)
 			{
@@ -220,14 +221,17 @@ You can try the following yourself to fix the issue.
 				float areaPosX = Screen.width / 2 - totalAreaWidth / 2;
 				float areaPosY = Screen.height / 2 - areaHeight / 2;
 
-				float toolTipPosX = areaPosX + areaWidth;
+				float toolTipPosX = areaWidth;
 
 				float exitButtonWidth = toolTipWidth * .1f;
 				float exitButtonHeight = areaHeight * .05f;
 
+				float innerMargin = 4f;
+
 				// Radio buttons
+				GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth + toolTipWidth, areaHeight), styleManager.modMenuAreaStyle);
 				{
-					GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modMenuAreaStyle);
+					GUILayout.BeginArea(new Rect(innerMargin, innerMargin, areaWidth-innerMargin, areaHeight-innerMargin), styleManager.modGUIBackgroundTextureTransparent);
 					// Note: GUILayout.Height is adjusted to be slightly smaller, otherwise not all content is visible/scroll bar is slightly cut off.
 					scrollPosition = GUILayout.BeginScrollView(scrollPosition, GUILayout.Width(areaWidth), GUILayout.Height(areaHeight-10));
 
@@ -238,53 +242,56 @@ You can try the following yourself to fix the issue.
 				}
 
 				// Descriptions for each button are shown on hover, like a tooltip
-				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modMenuAreaStyle);
-				c.HeadingLabel(currentMenu.Heading());
-				GUILayout.Space(10);
-
-				GUIStyle toolTipStyle = styleManager.Group.label;
-				string displayedToolTip;
-				if (GUI.tooltip == String.Empty)
 				{
-					if (defaultToolTipTimer.timeLeft == 0)
+					GUILayout.BeginArea(new Rect(toolTipPosX, innerMargin, toolTipWidth- innerMargin, areaHeight-innerMargin), styleManager.modGUIBackgroundTextureTransparent);
+					c.HeadingLabel(currentMenu.Heading());
+					GUILayout.Space(10);
+
+					GUIStyle toolTipStyle = styleManager.Group.label;
+					string displayedToolTip;
+					if (GUI.tooltip == String.Empty)
 					{
-						if(this.startupFailed)
+						if (defaultToolTipTimer.timeLeft == 0)
 						{
-							displayedToolTip = startupFailureToolTip;
-							toolTipStyle = styleManager.Group.errorLabel;
+							if (this.startupFailed)
+							{
+								displayedToolTip = startupFailureToolTip;
+								toolTipStyle = styleManager.Group.errorLabel;
+							}
+							else
+							{
+								displayedToolTip = currentMenu.DefaultTooltip();
+							}
 						}
 						else
 						{
-							displayedToolTip = currentMenu.DefaultTooltip();
+							displayedToolTip = lastToolTip;
 						}
 					}
 					else
 					{
-						displayedToolTip = lastToolTip;
+						lastToolTip = GUI.tooltip;
+						displayedToolTip = GUI.tooltip;
+						defaultToolTipTimer.Start(.2f);
 					}
-				}
-				else
-				{
-					lastToolTip = GUI.tooltip;
-					displayedToolTip = GUI.tooltip;
-					defaultToolTipTimer.Start(.2f);
-				}
-				// MUST pass in MinHeight option, otherwise Unity will get confused and assume
-				// label is one line high on first draw, and subsequent changes will truncate
-				// label to one line even if it is multiple lines tall.
-				GUILayout.Label(displayedToolTip, toolTipStyle, GUILayout.MinHeight(areaHeight));
-				GUILayout.EndArea();
-
-				// Exit button
-				if (currentMenu.UserCanClose())
-				{
-					GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth, areaPosY, exitButtonWidth, exitButtonHeight));
-					if (c.Button(new GUIContent("X", "Close the Mod menu")))
-					{
-						this.UserHide();
-					}
+					// MUST pass in MinHeight option, otherwise Unity will get confused and assume
+					// label is one line high on first draw, and subsequent changes will truncate
+					// label to one line even if it is multiple lines tall.
+					GUILayout.Label(displayedToolTip, toolTipStyle, GUILayout.MinHeight(areaHeight));
 					GUILayout.EndArea();
+
+					// Exit button
+					if (currentMenu.UserCanClose())
+					{
+						GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth - innerMargin, innerMargin, exitButtonWidth, exitButtonHeight));
+						if (c.Button(new GUIContent("X", "Close the Mod menu")))
+						{
+							this.UserHide();
+						}
+						GUILayout.EndArea();
+					}
 				}
+				GUILayout.EndArea();
 
 				if(MODRadio.anyRadioPressed || anyButtonPressed)
 				{

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -417,10 +417,10 @@ Sets the script censorship level
 
 					if (this.hasBGMSEOptions)
 					{
-						int zeroIndexed = new MODUtility.OneBasedFlag(GetGlobal("GAltBGMflow")).ZeroBased;
-						if (this.radioBGMSESet.OnGUIFragment(zeroIndexed) is int newBGMSEZeroIndexed)
+						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
+						if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
 						{
-							MODAudioTracking.Instance.SetAndSaveBGMSE(MODUtility.OneBasedFlag.FromZeroBased(newBGMSEZeroIndexed));
+							MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMSEValue);
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -107,7 +107,8 @@ F10 : Mod Menu
 M : Increase Voice Volume
 N : Decrease Voice Volume
 P : Cycle through art styles
-7 : Lip-Sync
+2 : Cycle through BGM/SE
+7 : Enable/Disable Lip-Sync
 LShift + M : Voice Volume MAX
 LShift + N : Voice Volume MIN";
 
@@ -154,7 +155,7 @@ Sets the script censorship level
   - 2: Default - most balanced option
   - 0: Original PC Script with voices where it fits (least uncensored), but uncensored scenes may be missing voices";
 
-			this.radioCensorshipLevel = new MODRadio("Voice Matching Level", new GUIContent[] {
+			this.radioCensorshipLevel = new MODRadio("Voice Matching Level (Hotkey: F2)", new GUIContent[] {
 				new GUIContent("0", "Censorship level 0 - Equivalent to PC" + baseCensorshipDescription),
 				new GUIContent("1", "Censorship level 1" + baseCensorshipDescription),
 				new GUIContent("2*", "Censorship level 2 (this is the default/recommended value)" + baseCensorshipDescription),
@@ -163,13 +164,13 @@ Sets the script censorship level
 				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
 				}, styleManager);
 
-			this.radioLipSync = new MODRadio("Lip Sync for Console Sprites", new GUIContent[]
+			this.radioLipSync = new MODRadio("Lip Sync for Console Sprites (Hotkey: 7)", new GUIContent[]
 			{
 				new GUIContent("Lip Sync Off", "Disables Lip Sync for Console Sprites"),
 				new GUIContent("Lip Sync On", "Enables Lip Sync for Console Sprites"),
 			}, styleManager);
 
-			this.radioOpenings = new MODRadio("Opening Movies", new GUIContent[]
+			this.radioOpenings = new MODRadio("Opening Movies (Hotkey: Shift-F12)", new GUIContent[]
 			{
 				new GUIContent("Disabled", "Disables all opening videos"),
 				new GUIContent("Enabled", "Enables opening videos\n\n" +
@@ -196,10 +197,11 @@ Sets the script censorship level
 				"WARNING: When using this option, you should have ADV/NVL mode selected, otherwise sprites will be cut off, and UI will appear in the wrong place"),
 			}, styleManager, itemsPerRow: 2);
 
-			this.radioBGMSESet = new MODRadio("Choose BGM/SE", new GUIContent[]
+			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[]
 			{
-				new GUIContent("New BGM/SE", "Enable the new BGM/SE introduced by MangaGamer in the April 2019 update."),
-				new GUIContent("Original BGM/SE", "Enable the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'."),
+				new GUIContent("New BGM/SE", "Use the new BGM/SE introduced by MangaGamer in the April 2019 update."),
+				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
+				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
 			}, styleManager);
 
 			// Start the watchdog timer as soon as possible, so it starts from "when the game started"
@@ -360,7 +362,7 @@ Sets the script censorship level
 
 					HeadingLabel("Basic Options");
 
-					Label("Graphics Presets");
+					Label("Graphics Presets (Hotkey: F1)");
 					{
 						GUILayout.BeginHorizontal();
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -263,6 +263,7 @@ Sets the script censorship level
 				// Left debug column
 				GUILayout.BeginArea(new Rect(0, 0, Screen.width/2, Screen.height / 4), styleManager.modMenuAreaStyleLight);
 				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
+				GUILayout.Label($"[Audio Tracking] - indicates what would play on each BGM flow", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.EndScrollView();
 				GUILayout.EndArea();
@@ -271,6 +272,7 @@ Sets the script censorship level
 				// Right debug column
 				GUILayout.BeginArea(new Rect(Screen.width / 2, 0, Screen.width/2, Screen.height/4), styleManager.modMenuAreaStyleLight);
 				rightDebugColumnScrollPosition = GUILayout.BeginScrollView(rightDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
+				GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Last Played Path: {AssetManager.Instance.debugLastBGM}\n" +
 					$"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Last Played Path: {AssetManager.Instance.debugLastSE}\n" +
 					$"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Last Played Path: {AssetManager.Instance.debugLastVoice}\n" +
@@ -515,11 +517,16 @@ Sets the script censorship level
 					ShowSupportButtons(content => Button(content));
 
 					Label("Developer");
-					if (Button(new GUIContent("Toggle debug menu", "Toggle the debug menu - mainly for developer use.")))
+					GUILayout.BeginHorizontal();
+					if (Button(new GUIContent("Toggle debug menu (Shift-F9)", "Toggle the debug menu")))
 					{
-						showDebugInfo = !showDebugInfo;
-						MODAudioTracking.Instance.LoggingEnabled = showDebugInfo;
+						ToggleDebugMenu();
 					}
+					if (Button(new GUIContent("Toggle flag menu (Shift-F10)", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.")))
+					{
+						MODActions.ToggleFlagMenu();
+					}
+					GUILayout.EndHorizontal();
 
 					GUILayout.EndScrollView();
 					GUILayout.EndArea();
@@ -733,6 +740,12 @@ Sets the script censorship level
 			{
 				Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
 			}
+		}
+
+		public void ToggleDebugMenu()
+		{
+			showDebugInfo = !showDebugInfo;
+			MODAudioTracking.Instance.LoggingEnabled = showDebugInfo;
 		}
 
 	}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
 
 namespace MOD.Scripts.UI
 {
@@ -22,8 +23,6 @@ namespace MOD.Scripts.UI
 	{
 		private const int DEBUG_WINDOW_ID = 1;
 
-		private readonly MODStyleManager styleManager;
-		private readonly MODMenuCommon c;
 		private readonly GameSystem gameSystem;
 		public bool visible;
 		public bool debug;
@@ -58,24 +57,22 @@ You can try the following yourself to fix the issue.
 
   4. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.";
 
-		public MODMenu(GameSystem gameSystem, MODStyleManager styleManager)
+		public MODMenu(GameSystem gameSystem)
 		{
 			this.gameSystem = gameSystem;
-			this.styleManager = styleManager;
 			this.visible = false;
 			this.debug = false;
 			this.lastMenuVisibleStatus = false;
 			this.defaultToolTipTimer = new MODSimpleTimer();
 			this.startupWatchdogTimer = new MODSimpleTimer();
 			this.startupFailed = false;
-			this.c = new MODMenuCommon(styleManager);
 
 			// Start the watchdog timer as soon as possible, so it starts from "when the game started"
 			this.startupWatchdogTimer.Start(5.0f);
 
-			this.audioOptionsMenu = new MODMenuAudioOptions(this, this.c, styleManager);
-			this.normalMenu = new MODMenuNormal(this, this.c, styleManager, this.audioOptionsMenu);
-			this.audioSetupMenu = new MODMenuAudioSetup(this, this.c, this.audioOptionsMenu);
+			this.audioOptionsMenu = new MODMenuAudioOptions(this);
+			this.normalMenu = new MODMenuNormal(this, this.audioOptionsMenu);
+			this.audioSetupMenu = new MODMenuAudioSetup(this, this.audioOptionsMenu);
 			this.currentMenu = this.normalMenu;
 
 			this.debugWindowRect = new Rect(0, 0, Screen.width / 3, Screen.height - 50);
@@ -97,10 +94,11 @@ You can try the following yourself to fix the issue.
 
 		private void OnGUIDebugWindow(int windowID)
 		{
+			MODStyleManager styleManager = MODStyleManager.OnGUIInstance;
 			GUI.depth = 1;
 
-			bool bgmFlagOK = MODAudioSet.Instance.GetBGMCascade(c.GetGlobal("GAltBGM"), out PathCascadeList BGMCascade);
-			bool seFlagOK = MODAudioSet.Instance.GetSECascade(c.GetGlobal("GAltSE"), out PathCascadeList SECascade);
+			bool bgmFlagOK = MODAudioSet.Instance.GetBGMCascade(GetGlobal("GAltBGM"), out PathCascadeList BGMCascade);
+			bool seFlagOK = MODAudioSet.Instance.GetSECascade(GetGlobal("GAltSE"), out PathCascadeList SECascade);
 
 			if (!visible)
 			{
@@ -110,32 +108,32 @@ You can try the following yourself to fix the issue.
 			GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
 
 			GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
-			GUILayout.Label($"Audio Set: {c.GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetDisplayName()})\n" +
+			GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetDisplayName()})\n" +
 				"\n" +
-				$"AltBGM: {c.GetGlobal("GAltBGM")}\n" +
-				$"AltBGMFlow: {c.GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(c.GetGlobal("GAltBGMflow"))})\n" +
+				$"AltBGM: {GetGlobal("GAltBGM")}\n" +
+				$"AltBGMFlow: {GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(GetGlobal("GAltBGMflow"))})\n" +
 				$"Last Played BGM: {AssetManager.Instance.debugLastBGM}\n" +
 				$"BGM Cascade: [{string.Join(":", BGMCascade.paths)}] ({BGMCascade.nameEN}) {(bgmFlagOK ? "" : "9Warning: Using default due to unknown flag)")}\n" +
 				"\n" +
-				$"AltSE:  {c.GetGlobal("GAltSE")}\n" +
-				$"AltSEFlow: {c.GetGlobal("GAltSEflow")}\n" +
+				$"AltSE:  {GetGlobal("GAltSE")}\n" +
+				$"AltSEFlow: {GetGlobal("GAltSEflow")}\n" +
 				$"Last Played SE Path: {AssetManager.Instance.debugLastSE}\n" +
 				$"SE Cascade: [{string.Join(":", SECascade.paths)}] ({SECascade.nameEN}) {(seFlagOK ? "" : "(Warning: Using default due to unknown flag)")}\n" +
-				$"Voice: {c.GetGlobal("GAltVoice")}\n" +
-				$"Priority: {c.GetGlobal("GAltVoicePriority")}\n" +
+				$"Voice: {GetGlobal("GAltVoice")}\n" +
+				$"Priority: {GetGlobal("GAltVoicePriority")}\n" +
 				"\n" +
 				$"Last Played Voice Path: {AssetManager.Instance.debugLastVoice}\n" +
 				$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}");
 
 			if (debug)
 			{
-				if(c.Button(new GUIContent("Reset GAudioSet", "Set GAudioSet to 0, to force the game to do audio setup on next startup")))
+				if(Button(new GUIContent("Reset GAudioSet", "Set GAudioSet to 0, to force the game to do audio setup on next startup")))
 				{
-					c.SetGlobal("GAudioSet", 0);
+					SetGlobal("GAudioSet", 0);
 				}
 			}
 
-			if (c.Button(new GUIContent("Close", "Close the debug menu")))
+			if (Button(new GUIContent("Close", "Close the debug menu")))
 			{
 				ToggleDebugMenu();
 			}
@@ -153,6 +151,7 @@ You can try the following yourself to fix the issue.
 		/// </summary>
 		public void OnGUIFragment()
 		{
+			MODStyleManager styleManager = MODStyleManager.OnGUIInstance;
 			buttonClickSound = GUISound.Click;
 
 			if (debug && AssetManager.Instance != null)
@@ -244,7 +243,7 @@ You can try the following yourself to fix the issue.
 				// Descriptions for each button are shown on hover, like a tooltip
 				{
 					GUILayout.BeginArea(new Rect(toolTipPosX, innerMargin, toolTipWidth- innerMargin, areaHeight-innerMargin), styleManager.modGUIBackgroundTextureTransparent);
-					c.HeadingLabel(currentMenu.Heading());
+					HeadingLabel(currentMenu.Heading());
 					GUILayout.Space(10);
 
 					GUIStyle toolTipStyle = styleManager.Group.label;
@@ -284,7 +283,7 @@ You can try the following yourself to fix the issue.
 					if (currentMenu.UserCanClose())
 					{
 						GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth - innerMargin, innerMargin, exitButtonWidth, exitButtonHeight));
-						if (c.Button(new GUIContent("X", "Close the Mod menu")))
+						if (Button(new GUIContent("X", "Close the Mod menu")))
 						{
 							this.UserHide();
 						}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -513,6 +513,8 @@ Sets the script censorship level
 					HeadingLabel("Troubleshooting");
 					Label("Save Files and Log Files");
 					ShowSupportButtons(content => Button(content));
+
+					Label("Developer");
 					if (Button(new GUIContent("Toggle debug menu", "Toggle the debug menu - mainly for developer use.")))
 					{
 						showDebugInfo = !showDebugInfo;

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -39,33 +39,6 @@ namespace MOD.Scripts.UI
 		private MODMenuModuleInterface currentMenu; // The menu that is currently visible
 
 		string lastToolTip = String.Empty;
-		string defaultTooltip = @"Hover over a button on the left panel for its description.
-
-[Vanilla Hotkeys]
-Enter,Return,RightArrow,PageDown : Advance Text
-LeftArrow,Pageup : See Backlog
-ESC : Open Menu
-Ctrl : Hold Skip Mode
-A : Auto Mode
-S : Toggle Skip Mode
-F, Alt-Enter : FullScreen
-Space : Hide Text
-L : Swap Language
-
-[MOD Hotkeys]
-F1 : ADV-NVL MODE
-F2 : Voice Matching Level
-F3 : Effect Level (Not Used)
-F5 : QuickSave
-F7 : QuickLoad
-F10 : Mod Menu
-M : Increase Voice Volume
-N : Decrease Voice Volume
-P : Cycle through art styles
-2 : Cycle through BGM/SE
-7 : Enable/Disable Lip-Sync
-LShift + M : Voice Volume MAX
-LShift + N : Voice Volume MIN";
 
 		string startupFailureToolTip = @"It looks like there was a problem starting up
 
@@ -211,7 +184,6 @@ You can try the following yourself to fix the issue.
 				float exitButtonHeight = areaHeight * .05f;
 
 				// Radio buttons
-				string customDefaultToolTip = null;
 				{
 					GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modMenuAreaStyle);
 					// Note: GUILayout.Height is adjusted to be slightly smaller, otherwise not all content is visible/scroll bar is slightly cut off.
@@ -225,7 +197,7 @@ You can try the following yourself to fix the issue.
 
 				// Descriptions for each button are shown on hover, like a tooltip
 				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modMenuAreaStyle);
-				c.HeadingLabel("Mod Options Menu");
+				c.HeadingLabel(currentMenu.Heading());
 				GUILayout.Space(10);
 
 				GUIStyle toolTipStyle = styleManager.Group.label;
@@ -241,7 +213,7 @@ You can try the following yourself to fix the issue.
 						}
 						else
 						{
-							displayedToolTip = customDefaultToolTip ?? defaultTooltip;
+							displayedToolTip = currentMenu.DefaultTooltip();
 						}
 					}
 					else

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -267,7 +267,7 @@ Sets the script censorship level
 				GUILayout.Label($"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Path: {AssetManager.Instance.debugLastSE}", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Path: {AssetManager.Instance.debugLastVoice}", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"Other Path: {AssetManager.Instance.debugLastOtherAudio}", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label(MODAudioTracking.Instance.ToString());
+				GUILayout.Label($"--- BGM Info ---\n{MODAudioTracking.Instance}");
 				GUILayout.EndScrollView();
 				GUILayout.EndArea();
 			}
@@ -445,15 +445,9 @@ Sets the script censorship level
 					if(this.hasBGMSEOptions)
 					{
 						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-						int oldBGMSEValue = GetGlobal("GAltBGM");
-						if (this.radioBGMSESet.OnGUIFragment(oldBGMSEValue) is int newBGMSEValue)
+						if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
 						{
-							SetGlobal("GAltBGM", newBGMSEValue);
-							SetGlobal("GAltSE", newBGMSEValue);
-							SetGlobal("GAltBGMflow", newBGMSEValue);
-							SetGlobal("GAltSEflow", newBGMSEValue);
-
-							MODAudioTracking.Instance.RestoreBGM(oldBGMSEValue, newBGMSEValue);
+							MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMSEValue);
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -112,7 +112,7 @@ You can try the following yourself to fix the issue.
 		{
 			if (Input.GetMouseButtonDown(1))
 			{
-				this.Hide();
+				this.UserHide();
 			}
 		}
 
@@ -262,12 +262,15 @@ You can try the following yourself to fix the issue.
 				GUILayout.EndArea();
 
 				// Exit button
-				GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth, areaPosY, exitButtonWidth, exitButtonHeight));
-				if (c.Button(new GUIContent("X", "Close the Mod menu")))
+				if (currentMenu.UserCanClose())
 				{
-					this.Hide();
+					GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth, areaPosY, exitButtonWidth, exitButtonHeight));
+					if (c.Button(new GUIContent("X", "Close the Mod menu")))
+					{
+						this.UserHide();
+					}
+					GUILayout.EndArea();
 				}
-				GUILayout.EndArea();
 
 				if(MODRadio.anyRadioPressed || anyButtonPressed)
 				{
@@ -320,18 +323,38 @@ You can try the following yourself to fix the issue.
 
 		}
 
-		public void Hide()
+		/// <summary>
+		/// This function should be called when the user has initiated the hiding of the menu.
+		/// This function call might be ignored if the menu disallows closing - call
+		/// </summary>
+		public void UserHide()
+		{
+			if (currentMenu.UserCanClose())
+			{
+				ForceHide();
+			}
+		}
+
+		public void UserToggleVisibility()
+		{
+			if (currentMenu.UserCanClose())
+			{
+				ForceToggleVisibility();
+			}
+		}
+
+		public void ForceHide()
 		{
 			this.visible = false;
 			gameSystem.MODIgnoreInputs = false;
 			gameSystem.ShowUIControls();
 		}
 
-		public void ToggleVisibility()
+		public void ForceToggleVisibility()
 		{
 			if (this.visible)
 			{
-				this.Hide();
+				this.ForceHide();
 			}
 			else
 			{

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -261,18 +261,31 @@ Sets the script censorship level
 		{
 			if (showDebugInfo && AssetManager.Instance != null)
 			{
+				bool bgmFlagOK = MODAudioSet.Instance.GetBGMCascade(GetGlobal("GAltBGM"), out PathCascadeList BGMCascade);
+				bool seFlagOK = MODAudioSet.Instance.GetSECascade(GetGlobal("GAltSE"), out PathCascadeList SECascade);
+
 				GUILayout.BeginArea(new Rect(0, 0, Screen.width/3, Screen.height), styleManager.modMenuAreaStyleLight);
-				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
+				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height - 10));
 				GUILayout.Label($"[Audio Tracking] - indicates what would play on each BGM flow", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
 
 				GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")}\n" +
-					$"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Last Played Path: {AssetManager.Instance.debugLastBGM}\n" +
-					$"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Last Played Path: {AssetManager.Instance.debugLastSE}\n" +
-					$"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Last Played Path: {AssetManager.Instance.debugLastVoice}\n" +
-					$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}",
-					styleManager.Group.upperLeftHeadingLabel);
+				GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetName()})\n" +
+					"\n" +
+					$"AltBGM: {GetGlobal("GAltBGM")}\n" +
+					$"AltBGMFlow: {GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(GetGlobal("GAltBGMflow"))})\n" +
+					$"Last Played BGM: {AssetManager.Instance.debugLastBGM}\n" +
+					$"BGM Cascade: [{string.Join(":", BGMCascade.paths)}] ({BGMCascade.nameEN}) {(bgmFlagOK ? "" : "9Warning: Using default due to unknown flag)")}\n" +
+					"\n" +
+					$"AltSE:  {GetGlobal("GAltSE")}\n" +
+					$"AltSEFlow: {GetGlobal("GAltSEflow")}\n" +
+					$"Last Played SE Path: {AssetManager.Instance.debugLastSE}\n" +
+					$"SE Cascade: [{string.Join(":", SECascade.paths)}] ({SECascade.nameEN}) {(seFlagOK ? "" : "(Warning: Using default due to unknown flag)")}\n" +
+					$"Voice: {GetGlobal("GAltVoice")}\n" +
+					$"Priority: {GetGlobal("GAltVoicePriority")}\n" +
+					"\n" +
+					$"Last Played Voice Path: {AssetManager.Instance.debugLastVoice}\n" +
+					$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}");
 				GUILayout.EndScrollView();
 				GUILayout.EndArea();
 			}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -77,7 +77,6 @@ namespace MOD.Scripts.UI
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
 		Vector2 leftDebugColumnScrollPosition;
-		Vector2 rightDebugColumnScrollPosition;
 		private static Vector2 emergencyMenuScrollPosition;
 		private bool hasOGBackgrounds;
 		private bool hasBGMSEOptions;
@@ -262,20 +261,14 @@ Sets the script censorship level
 		{
 			if (showDebugInfo && AssetManager.Instance != null)
 			{
-				// Left debug column
-				GUILayout.BeginArea(new Rect(0, 0, Screen.width/2, Screen.height / 4), styleManager.modMenuAreaStyleLight);
+				GUILayout.BeginArea(new Rect(0, 0, Screen.width/3, Screen.height), styleManager.modMenuAreaStyleLight);
 				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
 				GUILayout.Label($"[Audio Tracking] - indicates what would play on each BGM flow", styleManager.Group.upperLeftHeadingLabel);
 				GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.EndScrollView();
-				GUILayout.EndArea();
 
-
-				// Right debug column
-				GUILayout.BeginArea(new Rect(Screen.width / 2, 0, Screen.width/2, Screen.height/4), styleManager.modMenuAreaStyleLight);
-				rightDebugColumnScrollPosition = GUILayout.BeginScrollView(rightDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height / 4 - 10));
 				GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Last Played Path: {AssetManager.Instance.debugLastBGM}\n" +
+				GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")}\n" +
+					$"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Last Played Path: {AssetManager.Instance.debugLastBGM}\n" +
 					$"SE:  {GetGlobal("GAltSE")}  - Flow: {GetGlobal("GAltSEflow")} - Last Played Path: {AssetManager.Instance.debugLastSE}\n" +
 					$"Voice: {GetGlobal("GAltVoice")} - Priority: {GetGlobal("GAltVoicePriority")} - Last Played Path: {AssetManager.Instance.debugLastVoice}\n" +
 					$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}",
@@ -420,7 +413,7 @@ Sets the script censorship level
 						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
 						if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
 						{
-							MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMSEValue);
+							MODAudioSet.Instance.SetFromZeroBasedIndex(newBGMSEValue);
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -198,10 +198,8 @@ Sets the script censorship level
 
 			this.radioBGMSESet = new MODRadio("Choose BGM/SE", new GUIContent[]
 			{
-				new GUIContent("New BGM/SE", "Enable the new SE introduced by MangaGamer in the April 2019 update.\n\n" +
-				"NOTE: The BGM/SE might not update immediately, and you may encounter some BGM glitches until the scene ends, depending on when you toggle this value."),
-				new GUIContent("Original BGM/SE", "Enable the original sound effects from the Japanese version of the game.This option was previously known as 'SE fix' and is now installed by default.\n\n" +
-				"NOTE: The BGM/SE might not update immediately, and you may encounter some BGM glitches until the scene ends, depending on when you toggle this value."),
+				new GUIContent("New BGM/SE", "Enable the new BGM/SE introduced by MangaGamer in the April 2019 update."),
+				new GUIContent("Original BGM/SE", "Enable the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'."),
 			}, styleManager);
 
 			// Start the watchdog timer as soon as possible, so it starts from "when the game started"

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -105,7 +105,7 @@ You can try the following yourself to fix the issue.
 				GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
 
 				GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"Audio Set: {c.GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetName()})\n" +
+				GUILayout.Label($"Audio Set: {c.GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetDisplayName()})\n" +
 					"\n" +
 					$"AltBGM: {c.GetGlobal("GAltBGM")}\n" +
 					$"AltBGMFlow: {c.GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(c.GetGlobal("GAltBGMflow"))})\n" +

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -413,10 +413,10 @@ Sets the script censorship level
 
 					if (this.hasBGMSEOptions)
 					{
-						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-						if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
+						int zeroIndexed = new MODUtility.OneBasedFlag(GetGlobal("GAltBGMflow")).ZeroBased;
+						if (this.radioBGMSESet.OnGUIFragment(zeroIndexed) is int newBGMSEZeroIndexed)
 						{
-							MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMSEValue);
+							MODAudioTracking.Instance.SetAndSaveBGMSE(MODUtility.OneBasedFlag.FromZeroBased(newBGMSEZeroIndexed));
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -413,6 +413,15 @@ Sets the script censorship level
 						SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
 					};
 
+					if (this.hasBGMSEOptions)
+					{
+						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
+						if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
+						{
+							MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMSEValue);
+						}
+					}
+
 					HeadingLabel("Advanced Options");
 
 					if (this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
@@ -449,15 +458,6 @@ Sets the script censorship level
 								SetGlobal("GBackgroundSet", background);
 							}
 							GameSystem.Instance.SceneController.ReloadAllImages();
-						}
-					}
-
-					if(this.hasBGMSEOptions)
-					{
-						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-						if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
-						{
-							MODAudioTracking.Instance.SetAndSaveBGMSE(newBGMSEValue);
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -207,6 +207,7 @@ You can try the following yourself to fix the issue.
 				float exitButtonHeight = areaHeight * .05f;
 
 				// Radio buttons
+				string customDefaultToolTip = null;
 				{
 					GUILayout.BeginArea(new Rect(areaPosX, areaPosY, areaWidth, areaHeight), styleManager.modMenuAreaStyle);
 					// Note: GUILayout.Height is adjusted to be slightly smaller, otherwise not all content is visible/scroll bar is slightly cut off.
@@ -215,7 +216,7 @@ You can try the following yourself to fix the issue.
 					switch(menuMode)
 					{
 						case ModMenuMode.AudioSetup:
-							OnGUIFirstTimeAudioSetup();
+							customDefaultToolTip = OnGUIFirstTimeAudioSetup();
 							break;
 
 						case ModMenuMode.Normal:
@@ -246,7 +247,7 @@ You can try the following yourself to fix the issue.
 						}
 						else
 						{
-							displayedToolTip = defaultTooltip;
+							displayedToolTip = customDefaultToolTip ?? defaultTooltip;
 						}
 					}
 					else
@@ -331,7 +332,7 @@ You can try the following yourself to fix the issue.
 			}
 		}
 
-		private void OnGUIFirstTimeAudioSetup()
+		private string OnGUIFirstTimeAudioSetup()
 		{
 			c.Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.");
 			if(normalMenu.OnGUIFragmentChooseAudioSet(c))
@@ -339,6 +340,8 @@ You can try the following yourself to fix the issue.
 				menuMode = ModMenuMode.Normal;
 				Hide();
 			}
+
+			return "Please select a BGM type on the left before continuing.";
 		}
 
 		public void ToggleDebugMenu()

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -21,28 +21,21 @@ namespace MOD.Scripts.UI
 	public class MODMenu
 	{
 		private readonly MODStyleManager styleManager;
-		private readonly MODRadio radioCensorshipLevel;
-		private readonly MODRadio radioLipSync;
-		private readonly MODRadio radioOpenings;
-		private readonly MODRadio radioHideCG;
-		private readonly MODRadio radioBackgrounds;
-		private readonly MODRadio radioArtSet;
-		private readonly MODRadio radioBGMSESet;
+		private readonly MODMenuCommon c;
 		private readonly GameSystem gameSystem;
 		public bool visible;
+		private bool showDebugInfo;
 		private bool lastMenuVisibleStatus;
 		private MODSimpleTimer defaultToolTipTimer;
 		private MODSimpleTimer startupWatchdogTimer;
 		private bool startupFailed;
-		private string screenHeightString;
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
 		Vector2 leftDebugColumnScrollPosition;
-		private static Vector2 emergencyMenuScrollPosition;
-		private bool hasOGBackgrounds;
-		private bool hasBGMSEOptions;
-		private bool showDebugInfo;
+
 		private ModMenuMode menuMode;
+
+		private MODMenuNormal normalMenu;
 
 		string lastToolTip = String.Empty;
 		string defaultTooltip = @"Hover over a button on the left panel for its description.
@@ -87,86 +80,22 @@ You can try the following yourself to fix the issue.
 
   4. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.";
 
-		GUIContent[] defaultArtsetDescriptions = new GUIContent[] {
-			new GUIContent("Console", "Use the Console sprites and backgrounds"),
-			new GUIContent("Remake", "Use Mangagamer's remake sprites with Console backgrounds"),
-			new GUIContent("Original", "Use Original/Ryukishi sprites and backgrounds (if available - OG backgrounds not available for Console Arcs)\n\n" +
-			"Warning: Most users should use the Original/Ryukishi preset at the top of this menu!"),
-		};
-
 		public MODMenu(GameSystem gameSystem, MODStyleManager styleManager)
 		{
 			this.gameSystem = gameSystem;
 			this.styleManager = styleManager;
 			this.visible = false;
+			this.showDebugInfo = false;
 			this.lastMenuVisibleStatus = false;
 			this.defaultToolTipTimer = new MODSimpleTimer();
 			this.startupWatchdogTimer = new MODSimpleTimer();
 			this.startupFailed = false;
-			this.screenHeightString = String.Empty;
-			this.hasOGBackgrounds = MODActions.HasOGBackgrounds();
-			this.hasBGMSEOptions = MODActions.HasMusicToggle();
-
-			string baseCensorshipDescription = @"
-
-Sets the script censorship level
-- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.
-- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.
-  - 5: Full PS3 script fully voiced (most censored)
-  - 2: Default - most balanced option
-  - 0: Original PC Script with voices where it fits (least uncensored), but uncensored scenes may be missing voices";
-
-			this.radioCensorshipLevel = new MODRadio("Voice Matching Level (Hotkey: F2)", new GUIContent[] {
-				new GUIContent("0", "Censorship level 0 - Equivalent to PC" + baseCensorshipDescription),
-				new GUIContent("1", "Censorship level 1" + baseCensorshipDescription),
-				new GUIContent("2*", "Censorship level 2 (this is the default/recommended value)" + baseCensorshipDescription),
-				new GUIContent("3", "Censorship level 3" + baseCensorshipDescription),
-				new GUIContent("4", "Censorship level 4" + baseCensorshipDescription),
-				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
-				}, styleManager);
-
-			this.radioLipSync = new MODRadio("Lip Sync for Console Sprites (Hotkey: 7)", new GUIContent[]
-			{
-				new GUIContent("Lip Sync Off", "Disables Lip Sync for Console Sprites"),
-				new GUIContent("Lip Sync On", "Enables Lip Sync for Console Sprites"),
-			}, styleManager);
-
-			this.radioOpenings = new MODRadio("Opening Movies (Hotkey: Shift-F12)", new GUIContent[]
-			{
-				new GUIContent("Disabled", "Disables all opening videos"),
-				new GUIContent("Enabled", "Enables opening videos\n\n" +
-				"NOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\n" +
-				"We have setup openings this way to avoid spoilers."),
-				new GUIContent("Launch + In-Game", "WARNING: There is usually no need to set this manually.\n\n" +
-				"If openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\n" +
-				"That is, after the opening is played the first time, from then on openings will play every time the game launches"),
-			}, styleManager);
-
-			this.radioHideCG = new MODRadio("Show/Hide CGs", new GUIContent[]
-			{
-				new GUIContent("Show CGs", "Shows CGs (You probably want this enabled for Console ADV/NVL mode)"),
-				new GUIContent("Hide CGs", "Disables all CGs (mainly for use with the Original/Ryukishi preset)"),
-			}, styleManager);
-
-			this.radioArtSet = new MODRadio("Choose Art Set", defaultArtsetDescriptions, styleManager, itemsPerRow: 3);
-
-			this.radioBackgrounds = new MODRadio("Override Art Set Backgrounds", new GUIContent[]{
-				new GUIContent("Default BGs", "Use the default backgrounds for the current artset"),
-				new GUIContent("Console BGs", "Force Console backgrounds, regardless of the artset"),
-				new GUIContent("Original BGs", "Force Original/Ryukishi backgrounds, regardless of the artset"),
-				new GUIContent("Original Stretched", "Force Original/Ryukishi backgrounds, stretched to fit, regardless of the artset\n\n" +
-				"WARNING: When using this option, you should have ADV/NVL mode selected, otherwise sprites will be cut off, and UI will appear in the wrong place"),
-			}, styleManager, itemsPerRow: 2);
-
-			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[]
-			{
-				new GUIContent("New BGM/SE", "Use the new BGM/SE introduced by MangaGamer in the April 2019 update."),
-				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
-				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
-			}, styleManager);
+			this.c = new MODMenuCommon(styleManager);
 
 			// Start the watchdog timer as soon as possible, so it starts from "when the game started"
 			this.startupWatchdogTimer.Start(5.0f);
+
+			this.normalMenu = new MODMenuNormal(this, this.c, styleManager);
 		}
 
 		public void Update()
@@ -183,39 +112,6 @@ Sets the script censorship level
 			}
 		}
 
-		private void OnGUIRestoreSettings()
-		{
-			Label($"Restore Settings {(GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <Restart Pending>")}");
-
-			GUILayout.BeginHorizontal();
-			if (GetGlobal("GMOD_SETTING_LOADER") == 3)
-			{
-				if (Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
-					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
-				{
-					SetGlobal("GMOD_SETTING_LOADER", 0);
-				}
-				else if (Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
-					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
-				{
-					SetGlobal("GMOD_SETTING_LOADER", 1);
-				}
-				else if (Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
-					"NOTE: Requires a relaunch to come into effect. After this, uninstall the mod.")))
-				{
-					SetGlobal("GMOD_SETTING_LOADER", 2);
-				}
-			}
-			else
-			{
-				if (Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
-				{
-					SetGlobal("GMOD_SETTING_LOADER", 3);
-				}
-			}
-			GUILayout.EndHorizontal();
-		}
-
 		/// <summary>
 		/// Must be called from an OnGUI()
 		/// </summary>
@@ -223,8 +119,8 @@ Sets the script censorship level
 		{
 			if (showDebugInfo && AssetManager.Instance != null)
 			{
-				bool bgmFlagOK = MODAudioSet.Instance.GetBGMCascade(GetGlobal("GAltBGM"), out PathCascadeList BGMCascade);
-				bool seFlagOK = MODAudioSet.Instance.GetSECascade(GetGlobal("GAltSE"), out PathCascadeList SECascade);
+				bool bgmFlagOK = MODAudioSet.Instance.GetBGMCascade(c.GetGlobal("GAltBGM"), out PathCascadeList BGMCascade);
+				bool seFlagOK = MODAudioSet.Instance.GetSECascade(c.GetGlobal("GAltSE"), out PathCascadeList SECascade);
 
 				GUILayout.BeginArea(new Rect(0, 0, Screen.width/3, Screen.height), styleManager.modMenuAreaStyleLight);
 				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width), GUILayout.Height(Screen.height - 10));
@@ -232,19 +128,19 @@ Sets the script censorship level
 				GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
 
 				GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
-				GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetName()})\n" +
+				GUILayout.Label($"Audio Set: {c.GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetName()})\n" +
 					"\n" +
-					$"AltBGM: {GetGlobal("GAltBGM")}\n" +
-					$"AltBGMFlow: {GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(GetGlobal("GAltBGMflow"))})\n" +
+					$"AltBGM: {c.GetGlobal("GAltBGM")}\n" +
+					$"AltBGMFlow: {c.GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(c.GetGlobal("GAltBGMflow"))})\n" +
 					$"Last Played BGM: {AssetManager.Instance.debugLastBGM}\n" +
 					$"BGM Cascade: [{string.Join(":", BGMCascade.paths)}] ({BGMCascade.nameEN}) {(bgmFlagOK ? "" : "9Warning: Using default due to unknown flag)")}\n" +
 					"\n" +
-					$"AltSE:  {GetGlobal("GAltSE")}\n" +
-					$"AltSEFlow: {GetGlobal("GAltSEflow")}\n" +
+					$"AltSE:  {c.GetGlobal("GAltSE")}\n" +
+					$"AltSEFlow: {c.GetGlobal("GAltSEflow")}\n" +
 					$"Last Played SE Path: {AssetManager.Instance.debugLastSE}\n" +
 					$"SE Cascade: [{string.Join(":", SECascade.paths)}] ({SECascade.nameEN}) {(seFlagOK ? "" : "(Warning: Using default due to unknown flag)")}\n" +
-					$"Voice: {GetGlobal("GAltVoice")}\n" +
-					$"Priority: {GetGlobal("GAltVoicePriority")}\n" +
+					$"Voice: {c.GetGlobal("GAltVoice")}\n" +
+					$"Priority: {c.GetGlobal("GAltVoicePriority")}\n" +
 					"\n" +
 					$"Last Played Voice Path: {AssetManager.Instance.debugLastVoice}\n" +
 					$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}");
@@ -288,20 +184,7 @@ Sets the script censorship level
 			if (visible && !lastMenuVisibleStatus)
 			{
 				// Executes just before menu becomes visible
-				// Update the artset radio buttons/descriptions, as these are set by ModAddArtset() calls in init.txt at runtime
-				// Technically only need to do this once after init.txt has been called, but it's easier to just do it each time menu is opened
-				GUIContent[] descriptions = Core.MODSystem.instance.modTextureController.GetArtStyleDescriptions();
-				for (int i = 0; i < descriptions.Count(); i++)
-				{
-					if (i < this.defaultArtsetDescriptions.Count())
-					{
-						descriptions[i] = this.defaultArtsetDescriptions[i];
-					}
-				}
-				this.radioArtSet.SetContents(descriptions);
-
-				this.screenHeightString = $"{Screen.width}";
-				this.screenHeightString = $"{Screen.height}";
+				normalMenu.OnBeforeMenuVisible();
 			}
 			lastMenuVisibleStatus = visible;
 
@@ -337,7 +220,7 @@ Sets the script censorship level
 
 						case ModMenuMode.Normal:
 						default:
-							OnGUINormalMenu();
+							normalMenu.OnGUI();
 							break;
 					}
 
@@ -347,7 +230,7 @@ Sets the script censorship level
 
 				// Descriptions for each button are shown on hover, like a tooltip
 				GUILayout.BeginArea(new Rect(toolTipPosX, areaPosY, toolTipWidth, areaHeight), styleManager.modMenuAreaStyle);
-				HeadingLabel("Mod Options Menu");
+				c.HeadingLabel("Mod Options Menu");
 				GUILayout.Space(10);
 
 				GUIStyle toolTipStyle = styleManager.Group.label;
@@ -385,7 +268,7 @@ Sets the script censorship level
 
 				// Exit button
 				GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth, areaPosY, exitButtonWidth, exitButtonHeight));
-				if (Button(new GUIContent("X", "Close the Mod menu")))
+				if (c.Button(new GUIContent("X", "Close the Mod menu")))
 				{
 					this.Hide();
 				}
@@ -398,172 +281,6 @@ Sets the script censorship level
 					anyButtonPressed = false;
 				}
 			}
-		}
-
-		private void OnGUINormalMenu()
-		{
-			HeadingLabel("Basic Options");
-
-			Label("Graphics Presets (Hotkey: F1)");
-			{
-				GUILayout.BeginHorizontal();
-
-				int advNVLRyukishiMode = MODActions.GetADVNVLRyukishiModeFromFlags(out bool presetModified);
-
-				if (this.Button(new GUIContent(advNVLRyukishiMode == 0 && presetModified ? "ADV (custom)" : "ADV", "This preset:\n" +
-				"- Makes text show at the bottom of the screen in a textbox\n" +
-				"- Shows the name of the current character on the textbox\n" +
-				"- Uses the console sprites and backgrounds\n" +
-				"- Displays in 16:9 widescreen\n\n" +
-				"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 0))
-				{
-					MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
-				}
-
-				if (this.Button(new GUIContent(advNVLRyukishiMode == 1 && presetModified ? "NVL (custom)" : "NVL", "This preset:\n" +
-					"- Makes text show across the whole screen\n" +
-					"- Uses the console sprites and backgrounds\n" +
-					"- Displays in 16:9 widescreen\n\n" +
-					"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 1))
-				{
-					MODActions.SetAndSaveADV(MODActions.ModPreset.NVL, showInfoToast: false);
-				}
-
-				if (this.hasOGBackgrounds &&
-					this.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
-					"- Displays backgrounds in 4:3 'standard' aspect\n" +
-					"- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n" +
-					"- Switches to original sprites and backgrounds\n\n" +
-					"Note that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 2))
-				{
-					MODActions.SetAndSaveADV(MODActions.ModPreset.OG, showInfoToast: false);
-				}
-
-				GUILayout.EndHorizontal();
-			}
-
-			if (this.radioCensorshipLevel.OnGUIFragment(GetGlobal("GCensor")) is int censorLevel)
-			{
-				SetGlobal("GCensor", censorLevel);
-			};
-
-			if (this.radioLipSync.OnGUIFragment(GetGlobal("GLipSync")) is int lipSyncEnabled)
-			{
-				SetGlobal("GLipSync", lipSyncEnabled);
-			};
-
-			if (this.radioOpenings.OnGUIFragment(GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
-			{
-				SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
-			};
-
-			OnGUIFragmentChooseAudioSet();
-
-			HeadingLabel("Advanced Options");
-
-			if (this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
-			{
-				SetGlobal("GHideCG", hideCG);
-			};
-
-			if (this.radioArtSet.OnGUIFragment(Core.MODSystem.instance.modTextureController.GetArtStyle()) is int artStyle)
-			{
-				SetGlobal("GStretchBackgrounds", 0);
-				Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle, showInfoToast: false);
-			}
-
-			if (this.hasOGBackgrounds)
-			{
-				int currentBackground = GetGlobal("GBackgroundSet");
-				if (currentBackground == 2)
-				{
-					if (GetGlobal("GStretchBackgrounds") == 1)
-					{
-						currentBackground = 3;
-					}
-				}
-				if (this.radioBackgrounds.OnGUIFragment(currentBackground) is int background)
-				{
-					if (background == 3)
-					{
-						SetGlobal("GStretchBackgrounds", 1);
-						SetGlobal("GBackgroundSet", 2);
-					}
-					else
-					{
-						SetGlobal("GStretchBackgrounds", 0);
-						SetGlobal("GBackgroundSet", background);
-					}
-					GameSystem.Instance.SceneController.ReloadAllImages();
-				}
-			}
-
-			GUILayout.Space(10);
-			OnGUIRestoreSettings();
-
-			Label("Resolution Settings");
-			{
-				GUILayout.BeginHorizontal();
-				if (Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }
-				if (Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
-				if (Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
-				if (Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
-				if (gameSystem.IsFullscreen)
-				{
-					if (Button(new GUIContent("Windowed", "Toggle Fullscreen")))
-					{
-						GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
-					}
-				}
-				else
-				{
-					if (Button(new GUIContent("Fullscreen", "Toggle Fullscreen")))
-					{
-						gameSystem.GoFullscreen();
-					}
-				}
-
-				screenHeightString = GUILayout.TextField(screenHeightString);
-				if (Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.\n\n" +
-					"Height set automatically to maintain 16:9 aspect ratio.")))
-				{
-					if (int.TryParse(screenHeightString, out int new_height))
-					{
-						if (new_height < 480)
-						{
-							MODToaster.Show("Height too small - must be at least 480 pixels");
-							new_height = 480;
-						}
-						else if (new_height > 15360)
-						{
-							MODToaster.Show("Height too big - must be less than 15360 pixels");
-							new_height = 15360;
-						}
-						screenHeightString = $"{new_height}";
-						int new_width = Mathf.RoundToInt(new_height * 16f / 9f);
-						Screen.SetResolution(new_width, new_height, Screen.fullScreen);
-						PlayerPrefs.SetInt("width", new_width);
-						PlayerPrefs.SetInt("height", new_height);
-					}
-				}
-				GUILayout.EndHorizontal();
-			}
-
-			HeadingLabel("Troubleshooting");
-			Label("Save Files and Log Files");
-			ShowSupportButtons(content => Button(content));
-
-			Label("Developer");
-			GUILayout.BeginHorizontal();
-			if (Button(new GUIContent("Toggle debug menu (Shift-F9)", "Toggle the debug menu")))
-			{
-				ToggleDebugMenu();
-			}
-			if (Button(new GUIContent("Toggle flag menu (Shift-F10)", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.")))
-			{
-				MODActions.ToggleFlagMenu();
-			}
-			GUILayout.EndHorizontal();
 		}
 
 		public void Show(ModMenuMode menuMode = ModMenuMode.Normal)
@@ -614,119 +331,10 @@ Sets the script censorship level
 			}
 		}
 
-		private bool Button(GUIContent guiContent, bool selected=false)
-		{
-			if(GUILayout.Button(guiContent, selected ? styleManager.Group.selectedButton : styleManager.Group.button))
-			{
-				anyButtonPressed = true;
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-
-		private void Label(string label)
-		{
-			GUILayout.Label(label, styleManager.Group.label);
-		}
-
-		private void HeadingLabel(string label)
-		{
-			GUILayout.Label(label, styleManager.Group.headingLabel);
-		}
-
-		private int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
-		private void SetGlobal(string flagName, int flagValue) => BurikoMemory.Instance.SetGlobalFlag(flagName, flagValue);
-
-		private void SetAndSaveResolution(int height)
-		{
-			if (height < 480)
-			{
-				MODToaster.Show("Height too small - must be at least 480 pixels");
-				height = 480;
-			}
-			else if (height > 15360)
-			{
-				MODToaster.Show("Height too big - must be less than 15360 pixels");
-				height = 15360;
-			}
-			screenHeightString = $"{height}";
-			int width = Mathf.RoundToInt(height * 16f / 9f);
-			Screen.SetResolution(width, height, Screen.fullScreen);
-			PlayerPrefs.SetInt("width", width);
-			PlayerPrefs.SetInt("height", height);
-		}
-
-		/// <summary>
-		/// This function draws an emergency mod menu in case of a critical game error
-		/// (for example, corrupted game save)
-		///
-		/// Please do null checks/try catch for gamesystem etc. if used in this function as it may be called
-		/// during an error condition where gamesystem and other core system parts are not initialized yet
-		/// </summary>
-		/// <param name="errorMessage"></param>
-		public static void EmergencyModMenu(string shortErrorMessage, string longErrorMessage)
-		{
-			emergencyMenuScrollPosition = GUILayout.BeginScrollView(emergencyMenuScrollPosition);
-			GUILayout.Label(shortErrorMessage);
-			GUILayout.Label(longErrorMessage);
-
-			ShowSupportButtons(content => GUILayout.Button(content));
-
-			GUILayout.Label(GUI.tooltip == "" ? "Please hover over a button for more information" : GUI.tooltip, GUI.skin.textArea, GUILayout.MinHeight(210));
-
-			GUILayout.EndScrollView();
-		}
-
-		private static void ShowSupportButtons(Func<GUIContent, bool> buttonRenderer)
-		{
-			{
-				GUILayout.BeginHorizontal();
-				if (buttonRenderer(new GUIContent("Show output_log.txt / Player.log",
-					"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
-					"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
-					"- This file records errors that occur during gameplay, and during game startup\n" +
-					"- This file helps when the game fails start, for example\n" +
-					"  - a corrupted save file\n" +
-					"  - the wrong UI (sharedassets0.assets) file\n" +
-					"- Note that each time the game starts up, the current log file is replaced")))
-				{
-					MODActions.ShowLogFolder();
-				}
-
-				if (buttonRenderer(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
-					"- WARNING: Steam sync will restore your saves if you manually delete them! Therefore, remember to disable steam sync, otherwise your saves will magically reappear!\n" +
-					"- The 'global.dat' file stores your global unlock process and mod flags\n" +
-					"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
-					"- It's recommended to take a backup of all your saves before you modify them")))
-				{
-					MODActions.ShowSaveFolder();
-				}
-
-				if (buttonRenderer(new GUIContent("Show Compiled Scripts", "Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\n" +
-					"You can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\n" +
-					"Please be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.")))
-				{
-					Application.OpenURL(System.IO.Path.Combine(Application.streamingAssetsPath, "CompiledUpdateScripts"));
-				}
-
-
-				GUILayout.EndHorizontal();
-			}
-
-			if (buttonRenderer(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
-				"There are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly")))
-			{
-				Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
-			}
-		}
-
 		private void OnGUIFirstTimeAudioSetup()
 		{
-			Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.");
-			if(OnGUIFragmentChooseAudioSet())
+			c.Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.");
+			if(normalMenu.OnGUIFragmentChooseAudioSet(c))
 			{
 				menuMode = ModMenuMode.Normal;
 				Hide();
@@ -737,21 +345,6 @@ Sets the script censorship level
 		{
 			showDebugInfo = !showDebugInfo;
 			MODAudioTracking.Instance.LoggingEnabled = showDebugInfo;
-		}
-
-		public bool OnGUIFragmentChooseAudioSet()
-		{
-			if (this.hasBGMSEOptions)
-			{
-				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-				if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int newBGMSEValue)
-				{
-					MODAudioSet.Instance.SetFromZeroBasedIndex(newBGMSEValue);
-					return true;
-				}
-			}
-
-			return false;
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -32,6 +32,7 @@ namespace MOD.Scripts.UI
 		private bool anyButtonPressed;
 		Vector2 scrollPosition;
 		Vector2 leftDebugColumnScrollPosition;
+		GUISound buttonClickSound;
 
 		private MODMenuNormal normalMenu;
 		private MODMenuAudioOptions audioOptionsMenu;
@@ -69,7 +70,7 @@ You can try the following yourself to fix the issue.
 			// Start the watchdog timer as soon as possible, so it starts from "when the game started"
 			this.startupWatchdogTimer.Start(5.0f);
 
-			this.audioOptionsMenu = new MODMenuAudioOptions(this.c, styleManager);
+			this.audioOptionsMenu = new MODMenuAudioOptions(this, this.c, styleManager);
 			this.normalMenu = new MODMenuNormal(this, this.c, styleManager, this.audioOptionsMenu);
 			this.audioSetupMenu = new MODMenuAudioSetup(this, this.c, this.audioOptionsMenu);
 			this.currentMenu = this.normalMenu;
@@ -94,6 +95,8 @@ You can try the following yourself to fix the issue.
 		/// </summary>
 		public void OnGUIFragment()
 		{
+			buttonClickSound = GUISound.Click;
+
 			if (showDebugInfo && AssetManager.Instance != null)
 			{
 				bool bgmFlagOK = MODAudioSet.Instance.GetBGMCascade(c.GetGlobal("GAltBGM"), out PathCascadeList BGMCascade);
@@ -246,11 +249,16 @@ You can try the following yourself to fix the issue.
 
 				if(MODRadio.anyRadioPressed || anyButtonPressed)
 				{
-					GameSystem.Instance.AudioController.PlaySystemSound(MODSound.GetSoundPathFromEnum(GUISound.Click));
+					GameSystem.Instance.AudioController.PlaySystemSound(MODSound.GetSoundPathFromEnum(buttonClickSound));
 					MODRadio.anyRadioPressed = false;
 					anyButtonPressed = false;
 				}
 			}
+		}
+
+		public void OverrideClickSound(GUISound sound)
+		{
+			buttonClickSound = sound;
 		}
 
 		public void SetMode(ModMenuMode menuMode)

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -2,6 +2,7 @@
 using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
+using MOD.Scripts.Core.Audio;
 using MOD.Scripts.Core.State;
 using System;
 using System.Collections.Generic;
@@ -440,16 +441,15 @@ Sets the script censorship level
 					if(this.hasBGMSEOptions)
 					{
 						// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-						if(this.radioBGMSESet.OnGUIFragment(GetGlobal("GAltBGM")) is int BGMSEValue)
+						int oldBGMSEValue = GetGlobal("GAltBGM");
+						if (this.radioBGMSESet.OnGUIFragment(oldBGMSEValue) is int newBGMSEValue)
 						{
-							SetGlobal("GAltBGM", BGMSEValue);
-							SetGlobal("GAltSE", BGMSEValue);
-							SetGlobal("GAltBGMflow", BGMSEValue);
-							SetGlobal("GAltSEflow", BGMSEValue);
-							// TODO: Copy logic from sprite switching to reload bgm if necessary
-							// It may be best to cancel all SE/BGM during the switch, to ensure you don't have multiple bgm playing
-							// Only way to fix this is to not use if statements and instead track which bgm should currently be playing
-							//UpdateBGM();
+							SetGlobal("GAltBGM", newBGMSEValue);
+							SetGlobal("GAltSE", newBGMSEValue);
+							SetGlobal("GAltBGMflow", newBGMSEValue);
+							SetGlobal("GAltSEflow", newBGMSEValue);
+
+							MODAudio.Instance.MODRestoreBGM(oldBGMSEValue, newBGMSEValue);
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -449,7 +449,7 @@ Sets the script censorship level
 							SetGlobal("GAltBGMflow", newBGMSEValue);
 							SetGlobal("GAltSEflow", newBGMSEValue);
 
-							MODAudio.Instance.MODRestoreBGM(oldBGMSEValue, newBGMSEValue);
+							MODAudioTracking.Instance.RestoreBGM(oldBGMSEValue, newBGMSEValue);
 						}
 					}
 

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -162,6 +162,7 @@ You can try the following yourself to fix the issue.
 
 			GUI.depth = 0;
 
+			// Show a troubleshooting message if game failed to start-up
 			if (this.startupWatchdogTimer.Finished())
 			{
 				this.startupWatchdogTimer.Cancel();
@@ -172,6 +173,10 @@ You can try the following yourself to fix the issue.
 				}
 			}
 
+			if(BurikoScriptSystem.Instance.FlowWasReached)
+			{
+				this.startupFailed = false;
+			}
 			// Button to open the Mod Menu on the Config Screen
 			if (gameSystem.GameState == GameState.ConfigScreen)
 			{

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -78,6 +78,7 @@ namespace MOD.Scripts.UI
 		private static Vector2 emergencyMenuScrollPosition;
 		private bool hasOGBackgrounds;
 		private bool hasBGMSEOptions;
+		private bool showDebugInfo;
 
 		string lastToolTip = String.Empty;
 		string defaultTooltip = @"Hover over a button on the left panel for its description.
@@ -256,7 +257,7 @@ Sets the script censorship level
 		/// </summary>
 		public void OnGUIFragment()
 		{
-			if (AssetManager.Instance != null)
+			if (showDebugInfo && AssetManager.Instance != null)
 			{
 				GUILayout.BeginArea(new Rect(0, 0, Screen.width, Screen.height/7), styleManager.modMenuAreaStyleLight);
 				GUILayout.Label($"BGM: {GetGlobal("GAltBGM")} - Flow: {GetGlobal("GAltBGMflow")} - Path: {AssetManager.Instance.debugLastBGM}", styleManager.Group.upperLeftHeadingLabel);
@@ -506,6 +507,10 @@ Sets the script censorship level
 					HeadingLabel("Troubleshooting");
 					Label("Save Files and Log Files");
 					ShowSupportButtons(content => Button(content));
+					if (Button(new GUIContent("Toggle debug menu", "Toggle the debug menu - mainly for developer use.")))
+					{
+						showDebugInfo = !showDebugInfo;
+					}
 
 					GUILayout.EndScrollView();
 					GUILayout.EndArea();

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -69,12 +69,12 @@ namespace MOD.Scripts.UI
 			ReloadMenu();
 		}
 
-		public void OnGUI()
+		public void OnGUI(bool hideLabel=false)
 		{
 			if (MODAudioSet.Instance.HasAudioSetsDefined())
 			{
 				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : 0) is int newAudioSetZeroBased)
+				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : -1, hideLabel: hideLabel) is int newAudioSetZeroBased)
 				{
 					if(MODAudioSet.Instance.GetAudioSet(newAudioSetZeroBased, out AudioSet audioSet))
 					{

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -11,12 +11,10 @@ namespace MOD.Scripts.UI
 	{
 		private readonly MODRadio radioBGMSESet;
 		private readonly MODMenuCommon c;
-		private readonly bool hasBGMSEOptions;
 
 		public MODMenuAudioOptions(MODMenuCommon c, MODStyleManager styleManager)
 		{
 			this.c = c;
-			hasBGMSEOptions = MODActions.HasMusicToggle();
 
 			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[] { }, styleManager);
 		}
@@ -34,7 +32,7 @@ namespace MOD.Scripts.UI
 
 		public void OnGUI()
 		{
-			if (this.hasBGMSEOptions)
+			if (MODAudioSet.Instance.HasAudioSetsDefined())
 			{
 				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
 				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : 0) is int newBGMSEValue)

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -11,10 +11,11 @@ namespace MOD.Scripts.UI
 	{
 		private readonly MODRadio radioBGMSESet;
 		private readonly MODRadio radioSE;
+		private readonly MODMenu modMenu;
 		private readonly MODMenuCommon c;
-
-		public MODMenuAudioOptions(MODMenuCommon c, MODStyleManager styleManager)
+		public MODMenuAudioOptions(MODMenu m, MODMenuCommon c, MODStyleManager styleManager)
 		{
+			this.modMenu = m;
 			this.c = c;
 
 			this.radioBGMSESet = new MODRadio("Audio Presets (Hotkey: 2)", new GUIContent[] { }, styleManager, itemsPerRow: 2);
@@ -47,8 +48,8 @@ namespace MOD.Scripts.UI
 					}
 
 					buttonText += " (NOT INSTALLED)";
-					tooltipText += $"\n\nWARNING: This audio set is not installed! You can try to run the installer again to update your mod with this option.\n\n" +
-						$"\n\nDetailed Info: you're either missing the BGM folder '{bgmPrimaryInfo}' or the SE folder '{sePrimaryInfo}' in the StreamingAssets folder.";
+					tooltipText += $"\n\nWARNING: This audio set is not installed! You can try to run the installer again to update your mod with this option.\n" +
+						$"You're either missing the BGM folder '{bgmPrimaryInfo}' or the SE folder '{sePrimaryInfo}' in the StreamingAssets folder.";
 				}
 
 				buttonContents.Add(new GUIContent(buttonText, tooltipText));
@@ -75,10 +76,18 @@ namespace MOD.Scripts.UI
 				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
 				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : 0) is int newAudioSetZeroBased)
 				{
-					if(MODAudioSet.Instance.GetAudioSet(newAudioSetZeroBased, out AudioSet audioSet) && audioSet.IsInstalledCached())
+					if(MODAudioSet.Instance.GetAudioSet(newAudioSetZeroBased, out AudioSet audioSet))
 					{
-						MODAudioSet.Instance.SetAndSaveAudioFlags(newAudioSetZeroBased);
-						ReloadMenu();
+						if (audioSet.IsInstalledCached())
+						{
+							MODAudioSet.Instance.SetAndSaveAudioFlags(newAudioSetZeroBased);
+							ReloadMenu();
+						}
+						else
+						{
+							MODToaster.Show("Option Not Installed!", maybeSound: null);
+							this.modMenu.OverrideClickSound(GUISound.Disable);
+						}
 					}
 				}
 			}

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
 
 namespace MOD.Scripts.UI
 {
@@ -12,19 +13,17 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioBGMSESet;
 		private readonly MODRadio radioSE;
 		private readonly MODMenu modMenu;
-		private readonly MODMenuCommon c;
-		public MODMenuAudioOptions(MODMenu m, MODMenuCommon c, MODStyleManager styleManager)
+		public MODMenuAudioOptions(MODMenu m)
 		{
 			this.modMenu = m;
-			this.c = c;
 
-			this.radioBGMSESet = new MODRadio("Audio Presets (Hotkey: 2)", new GUIContent[] { }, styleManager, itemsPerRow: 2, asButtons: true);
-			this.radioSE = new MODRadio("Override SE", new GUIContent[] { }, styleManager, itemsPerRow: 2);
+			this.radioBGMSESet = new MODRadio("Audio Presets (Hotkey: 2)", new GUIContent[] { }, itemsPerRow: 2, asButtons: true);
+			this.radioSE = new MODRadio("Override SE", new GUIContent[] { },  itemsPerRow: 2);
 		}
 
 		public void ReloadMenu()
 		{
-			bool japanese = c.GetGlobal("GLanguage") == 0;
+			bool japanese = GetGlobal("GLanguage") == 0;
 
 			List<GUIContent> buttonContents = new List<GUIContent>();
 			foreach (AudioSet audioSet in MODAudioSet.Instance.GetAudioSets())
@@ -74,7 +73,7 @@ namespace MOD.Scripts.UI
 			if (MODAudioSet.Instance.HasAudioSetsDefined())
 			{
 				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : -1, hideLabel: hideLabel) is int newAudioSetZeroBased)
+				if (this.radioBGMSESet.OnGUIFragment(GetGlobal("GAudioSet") > 0 ? GetGlobal("GAudioSet") - 1 : -1, hideLabel: hideLabel) is int newAudioSetZeroBased)
 				{
 					if(MODAudioSet.Instance.GetAudioSet(newAudioSetZeroBased, out AudioSet audioSet))
 					{
@@ -96,9 +95,9 @@ namespace MOD.Scripts.UI
 
 		public void AdvancedOnGUI()
 		{
-			if (this.radioSE.OnGUIFragment(c.GetGlobal("GAltSE")) is int newAltSE)
+			if (this.radioSE.OnGUIFragment(GetGlobal("GAltSE")) is int newAltSE)
 			{
-				c.SetGlobal("GAltSE", newAltSE);
+				SetGlobal("GAltSE", newAltSE);
 				ReloadMenu();
 			}
 		}

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -95,10 +95,13 @@ namespace MOD.Scripts.UI
 
 		public void AdvancedOnGUI()
 		{
-			if (this.radioSE.OnGUIFragment(GetGlobal("GAltSE")) is int newAltSE)
+			if (MODAudioSet.Instance.SECascades.Count > 0)
 			{
-				SetGlobal("GAltSE", newAltSE);
-				ReloadMenu();
+				if (this.radioSE.OnGUIFragment(GetGlobal("GAltSE")) is int newAltSE)
+				{
+					SetGlobal("GAltSE", newAltSE);
+					ReloadMenu();
+				}
 			}
 		}
 	}

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -18,7 +18,7 @@ namespace MOD.Scripts.UI
 			this.modMenu = m;
 			this.c = c;
 
-			this.radioBGMSESet = new MODRadio("Audio Presets (Hotkey: 2)", new GUIContent[] { }, styleManager, itemsPerRow: 2);
+			this.radioBGMSESet = new MODRadio("Audio Presets (Hotkey: 2)", new GUIContent[] { }, styleManager, itemsPerRow: 2, asButtons: true);
 			this.radioSE = new MODRadio("Override SE", new GUIContent[] { }, styleManager, itemsPerRow: 2);
 		}
 

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -1,0 +1,44 @@
+﻿using MOD.Scripts.Core.Audio;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODMenuAudioOptions : MODMenuModuleInterface
+	{
+		private readonly MODRadio radioBGMSESet;
+		private readonly MODMenuCommon c;
+		private readonly bool hasBGMSEOptions;
+
+		public MODMenuAudioOptions(MODMenuCommon c, MODStyleManager styleManager)
+		{
+			this.c = c;
+			hasBGMSEOptions = MODActions.HasMusicToggle();
+
+			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[]
+			{
+				new GUIContent("New BGM/SE", "Use the new BGM/SE introduced by MangaGamer in the April 2019 update."),
+				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
+				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
+			}, styleManager);
+		}
+
+		public void OnBeforeMenuVisible()
+		{
+		}
+
+		public void OnGUI()
+		{
+			if (this.hasBGMSEOptions)
+			{
+				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
+				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : 0) is int newBGMSEValue)
+				{
+					MODAudioSet.Instance.SetFromZeroBasedIndex(newBGMSEValue);
+				}
+			}
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace MOD.Scripts.UI
 {
-	class MODMenuAudioOptions : MODMenuModuleInterface
+	class MODMenuAudioOptions
 	{
 		private readonly MODRadio radioBGMSESet;
 		private readonly MODMenuCommon c;
@@ -23,10 +23,6 @@ namespace MOD.Scripts.UI
 				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
 				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
 			}, styleManager);
-		}
-
-		public void OnBeforeMenuVisible()
-		{
 		}
 
 		public void OnGUI()

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -1,6 +1,7 @@
 ﻿using MOD.Scripts.Core.Audio;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -17,12 +18,18 @@ namespace MOD.Scripts.UI
 			this.c = c;
 			hasBGMSEOptions = MODActions.HasMusicToggle();
 
-			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[]
+			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[] { }, styleManager);
+		}
+
+		public void OnBeforeMenuVisible()
+		{
+			if (this.radioBGMSESet.GetContents().Length == 0)
 			{
-				new GUIContent("New BGM/SE", "Use the new BGM/SE introduced by MangaGamer in the April 2019 update."),
-				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
-				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
-			}, styleManager);
+				bool japanese = c.GetGlobal("GLanguage") == 0;
+				this.radioBGMSESet.SetContents(
+					MODAudioSet.Instance.GetAudioSets().Select(x => new GUIContent(x.Name(japanese), x.Description(japanese))).ToArray()
+				);
+			}
 		}
 
 		public void OnGUI()

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -2,19 +2,18 @@
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
 
 namespace MOD.Scripts.UI
 {
 	class MODMenuAudioSetup : MODMenuModuleInterface
 	{
 		MODMenu modMenu;
-		MODMenuCommon c;
 		MODMenuAudioOptions audioOptions;
 
-		public MODMenuAudioSetup(MODMenu modMenu, MODMenuCommon c, MODMenuAudioOptions audioOptions)
+		public MODMenuAudioSetup(MODMenu modMenu, MODMenuAudioOptions audioOptions)
 		{
 			this.modMenu = modMenu;
-			this.c = c;
 			this.audioOptions = audioOptions;
 		}
 
@@ -25,14 +24,14 @@ namespace MOD.Scripts.UI
 
 		public void OnGUI()
 		{
-			c.Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.\n\n" +
+			Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.\n\n" +
 				"You can change this at any time via the mod menu.");
 
 			audioOptions.OnGUI(hideLabel: true);
 
 			GUILayout.Space(20);
 
-			if (c.GetGlobal("GAudioSet") != 0 && c.Button(new GUIContent("Click here when you're finished.")))
+			if (GetGlobal("GAudioSet") != 0 && Button(new GUIContent("Click here when you're finished.")))
 			{
 				modMenu.SetMode(ModMenuMode.Normal);
 				modMenu.ForceHide();

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -18,10 +18,7 @@ namespace MOD.Scripts.UI
 			this.audioOptions = audioOptions;
 		}
 
-		public void OnBeforeMenuVisible()
-		{
-			audioOptions.OnBeforeMenuVisible();
-		}
+		public void OnBeforeMenuVisible()	{}
 
 		public void OnGUI()
 		{
@@ -34,8 +31,10 @@ namespace MOD.Scripts.UI
 			if (c.GetGlobal("GAudioSet") != 0 && c.Button(new GUIContent("Click here when you're finished.")))
 			{
 				modMenu.SetMode(ModMenuMode.Normal);
-				modMenu.Hide();
+				modMenu.ForceHide();
 			}
 		}
+
+		public bool UserCanClose() => false;
 	}
 }

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODMenuAudioSetup : MODMenuModuleInterface
+	{
+		MODMenu modMenu;
+		MODMenuCommon c;
+		MODMenuAudioOptions audioOptions;
+
+		public MODMenuAudioSetup(MODMenu modMenu, MODMenuCommon c, MODMenuAudioOptions audioOptions)
+		{
+			this.modMenu = modMenu;
+			this.c = c;
+			this.audioOptions = audioOptions;
+		}
+
+		public void OnBeforeMenuVisible()
+		{
+			audioOptions.OnBeforeMenuVisible();
+		}
+
+		public void OnGUI()
+		{
+			c.Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.");
+
+			audioOptions.OnGUI();
+
+			GUILayout.Space(20);
+
+			if (c.GetGlobal("GAudioSet") != 0 && c.Button(new GUIContent("Click here when you're finished.")))
+			{
+				modMenu.SetMode(ModMenuMode.Normal);
+				modMenu.Hide();
+			}
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -18,7 +18,10 @@ namespace MOD.Scripts.UI
 			this.audioOptions = audioOptions;
 		}
 
-		public void OnBeforeMenuVisible()	{}
+		public void OnBeforeMenuVisible()
+		{
+			audioOptions.OnBeforeMenuVisible();
+		}
 
 		public void OnGUI()
 		{

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -36,5 +36,7 @@ namespace MOD.Scripts.UI
 		}
 
 		public bool UserCanClose() => false;
+		public string Heading() => "First-Time Setup Menu";
+		public string DefaultTooltip() => "Please choose the options on the left before continuing. You can hover over a button to view its description.";
 	}
 }

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -25,9 +25,10 @@ namespace MOD.Scripts.UI
 
 		public void OnGUI()
 		{
-			c.Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.");
+			c.Label("The patch supports different BGM/SE types, they can vary what you will hear and when. Choose the one that feels most appropriate for your experience.\n\n" +
+				"You can change this at any time via the mod menu.");
 
-			audioOptions.OnGUI();
+			audioOptions.OnGUI(hideLabel: true);
 
 			GUILayout.Space(20);
 

--- a/MOD.Scripts.UI/MODMenuCommon.cs
+++ b/MOD.Scripts.UI/MODMenuCommon.cs
@@ -9,7 +9,6 @@ namespace MOD.Scripts.UI
 	class MODMenuCommon
 	{
 		MODStyleManager styleManager;
-		bool anyButtonPressed;
 		public MODMenuCommon(MODStyleManager styleManager)
 		{
 			this.styleManager = styleManager;
@@ -25,18 +24,11 @@ namespace MOD.Scripts.UI
 			GUILayout.Label(label, styleManager.Group.headingLabel);
 		}
 
-		public bool Button(GUIContent guiContent, bool selected = false)
+		public static bool Button(GUIContent guiContent, MODStyleManager styleManager, bool selected = false)
 		{
-			if (GUILayout.Button(guiContent, selected ? styleManager.Group.selectedButton : styleManager.Group.button))
-			{
-				anyButtonPressed = true;
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return GUILayout.Button(guiContent, selected ? styleManager.Group.selectedButton : styleManager.Group.button);
 		}
+		public bool Button(GUIContent guiContent, bool selected = false) => Button(guiContent, styleManager, selected);
 
 		public int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
 		public void SetGlobal(string flagName, int flagValue) => BurikoMemory.Instance.SetGlobalFlag(flagName, flagValue);

--- a/MOD.Scripts.UI/MODMenuCommon.cs
+++ b/MOD.Scripts.UI/MODMenuCommon.cs
@@ -6,31 +6,24 @@ using UnityEngine;
 
 namespace MOD.Scripts.UI
 {
-	class MODMenuCommon
+	static class MODMenuCommon
 	{
-		MODStyleManager styleManager;
-		public MODMenuCommon(MODStyleManager styleManager)
+		public static void Label(string label)
 		{
-			this.styleManager = styleManager;
+			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.label);
 		}
 
-		public void Label(string label)
+		public static void HeadingLabel(string label)
 		{
-			GUILayout.Label(label, styleManager.Group.label);
+			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.headingLabel);
 		}
 
-		public void HeadingLabel(string label)
+		public static bool Button(GUIContent guiContent, bool selected = false)
 		{
-			GUILayout.Label(label, styleManager.Group.headingLabel);
+			return GUILayout.Button(guiContent, selected ? MODStyleManager.OnGUIInstance.Group.selectedButton : MODStyleManager.OnGUIInstance.Group.button);
 		}
 
-		public static bool Button(GUIContent guiContent, MODStyleManager styleManager, bool selected = false)
-		{
-			return GUILayout.Button(guiContent, selected ? styleManager.Group.selectedButton : styleManager.Group.button);
-		}
-		public bool Button(GUIContent guiContent, bool selected = false) => Button(guiContent, styleManager, selected);
-
-		public int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
-		public void SetGlobal(string flagName, int flagValue) => BurikoMemory.Instance.SetGlobalFlag(flagName, flagValue);
+		public static int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
+		public static void SetGlobal(string flagName, int flagValue) => BurikoMemory.Instance.SetGlobalFlag(flagName, flagValue);
 	}
 }

--- a/MOD.Scripts.UI/MODMenuCommon.cs
+++ b/MOD.Scripts.UI/MODMenuCommon.cs
@@ -1,0 +1,44 @@
+﻿using Assets.Scripts.Core.Buriko;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODMenuCommon
+	{
+		MODStyleManager styleManager;
+		bool anyButtonPressed;
+		public MODMenuCommon(MODStyleManager styleManager)
+		{
+			this.styleManager = styleManager;
+		}
+
+		public void Label(string label)
+		{
+			GUILayout.Label(label, styleManager.Group.label);
+		}
+
+		public void HeadingLabel(string label)
+		{
+			GUILayout.Label(label, styleManager.Group.headingLabel);
+		}
+
+		public bool Button(GUIContent guiContent, bool selected = false)
+		{
+			if (GUILayout.Button(guiContent, selected ? styleManager.Group.selectedButton : styleManager.Group.button))
+			{
+				anyButtonPressed = true;
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		public int GetGlobal(string flagName) => BurikoMemory.Instance.GetGlobalFlag(flagName).IntValue();
+		public void SetGlobal(string flagName, int flagValue) => BurikoMemory.Instance.SetGlobalFlag(flagName, flagValue);
+	}
+}

--- a/MOD.Scripts.UI/MODMenuModuleInterface.cs
+++ b/MOD.Scripts.UI/MODMenuModuleInterface.cs
@@ -6,7 +6,14 @@ namespace MOD.Scripts.UI
 {
 	interface MODMenuModuleInterface
 	{
+		/// <summary>
+		/// Called every frame to draw the module
+		/// </summary>
 		void OnGUI();
+		/// <summary>
+		/// Called once just before the menu is shown
+		/// Use for setup, or to do tasks that you don't want to execute every frame
+		/// </summary>
 		void OnBeforeMenuVisible();
 	}
 }

--- a/MOD.Scripts.UI/MODMenuModuleInterface.cs
+++ b/MOD.Scripts.UI/MODMenuModuleInterface.cs
@@ -15,5 +15,7 @@ namespace MOD.Scripts.UI
 		/// Use for setup, or to do tasks that you don't want to execute every frame
 		/// </summary>
 		void OnBeforeMenuVisible();
+
+		bool UserCanClose();
 	}
 }

--- a/MOD.Scripts.UI/MODMenuModuleInterface.cs
+++ b/MOD.Scripts.UI/MODMenuModuleInterface.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MOD.Scripts.UI
+{
+	interface MODMenuModuleInterface
+	{
+		void OnGUI();
+		void OnBeforeMenuVisible();
+	}
+}

--- a/MOD.Scripts.UI/MODMenuModuleInterface.cs
+++ b/MOD.Scripts.UI/MODMenuModuleInterface.cs
@@ -17,5 +17,8 @@ namespace MOD.Scripts.UI
 		void OnBeforeMenuVisible();
 
 		bool UserCanClose();
+
+		string DefaultTooltip();
+		string Heading();
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -12,10 +12,10 @@ namespace MOD.Scripts.UI
 		private readonly MODMenu modMenu;
 		private readonly MODMenuCommon c;
 		private readonly MODMenuResolution resolutionMenu;
+		private readonly MODMenuAudioOptions audioOptionsMenu;
 
 		private GUIContent[] defaultArtsetDescriptions;
 		private readonly bool hasOGBackgrounds;
-		private bool hasBGMSEOptions;
 
 		private readonly MODRadio radioCensorshipLevel;
 		private readonly MODRadio radioLipSync;
@@ -23,16 +23,15 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioHideCG;
 		private readonly MODRadio radioBackgrounds;
 		private readonly MODRadio radioArtSet;
-		private readonly MODRadio radioBGMSESet;
 
-		public MODMenuNormal(MODMenu modMenu, MODMenuCommon c, MODStyleManager styleManager)
+		public MODMenuNormal(MODMenu modMenu, MODMenuCommon c, MODStyleManager styleManager, MODMenuAudioOptions audioOptionsMenu)
 		{
 			this.modMenu = modMenu;
 			this.c = c;
+			this.audioOptionsMenu = audioOptionsMenu;
 			this.resolutionMenu = new MODMenuResolution(c);
 
 			hasOGBackgrounds = MODActions.HasOGBackgrounds();
-			hasBGMSEOptions = MODActions.HasMusicToggle();
 
 			defaultArtsetDescriptions = new GUIContent[] {
 				new GUIContent("Console", "Use the Console sprites and backgrounds"),
@@ -91,13 +90,6 @@ Sets the script censorship level
 			}, styleManager, itemsPerRow: 2);
 
 			radioArtSet = new MODRadio("Choose Art Set", defaultArtsetDescriptions, styleManager, itemsPerRow: 3);
-
-			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[]
-			{
-				new GUIContent("New BGM/SE", "Use the new BGM/SE introduced by MangaGamer in the April 2019 update."),
-				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
-				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
-			}, styleManager);
 		}
 
 		public void OnGUI()
@@ -157,7 +149,7 @@ Sets the script censorship level
 				c.SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
 			};
 
-			OnGUIFragmentChooseAudioSet(c);
+			this.audioOptionsMenu.OnGUI();
 
 			c.HeadingLabel("Advanced Options");
 
@@ -235,6 +227,7 @@ Sets the script censorship level
 			this.radioArtSet.SetContents(descriptions);
 
 			resolutionMenu.OnBeforeMenuVisible();
+			audioOptionsMenu.OnBeforeMenuVisible();
 		}
 
 		private void OnGUIRestoreSettings(MODMenuCommon w)
@@ -268,27 +261,6 @@ Sets the script censorship level
 				}
 			}
 			GUILayout.EndHorizontal();
-		}
-
-		public bool OnGUIFragmentChooseAudioSet(MODMenuCommon c)
-		{
-			if (this.hasBGMSEOptions)
-			{
-				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
-				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : 0) is int newBGMSEValue)
-				{
-					MODAudioSet.Instance.SetFromZeroBasedIndex(newBGMSEValue);
-				}
-
-				GUILayout.Space(20);
-
-				if (c.GetGlobal("GAudioSet") != 0 && c.Button(new GUIContent("Click here when you're finished.")))
-				{
-					return true;
-				}
-			}
-
-			return false;
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -1,0 +1,294 @@
+﻿using Assets.Scripts.Core;
+using MOD.Scripts.Core.Audio;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODMenuNormal : MODMenuModuleInterface
+	{
+		private readonly MODMenu modMenu;
+		private readonly MODMenuCommon c;
+		private readonly MODMenuResolution resolutionMenu;
+
+		private GUIContent[] defaultArtsetDescriptions;
+		private readonly bool hasOGBackgrounds;
+		private bool hasBGMSEOptions;
+
+		private readonly MODRadio radioCensorshipLevel;
+		private readonly MODRadio radioLipSync;
+		private readonly MODRadio radioOpenings;
+		private readonly MODRadio radioHideCG;
+		private readonly MODRadio radioBackgrounds;
+		private readonly MODRadio radioArtSet;
+		private readonly MODRadio radioBGMSESet;
+
+		public MODMenuNormal(MODMenu modMenu, MODMenuCommon c, MODStyleManager styleManager)
+		{
+			this.modMenu = modMenu;
+			this.c = c;
+			this.resolutionMenu = new MODMenuResolution(c);
+
+			hasOGBackgrounds = MODActions.HasOGBackgrounds();
+			hasBGMSEOptions = MODActions.HasMusicToggle();
+
+			defaultArtsetDescriptions = new GUIContent[] {
+				new GUIContent("Console", "Use the Console sprites and backgrounds"),
+				new GUIContent("Remake", "Use Mangagamer's remake sprites with Console backgrounds"),
+				new GUIContent("Original", "Use Original/Ryukishi sprites and backgrounds (if available - OG backgrounds not available for Console Arcs)\n\n" +
+				"Warning: Most users should use the Original/Ryukishi preset at the top of this menu!"),
+			};
+
+			string baseCensorshipDescription = @"
+
+Sets the script censorship level
+- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.
+- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.
+  - 5: Full PS3 script fully voiced (most censored)
+  - 2: Default - most balanced option
+  - 0: Original PC Script with voices where it fits (least uncensored), but uncensored scenes may be missing voices";
+
+			radioCensorshipLevel = new MODRadio("Voice Matching Level (Hotkey: F2)", new GUIContent[] {
+				new GUIContent("0", "Censorship level 0 - Equivalent to PC" + baseCensorshipDescription),
+				new GUIContent("1", "Censorship level 1" + baseCensorshipDescription),
+				new GUIContent("2*", "Censorship level 2 (this is the default/recommended value)" + baseCensorshipDescription),
+				new GUIContent("3", "Censorship level 3" + baseCensorshipDescription),
+				new GUIContent("4", "Censorship level 4" + baseCensorshipDescription),
+				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
+				}, styleManager);
+
+			radioLipSync = new MODRadio("Lip Sync for Console Sprites (Hotkey: 7)", new GUIContent[]
+			{
+				new GUIContent("Lip Sync Off", "Disables Lip Sync for Console Sprites"),
+				new GUIContent("Lip Sync On", "Enables Lip Sync for Console Sprites"),
+			}, styleManager);
+
+			radioOpenings = new MODRadio("Opening Movies (Hotkey: Shift-F12)", new GUIContent[]
+			{
+				new GUIContent("Disabled", "Disables all opening videos"),
+				new GUIContent("Enabled", "Enables opening videos\n\n" +
+				"NOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\n" +
+				"We have setup openings this way to avoid spoilers."),
+				new GUIContent("Launch + In-Game", "WARNING: There is usually no need to set this manually.\n\n" +
+				"If openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\n" +
+				"That is, after the opening is played the first time, from then on openings will play every time the game launches"),
+			}, styleManager);
+
+			radioHideCG = new MODRadio("Show/Hide CGs", new GUIContent[]
+			{
+				new GUIContent("Show CGs", "Shows CGs (You probably want this enabled for Console ADV/NVL mode)"),
+				new GUIContent("Hide CGs", "Disables all CGs (mainly for use with the Original/Ryukishi preset)"),
+			}, styleManager);
+
+			radioBackgrounds = new MODRadio("Override Art Set Backgrounds", new GUIContent[]{
+				new GUIContent("Default BGs", "Use the default backgrounds for the current artset"),
+				new GUIContent("Console BGs", "Force Console backgrounds, regardless of the artset"),
+				new GUIContent("Original BGs", "Force Original/Ryukishi backgrounds, regardless of the artset"),
+				new GUIContent("Original Stretched", "Force Original/Ryukishi backgrounds, stretched to fit, regardless of the artset\n\n" +
+				"WARNING: When using this option, you should have ADV/NVL mode selected, otherwise sprites will be cut off, and UI will appear in the wrong place"),
+			}, styleManager, itemsPerRow: 2);
+
+			radioArtSet = new MODRadio("Choose Art Set", defaultArtsetDescriptions, styleManager, itemsPerRow: 3);
+
+			this.radioBGMSESet = new MODRadio("Choose BGM/SE (Hotkey: 2)", new GUIContent[]
+			{
+				new GUIContent("New BGM/SE", "Use the new BGM/SE introduced by MangaGamer in the April 2019 update."),
+				new GUIContent("Original BGM/SE", "Use the original BGM/SE from the Japanese version of the game. This option was previously known as 'BGM/SE fix'.\n\n" +
+				"Note that this not only changes which audio files are played, but also when BGM starts to play/stops playing, in certain cases."),
+			}, styleManager);
+		}
+
+		public void OnGUI()
+		{
+			c.HeadingLabel("Basic Options");
+
+			c.Label("Graphics Presets (Hotkey: F1)");
+			{
+				GUILayout.BeginHorizontal();
+
+				int advNVLRyukishiMode = MODActions.GetADVNVLRyukishiModeFromFlags(out bool presetModified);
+
+				if (c.Button(new GUIContent(advNVLRyukishiMode == 0 && presetModified ? "ADV (custom)" : "ADV", "This preset:\n" +
+				"- Makes text show at the bottom of the screen in a textbox\n" +
+				"- Shows the name of the current character on the textbox\n" +
+				"- Uses the console sprites and backgrounds\n" +
+				"- Displays in 16:9 widescreen\n\n" +
+				"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 0))
+				{
+					MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
+				}
+
+				if (c.Button(new GUIContent(advNVLRyukishiMode == 1 && presetModified ? "NVL (custom)" : "NVL", "This preset:\n" +
+					"- Makes text show across the whole screen\n" +
+					"- Uses the console sprites and backgrounds\n" +
+					"- Displays in 16:9 widescreen\n\n" +
+					"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 1))
+				{
+					MODActions.SetAndSaveADV(MODActions.ModPreset.NVL, showInfoToast: false);
+				}
+
+				if (this.hasOGBackgrounds &&
+					c.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
+					"- Displays backgrounds in 4:3 'standard' aspect\n" +
+					"- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n" +
+					"- Switches to original sprites and backgrounds\n\n" +
+					"Note that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: advNVLRyukishiMode == 2))
+				{
+					MODActions.SetAndSaveADV(MODActions.ModPreset.OG, showInfoToast: false);
+				}
+
+				GUILayout.EndHorizontal();
+			}
+
+			if (this.radioCensorshipLevel.OnGUIFragment(c.GetGlobal("GCensor")) is int censorLevel)
+			{
+				c.SetGlobal("GCensor", censorLevel);
+			};
+
+			if (this.radioLipSync.OnGUIFragment(c.GetGlobal("GLipSync")) is int lipSyncEnabled)
+			{
+				c.SetGlobal("GLipSync", lipSyncEnabled);
+			};
+
+			if (this.radioOpenings.OnGUIFragment(c.GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
+			{
+				c.SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
+			};
+
+			OnGUIFragmentChooseAudioSet(c);
+
+			c.HeadingLabel("Advanced Options");
+
+			if (this.radioHideCG.OnGUIFragment(c.GetGlobal("GHideCG")) is int hideCG)
+			{
+				c.SetGlobal("GHideCG", hideCG);
+			};
+
+			if (this.radioArtSet.OnGUIFragment(Core.MODSystem.instance.modTextureController.GetArtStyle()) is int artStyle)
+			{
+				c.SetGlobal("GStretchBackgrounds", 0);
+				Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle, showInfoToast: false);
+			}
+
+			if (this.hasOGBackgrounds)
+			{
+				int currentBackground = c.GetGlobal("GBackgroundSet");
+				if (currentBackground == 2)
+				{
+					if (c.GetGlobal("GStretchBackgrounds") == 1)
+					{
+						currentBackground = 3;
+					}
+				}
+				if (this.radioBackgrounds.OnGUIFragment(currentBackground) is int background)
+				{
+					if (background == 3)
+					{
+						c.SetGlobal("GStretchBackgrounds", 1);
+						c.SetGlobal("GBackgroundSet", 2);
+					}
+					else
+					{
+						c.SetGlobal("GStretchBackgrounds", 0);
+						c.SetGlobal("GBackgroundSet", background);
+					}
+					GameSystem.Instance.SceneController.ReloadAllImages();
+				}
+			}
+
+			resolutionMenu.OnGUI();
+
+			GUILayout.Space(10);
+			OnGUIRestoreSettings(c);
+
+
+			c.HeadingLabel("Troubleshooting");
+			c.Label("Save Files and Log Files");
+			MODMenuSupport.ShowSupportButtons(content => c.Button(content));
+
+			c.Label("Developer");
+			GUILayout.BeginHorizontal();
+			if (c.Button(new GUIContent("Toggle debug menu (Shift-F9)", "Toggle the debug menu")))
+			{
+				modMenu.ToggleDebugMenu();
+			}
+			if (c.Button(new GUIContent("Toggle flag menu (Shift-F10)", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.")))
+			{
+				MODActions.ToggleFlagMenu();
+			}
+			GUILayout.EndHorizontal();
+		}
+
+		public void OnBeforeMenuVisible() {
+			// Update the artset radio buttons/descriptions, as these are set by ModAddArtset() calls in init.txt at runtime
+			// Technically only need to do this once after init.txt has been called, but it's easier to just do it each time menu is opened
+			GUIContent[] descriptions = Core.MODSystem.instance.modTextureController.GetArtStyleDescriptions();
+			for (int i = 0; i < descriptions.Length; i++)
+			{
+				if (i < this.defaultArtsetDescriptions.Length)
+				{
+					descriptions[i] = this.defaultArtsetDescriptions[i];
+				}
+			}
+			this.radioArtSet.SetContents(descriptions);
+
+			resolutionMenu.OnBeforeMenuVisible();
+		}
+
+		private void OnGUIRestoreSettings(MODMenuCommon w)
+		{
+			w.Label($"Restore Settings {(w.GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <Restart Pending>")}");
+
+			GUILayout.BeginHorizontal();
+			if (w.GetGlobal("GMOD_SETTING_LOADER") == 3)
+			{
+				if (w.Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
+					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
+				{
+					w.SetGlobal("GMOD_SETTING_LOADER", 0);
+				}
+				else if (w.Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
+					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
+				{
+					w.SetGlobal("GMOD_SETTING_LOADER", 1);
+				}
+				else if (w.Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
+					"NOTE: Requires a relaunch to come into effect. After this, uninstall the mod.")))
+				{
+					w.SetGlobal("GMOD_SETTING_LOADER", 2);
+				}
+			}
+			else
+			{
+				if (w.Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
+				{
+					w.SetGlobal("GMOD_SETTING_LOADER", 3);
+				}
+			}
+			GUILayout.EndHorizontal();
+		}
+
+		public bool OnGUIFragmentChooseAudioSet(MODMenuCommon c)
+		{
+			if (this.hasBGMSEOptions)
+			{
+				// Set GAltBGM, GAltSE, GAltBGMFlow, GAltSEFlow to the same value. In the future we may set them to different values.
+				if (this.radioBGMSESet.OnGUIFragment(c.GetGlobal("GAudioSet") > 0 ? c.GetGlobal("GAudioSet") - 1 : 0) is int newBGMSEValue)
+				{
+					MODAudioSet.Instance.SetFromZeroBasedIndex(newBGMSEValue);
+				}
+
+				GUILayout.Space(20);
+
+				if (c.GetGlobal("GAudioSet") != 0 && c.Button(new GUIContent("Click here when you're finished.")))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -263,5 +263,37 @@ Sets the script censorship level
 		}
 
 		public bool UserCanClose() => true;
+		public string Heading() => "Mod Options Menu";
+
+		public string DefaultTooltip()
+		{
+			return @"Hover over a button on the left panel for its description.
+
+[Vanilla Hotkeys]
+Enter,Return,RightArrow,PageDown : Advance Text
+LeftArrow,Pageup : See Backlog
+ESC : Open Menu
+Ctrl : Hold Skip Mode
+A : Auto Mode
+S : Toggle Skip Mode
+F, Alt-Enter : FullScreen
+Space : Hide Text
+L : Swap Language
+
+[MOD Hotkeys]
+F1 : ADV-NVL MODE
+F2 : Voice Matching Level
+F3 : Effect Level (Not Used)
+F5 : QuickSave
+F7 : QuickLoad
+F10 : Mod Menu
+M : Increase Voice Volume
+N : Decrease Voice Volume
+P : Cycle through art styles
+2 : Cycle through BGM/SE
+7 : Enable/Disable Lip-Sync
+LShift + M : Voice Volume MAX
+LShift + N : Voice Volume MIN";
+		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -227,7 +227,6 @@ Sets the script censorship level
 			this.radioArtSet.SetContents(descriptions);
 
 			resolutionMenu.OnBeforeMenuVisible();
-			audioOptionsMenu.OnBeforeMenuVisible();
 		}
 
 		private void OnGUIRestoreSettings(MODMenuCommon w)
@@ -262,5 +261,7 @@ Sets the script censorship level
 			}
 			GUILayout.EndHorizontal();
 		}
+
+		public bool UserCanClose() => true;
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -4,13 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
 
 namespace MOD.Scripts.UI
 {
 	class MODMenuNormal : MODMenuModuleInterface
 	{
 		private readonly MODMenu modMenu;
-		private readonly MODMenuCommon c;
 		private readonly MODMenuResolution resolutionMenu;
 		private readonly MODMenuAudioOptions audioOptionsMenu;
 
@@ -24,12 +24,11 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioBackgrounds;
 		private readonly MODRadio radioArtSet;
 
-		public MODMenuNormal(MODMenu modMenu, MODMenuCommon c, MODStyleManager styleManager, MODMenuAudioOptions audioOptionsMenu)
+		public MODMenuNormal(MODMenu modMenu, MODMenuAudioOptions audioOptionsMenu)
 		{
 			this.modMenu = modMenu;
-			this.c = c;
 			this.audioOptionsMenu = audioOptionsMenu;
-			this.resolutionMenu = new MODMenuResolution(c);
+			this.resolutionMenu = new MODMenuResolution();
 
 			hasOGBackgrounds = MODActions.HasOGBackgrounds();
 
@@ -56,13 +55,13 @@ Sets the script censorship level
 				new GUIContent("3", "Censorship level 3" + baseCensorshipDescription),
 				new GUIContent("4", "Censorship level 4" + baseCensorshipDescription),
 				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
-				}, styleManager);
+				});
 
 			radioLipSync = new MODRadio("Lip Sync for Console Sprites (Hotkey: 7)", new GUIContent[]
 			{
 				new GUIContent("Lip Sync Off", "Disables Lip Sync for Console Sprites"),
 				new GUIContent("Lip Sync On", "Enables Lip Sync for Console Sprites"),
-			}, styleManager);
+			});
 
 			radioOpenings = new MODRadio("Opening Movies (Hotkey: Shift-F12)", new GUIContent[]
 			{
@@ -73,13 +72,13 @@ Sets the script censorship level
 				new GUIContent("Launch + In-Game", "WARNING: There is usually no need to set this manually.\n\n" +
 				"If openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\n" +
 				"That is, after the opening is played the first time, from then on openings will play every time the game launches"),
-			}, styleManager);
+			});
 
 			radioHideCG = new MODRadio("Show/Hide CGs", new GUIContent[]
 			{
 				new GUIContent("Show CGs", "Shows CGs (You probably want this enabled for Console ADV/NVL mode)"),
 				new GUIContent("Hide CGs", "Disables all CGs (mainly for use with the Original/Ryukishi preset)"),
-			}, styleManager);
+			});
 
 			radioBackgrounds = new MODRadio("Override Art Set Backgrounds", new GUIContent[]{
 				new GUIContent("Default BGs", "Use the default backgrounds for the current artset"),
@@ -87,22 +86,22 @@ Sets the script censorship level
 				new GUIContent("Original BGs", "Force Original/Ryukishi backgrounds, regardless of the artset"),
 				new GUIContent("Original Stretched", "Force Original/Ryukishi backgrounds, stretched to fit, regardless of the artset\n\n" +
 				"WARNING: When using this option, you should have ADV/NVL mode selected, otherwise sprites will be cut off, and UI will appear in the wrong place"),
-			}, styleManager, itemsPerRow: 2);
+			}, itemsPerRow: 2);
 
-			radioArtSet = new MODRadio("Choose Art Set", defaultArtsetDescriptions, styleManager, itemsPerRow: 3);
+			radioArtSet = new MODRadio("Choose Art Set", defaultArtsetDescriptions, itemsPerRow: 3);
 		}
 
 		public void OnGUI()
 		{
-			c.HeadingLabel("Basic Options");
+			HeadingLabel("Basic Options");
 
-			c.Label("Graphics Presets (Hotkey: F1)");
+			Label("Graphics Presets (Hotkey: F1)");
 			{
 				GUILayout.BeginHorizontal();
 
 				int advNVLRyukishiMode = MODActions.GetADVNVLRyukishiModeFromFlags(out bool presetModified);
 
-				if (c.Button(new GUIContent(advNVLRyukishiMode == 0 && presetModified ? "ADV (custom)" : "ADV", "This preset:\n" +
+				if (Button(new GUIContent(advNVLRyukishiMode == 0 && presetModified ? "ADV (custom)" : "ADV", "This preset:\n" +
 				"- Makes text show at the bottom of the screen in a textbox\n" +
 				"- Shows the name of the current character on the textbox\n" +
 				"- Uses the console sprites and backgrounds\n" +
@@ -112,7 +111,7 @@ Sets the script censorship level
 					MODActions.SetAndSaveADV(MODActions.ModPreset.ADV, showInfoToast: false);
 				}
 
-				if (c.Button(new GUIContent(advNVLRyukishiMode == 1 && presetModified ? "NVL (custom)" : "NVL", "This preset:\n" +
+				if (Button(new GUIContent(advNVLRyukishiMode == 1 && presetModified ? "NVL (custom)" : "NVL", "This preset:\n" +
 					"- Makes text show across the whole screen\n" +
 					"- Uses the console sprites and backgrounds\n" +
 					"- Displays in 16:9 widescreen\n\n" +
@@ -122,7 +121,7 @@ Sets the script censorship level
 				}
 
 				if (this.hasOGBackgrounds &&
-					c.Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
+					Button(new GUIContent(advNVLRyukishiMode == 2 && presetModified ? "Original/Ryukishi (custom)" : "Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
 					"- Displays backgrounds in 4:3 'standard' aspect\n" +
 					"- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n" +
 					"- Switches to original sprites and backgrounds\n\n" +
@@ -134,44 +133,44 @@ Sets the script censorship level
 				GUILayout.EndHorizontal();
 			}
 
-			if (this.radioCensorshipLevel.OnGUIFragment(c.GetGlobal("GCensor")) is int censorLevel)
+			if (this.radioCensorshipLevel.OnGUIFragment(GetGlobal("GCensor")) is int censorLevel)
 			{
-				c.SetGlobal("GCensor", censorLevel);
+				SetGlobal("GCensor", censorLevel);
 			};
 
-			if (this.radioLipSync.OnGUIFragment(c.GetGlobal("GLipSync")) is int lipSyncEnabled)
+			if (this.radioLipSync.OnGUIFragment(GetGlobal("GLipSync")) is int lipSyncEnabled)
 			{
-				c.SetGlobal("GLipSync", lipSyncEnabled);
+				SetGlobal("GLipSync", lipSyncEnabled);
 			};
 
-			if (this.radioOpenings.OnGUIFragment(c.GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
+			if (this.radioOpenings.OnGUIFragment(GetGlobal("GVideoOpening") - 1) is int openingVideoLevelZeroIndexed)
 			{
-				c.SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
+				SetGlobal("GVideoOpening", openingVideoLevelZeroIndexed + 1);
 			};
 
 			this.audioOptionsMenu.OnGUI();
 
-			c.HeadingLabel("Advanced Options");
+			HeadingLabel("Advanced Options");
 
 			this.audioOptionsMenu.AdvancedOnGUI();
 
-			if (this.radioHideCG.OnGUIFragment(c.GetGlobal("GHideCG")) is int hideCG)
+			if (this.radioHideCG.OnGUIFragment(GetGlobal("GHideCG")) is int hideCG)
 			{
-				c.SetGlobal("GHideCG", hideCG);
+				SetGlobal("GHideCG", hideCG);
 			};
 
 			if (this.radioArtSet.OnGUIFragment(Core.MODSystem.instance.modTextureController.GetArtStyle()) is int artStyle)
 			{
-				c.SetGlobal("GStretchBackgrounds", 0);
+				SetGlobal("GStretchBackgrounds", 0);
 				Core.MODSystem.instance.modTextureController.SetArtStyle(artStyle, showInfoToast: false);
 			}
 
 			if (this.hasOGBackgrounds)
 			{
-				int currentBackground = c.GetGlobal("GBackgroundSet");
+				int currentBackground = GetGlobal("GBackgroundSet");
 				if (currentBackground == 2)
 				{
-					if (c.GetGlobal("GStretchBackgrounds") == 1)
+					if (GetGlobal("GStretchBackgrounds") == 1)
 					{
 						currentBackground = 3;
 					}
@@ -180,13 +179,13 @@ Sets the script censorship level
 				{
 					if (background == 3)
 					{
-						c.SetGlobal("GStretchBackgrounds", 1);
-						c.SetGlobal("GBackgroundSet", 2);
+						SetGlobal("GStretchBackgrounds", 1);
+						SetGlobal("GBackgroundSet", 2);
 					}
 					else
 					{
-						c.SetGlobal("GStretchBackgrounds", 0);
-						c.SetGlobal("GBackgroundSet", background);
+						SetGlobal("GStretchBackgrounds", 0);
+						SetGlobal("GBackgroundSet", background);
 					}
 					GameSystem.Instance.SceneController.ReloadAllImages();
 				}
@@ -195,20 +194,20 @@ Sets the script censorship level
 			resolutionMenu.OnGUI();
 
 			GUILayout.Space(10);
-			OnGUIRestoreSettings(c);
+			OnGUIRestoreSettings();
 
 
-			c.HeadingLabel("Troubleshooting");
-			c.Label("Save Files and Log Files");
-			MODMenuSupport.ShowSupportButtons(content => c.Button(content));
+			HeadingLabel("Troubleshooting");
+			Label("Save Files and Log Files");
+			MODMenuSupport.ShowSupportButtons(content => Button(content));
 
-			c.Label("Developer");
+			Label("Developer");
 			GUILayout.BeginHorizontal();
-			if (c.Button(new GUIContent("Toggle debug menu (Shift-F9)", "Toggle the debug menu")))
+			if (Button(new GUIContent("Toggle debug menu (Shift-F9)", "Toggle the debug menu")))
 			{
 				modMenu.ToggleDebugMenu();
 			}
-			if (c.Button(new GUIContent("Toggle flag menu (Shift-F10)", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.")))
+			if (Button(new GUIContent("Toggle flag menu (Shift-F10)", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.")))
 			{
 				MODActions.ToggleFlagMenu();
 			}
@@ -232,34 +231,34 @@ Sets the script censorship level
 			audioOptionsMenu.OnBeforeMenuVisible();
 		}
 
-		private void OnGUIRestoreSettings(MODMenuCommon w)
+		private void OnGUIRestoreSettings()
 		{
-			w.Label($"Restore Settings {(w.GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <Restart Pending>")}");
+			Label($"Restore Settings {(GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <Restart Pending>")}");
 
 			GUILayout.BeginHorizontal();
-			if (w.GetGlobal("GMOD_SETTING_LOADER") == 3)
+			if (GetGlobal("GMOD_SETTING_LOADER") == 3)
 			{
-				if (w.Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
+				if (Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
 					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
 				{
-					w.SetGlobal("GMOD_SETTING_LOADER", 0);
+					SetGlobal("GMOD_SETTING_LOADER", 0);
 				}
-				else if (w.Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
+				else if (Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
 					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
 				{
-					w.SetGlobal("GMOD_SETTING_LOADER", 1);
+					SetGlobal("GMOD_SETTING_LOADER", 1);
 				}
-				else if (w.Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
+				else if (Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
 					"NOTE: Requires a relaunch to come into effect. After this, uninstall the mod.")))
 				{
-					w.SetGlobal("GMOD_SETTING_LOADER", 2);
+					SetGlobal("GMOD_SETTING_LOADER", 2);
 				}
 			}
 			else
 			{
-				if (w.Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
+				if (Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
 				{
-					w.SetGlobal("GMOD_SETTING_LOADER", 3);
+					SetGlobal("GMOD_SETTING_LOADER", 3);
 				}
 			}
 			GUILayout.EndHorizontal();

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -153,6 +153,8 @@ Sets the script censorship level
 
 			c.HeadingLabel("Advanced Options");
 
+			this.audioOptionsMenu.AdvancedOnGUI();
+
 			if (this.radioHideCG.OnGUIFragment(c.GetGlobal("GHideCG")) is int hideCG)
 			{
 				c.SetGlobal("GHideCG", hideCG);

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -227,6 +227,7 @@ Sets the script censorship level
 			this.radioArtSet.SetContents(descriptions);
 
 			resolutionMenu.OnBeforeMenuVisible();
+			audioOptionsMenu.OnBeforeMenuVisible();
 		}
 
 		private void OnGUIRestoreSettings(MODMenuCommon w)

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -1,0 +1,95 @@
+﻿using Assets.Scripts.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODMenuResolution : MODMenuModuleInterface
+	{
+		private string screenHeightString;
+		MODMenuCommon c;
+
+		public MODMenuResolution(MODMenuCommon c)
+		{
+			this.c = c;
+			screenHeightString = "";
+		}
+
+		public void OnBeforeMenuVisible()
+		{
+			screenHeightString = $"{Screen.height}";
+		}
+
+		public void OnGUI()
+		{
+			c.Label("Resolution Settings");
+			{
+				GUILayout.BeginHorizontal();
+				if (c.Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }
+				if (c.Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
+				if (c.Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
+				if (c.Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
+				if (GameSystem.Instance.IsFullscreen)
+				{
+					if (c.Button(new GUIContent("Windowed", "Toggle Fullscreen")))
+					{
+						GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
+					}
+				}
+				else
+				{
+					if (c.Button(new GUIContent("Fullscreen", "Toggle Fullscreen")))
+					{
+						GameSystem.Instance.GoFullscreen();
+					}
+				}
+
+				screenHeightString = GUILayout.TextField(screenHeightString);
+				if (c.Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.\n\n" +
+					"Height set automatically to maintain 16:9 aspect ratio.")))
+				{
+					if (int.TryParse(screenHeightString, out int new_height))
+					{
+						if (new_height < 480)
+						{
+							MODToaster.Show("Height too small - must be at least 480 pixels");
+							new_height = 480;
+						}
+						else if (new_height > 15360)
+						{
+							MODToaster.Show("Height too big - must be less than 15360 pixels");
+							new_height = 15360;
+						}
+						screenHeightString = $"{new_height}";
+						int new_width = Mathf.RoundToInt(new_height * 16f / 9f);
+						Screen.SetResolution(new_width, new_height, Screen.fullScreen);
+						PlayerPrefs.SetInt("width", new_width);
+						PlayerPrefs.SetInt("height", new_height);
+					}
+				}
+				GUILayout.EndHorizontal();
+			}
+		}
+
+		private void SetAndSaveResolution(int height)
+		{
+			if (height < 480)
+			{
+				MODToaster.Show("Height too small - must be at least 480 pixels");
+				height = 480;
+			}
+			else if (height > 15360)
+			{
+				MODToaster.Show("Height too big - must be less than 15360 pixels");
+				height = 15360;
+			}
+			screenHeightString = $"{height}";
+			int width = Mathf.RoundToInt(height * 16f / 9f);
+			Screen.SetResolution(width, height, Screen.fullScreen);
+			PlayerPrefs.SetInt("width", width);
+			PlayerPrefs.SetInt("height", height);
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -3,17 +3,16 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
 
 namespace MOD.Scripts.UI
 {
 	class MODMenuResolution
 	{
 		private string screenHeightString;
-		MODMenuCommon c;
 
-		public MODMenuResolution(MODMenuCommon c)
+		public MODMenuResolution()
 		{
-			this.c = c;
 			screenHeightString = "";
 		}
 
@@ -24,30 +23,30 @@ namespace MOD.Scripts.UI
 
 		public void OnGUI()
 		{
-			c.Label("Resolution Settings");
+			Label("Resolution Settings");
 			{
 				GUILayout.BeginHorizontal();
-				if (c.Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }
-				if (c.Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
-				if (c.Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
-				if (c.Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
+				if (Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }
+				if (Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
+				if (Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
+				if (Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
 				if (GameSystem.Instance.IsFullscreen)
 				{
-					if (c.Button(new GUIContent("Windowed", "Toggle Fullscreen")))
+					if (Button(new GUIContent("Windowed", "Toggle Fullscreen")))
 					{
 						GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
 					}
 				}
 				else
 				{
-					if (c.Button(new GUIContent("Fullscreen", "Toggle Fullscreen")))
+					if (Button(new GUIContent("Fullscreen", "Toggle Fullscreen")))
 					{
 						GameSystem.Instance.GoFullscreen();
 					}
 				}
 
 				screenHeightString = GUILayout.TextField(screenHeightString);
-				if (c.Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.\n\n" +
+				if (Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.\n\n" +
 					"Height set automatically to maintain 16:9 aspect ratio.")))
 				{
 					if (int.TryParse(screenHeightString, out int new_height))

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace MOD.Scripts.UI
 {
-	class MODMenuResolution : MODMenuModuleInterface
+	class MODMenuResolution
 	{
 		private string screenHeightString;
 		MODMenuCommon c;

--- a/MOD.Scripts.UI/MODMenuSupport.cs
+++ b/MOD.Scripts.UI/MODMenuSupport.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODMenuSupport
+	{
+		private static Vector2 emergencyMenuScrollPosition;
+
+		/// <summary>
+		/// NOTE: You must call this from within a OnGUI() call
+		///
+		/// This function draws an emergency mod menu in case of a critical game error
+		/// (for example, corrupted game save)
+		///
+		/// Please do null checks/try catch for gamesystem etc. if used in this function as it may be called
+		/// during an error condition where gamesystem and other core system parts are not initialized yet
+		/// </summary>
+		/// <param name="errorMessage"></param>
+		public static void EmergencyModMenu(string shortErrorMessage, string longErrorMessage)
+		{
+			emergencyMenuScrollPosition = GUILayout.BeginScrollView(emergencyMenuScrollPosition);
+			GUILayout.Label(shortErrorMessage);
+			GUILayout.Label(longErrorMessage);
+
+			ShowSupportButtons(content => GUILayout.Button(content));
+
+			GUILayout.Label(GUI.tooltip == "" ? "Please hover over a button for more information" : GUI.tooltip, GUI.skin.textArea, GUILayout.MinHeight(210));
+
+			GUILayout.EndScrollView();
+		}
+
+		/// <summary>
+		/// NOTE: You must call this from within a OnGUI() call
+		/// </summary>
+		public static void ShowSupportButtons(Func<GUIContent, bool> buttonRenderer)
+		{
+			{
+				GUILayout.BeginHorizontal();
+				if (buttonRenderer(new GUIContent("Show output_log.txt / Player.log",
+					"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
+					"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
+					"- This file records errors that occur during gameplay, and during game startup\n" +
+					"- This file helps when the game fails start, for example\n" +
+					"  - a corrupted save file\n" +
+					"  - the wrong UI (sharedassets0.assets) file\n" +
+					"- Note that each time the game starts up, the current log file is replaced")))
+				{
+					MODActions.ShowLogFolder();
+				}
+
+				if (buttonRenderer(new GUIContent("Show Saves", "Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
+					"- WARNING: Steam sync will restore your saves if you manually delete them! Therefore, remember to disable steam sync, otherwise your saves will magically reappear!\n" +
+					"- The 'global.dat' file stores your global unlock process and mod flags\n" +
+					"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
+					"- It's recommended to take a backup of all your saves before you modify them")))
+				{
+					MODActions.ShowSaveFolder();
+				}
+
+				if (buttonRenderer(new GUIContent("Show Compiled Scripts", "Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\n" +
+					"You can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\n" +
+					"Please be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.")))
+				{
+					Application.OpenURL(System.IO.Path.Combine(Application.streamingAssetsPath, "CompiledUpdateScripts"));
+				}
+
+
+				GUILayout.EndHorizontal();
+			}
+
+			if (buttonRenderer(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
+				"There are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly")))
+			{
+				Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
+			}
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODRadio.cs
+++ b/MOD.Scripts.UI/MODRadio.cs
@@ -12,8 +12,17 @@ namespace MOD.Scripts.UI
 		private GUIContent[] radioContents;
 		MODStyleManager styleManager;
 		int itemsPerRow;
+		bool asButtons;
 
-		public MODRadio(string label, GUIContent[] radioContents, MODStyleManager styleManager, int itemsPerRow = 0) //Action<int> onRadioChange, 
+		/// <summary>
+		/// Create a radio widget
+		/// </summary>
+		/// <param name="label">The heading label for this radio widget</param>
+		/// <param name="radioContents">The button name and hover tooltip for each option</param>
+		/// <param name="styleManager">The style manager with which the label and buttons will be rendered</param>
+		/// <param name="itemsPerRow">The number of buttons per row</param>
+		/// <param name="asButtons">Implement this as Buttons rather than SelectionGrid, which allows clicking on an already selected item</param>
+		public MODRadio(string label, GUIContent[] radioContents, MODStyleManager styleManager, int itemsPerRow = 0, bool asButtons = false)
 		{
 			this.label = label;
 			this.radioContents = radioContents;
@@ -23,6 +32,7 @@ namespace MOD.Scripts.UI
 				this.itemsPerRow = itemsPerRow;
 			}
 			this.styleManager = styleManager;
+			this.asButtons = asButtons;
 		}
 
 		/// <summary>
@@ -30,7 +40,10 @@ namespace MOD.Scripts.UI
 		/// Displays the radio, calling onRadioChange when the user clicks on a different radio value.
 		/// </summary>
 		/// <param name="displayedRadio">Sets the currently displayed radio. Use "-1" for "None selected"</param>
-		/// <returns>If radio did not change value, null is returned, otherwise the new value is returned.</returns>
+		/// <returns>
+		/// If asButtons is false, If radio did not change value, null is returned, otherwise the new value is returned.
+		/// If asButtons is true, returns the clicked button's index, even if the radio did not change. If nothing clicked, null returned.
+		/// </returns>
 		public int? OnGUIFragment(int displayedRadio, bool hideLabel = false)
 		{
 			if (!hideLabel)
@@ -43,12 +56,37 @@ namespace MOD.Scripts.UI
 				GUILayout.Label("MODRadio Error: this radio has no options!", styleManager.Group.label);
 			}
 
-			int i = GUILayout.SelectionGrid(displayedRadio, radioContents, itemsPerRow, styleManager.Group.modMenuSelectionGrid);
-			if (i != displayedRadio)
+			if(asButtons)
 			{
-				MODRadio.anyRadioPressed = true;
-				return i;
+				GUILayout.BeginVertical();
+				GUILayout.BeginHorizontal();
+				for(int i = 0; i < radioContents.Length; i++)
+				{
+					if ((i % itemsPerRow) == 0 && i != 0)
+					{
+						GUILayout.EndHorizontal();
+						GUILayout.BeginHorizontal();
+					}
+
+					if (MODMenuCommon.Button(radioContents[i], styleManager, selected: i == displayedRadio))
+					{
+						MODRadio.anyRadioPressed = true;
+						return i;
+					}
+				}
+				GUILayout.EndHorizontal();
+				GUILayout.EndVertical();
 			}
+			else
+			{
+				int i = GUILayout.SelectionGrid(displayedRadio, radioContents, itemsPerRow, styleManager.Group.modMenuSelectionGrid);
+				if (i != displayedRadio)
+				{
+					MODRadio.anyRadioPressed = true;
+					return i;
+				}
+			}
+
 
 			return null;
 		}

--- a/MOD.Scripts.UI/MODRadio.cs
+++ b/MOD.Scripts.UI/MODRadio.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
 
 namespace MOD.Scripts.UI
 {
@@ -10,7 +11,6 @@ namespace MOD.Scripts.UI
 		public static bool anyRadioPressed;
 		string label;
 		private GUIContent[] radioContents;
-		MODStyleManager styleManager;
 		int itemsPerRow;
 		bool asButtons;
 
@@ -19,10 +19,9 @@ namespace MOD.Scripts.UI
 		/// </summary>
 		/// <param name="label">The heading label for this radio widget</param>
 		/// <param name="radioContents">The button name and hover tooltip for each option</param>
-		/// <param name="styleManager">The style manager with which the label and buttons will be rendered</param>
 		/// <param name="itemsPerRow">The number of buttons per row</param>
 		/// <param name="asButtons">Implement this as Buttons rather than SelectionGrid, which allows clicking on an already selected item</param>
-		public MODRadio(string label, GUIContent[] radioContents, MODStyleManager styleManager, int itemsPerRow = 0, bool asButtons = false)
+		public MODRadio(string label, GUIContent[] radioContents, int itemsPerRow = 0, bool asButtons = false)
 		{
 			this.label = label;
 			this.radioContents = radioContents;
@@ -31,7 +30,6 @@ namespace MOD.Scripts.UI
 			{
 				this.itemsPerRow = itemsPerRow;
 			}
-			this.styleManager = styleManager;
 			this.asButtons = asButtons;
 		}
 
@@ -46,6 +44,7 @@ namespace MOD.Scripts.UI
 		/// </returns>
 		public int? OnGUIFragment(int displayedRadio, bool hideLabel = false)
 		{
+			MODStyleManager styleManager = MODStyleManager.OnGUIInstance;
 			if (!hideLabel)
 			{
 				GUILayout.Label(this.label, styleManager.Group.label);
@@ -68,7 +67,7 @@ namespace MOD.Scripts.UI
 						GUILayout.BeginHorizontal();
 					}
 
-					if (MODMenuCommon.Button(radioContents[i], styleManager, selected: i == displayedRadio))
+					if (Button(radioContents[i], selected: i == displayedRadio))
 					{
 						MODRadio.anyRadioPressed = true;
 						return i;

--- a/MOD.Scripts.UI/MODRadio.cs
+++ b/MOD.Scripts.UI/MODRadio.cs
@@ -34,6 +34,12 @@ namespace MOD.Scripts.UI
 		public int? OnGUIFragment(int displayedRadio)
 		{
 			GUILayout.Label(this.label, styleManager.Group.label);
+
+			if(radioContents.Length == 0)
+			{
+				GUILayout.Label("MODRadio Error: this radio has no options!", styleManager.Group.label);
+			}
+
 			int i = GUILayout.SelectionGrid(displayedRadio, radioContents, itemsPerRow, styleManager.Group.modMenuSelectionGrid);
 			if (i != displayedRadio)
 			{
@@ -48,5 +54,7 @@ namespace MOD.Scripts.UI
 		{
 			this.radioContents = content;
 		}
+
+		public GUIContent[] GetContents() => this.radioContents;
 	}
 }

--- a/MOD.Scripts.UI/MODRadio.cs
+++ b/MOD.Scripts.UI/MODRadio.cs
@@ -31,9 +31,12 @@ namespace MOD.Scripts.UI
 		/// </summary>
 		/// <param name="displayedRadio">Sets the currently displayed radio. Use "-1" for "None selected"</param>
 		/// <returns>If radio did not change value, null is returned, otherwise the new value is returned.</returns>
-		public int? OnGUIFragment(int displayedRadio)
+		public int? OnGUIFragment(int displayedRadio, bool hideLabel = false)
 		{
-			GUILayout.Label(this.label, styleManager.Group.label);
+			if (!hideLabel)
+			{
+				GUILayout.Label(this.label, styleManager.Group.label);
+			}
 
 			if(radioContents.Length == 0)
 			{

--- a/MOD.Scripts.UI/MODRadio.cs
+++ b/MOD.Scripts.UI/MODRadio.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.UI
+{
+	class MODRadio
+	{
+		public static bool anyRadioPressed;
+		string label;
+		private GUIContent[] radioContents;
+		MODStyleManager styleManager;
+		int itemsPerRow;
+
+		public MODRadio(string label, GUIContent[] radioContents, MODStyleManager styleManager, int itemsPerRow = 0) //Action<int> onRadioChange, 
+		{
+			this.label = label;
+			this.radioContents = radioContents;
+			this.itemsPerRow = radioContents.Length == 0 ? 1 : radioContents.Length;
+			if (itemsPerRow != 0)
+			{
+				this.itemsPerRow = itemsPerRow;
+			}
+			this.styleManager = styleManager;
+		}
+
+		/// <summary>
+		/// NOTE: only call this function within OnGUI()
+		/// Displays the radio, calling onRadioChange when the user clicks on a different radio value.
+		/// </summary>
+		/// <param name="displayedRadio">Sets the currently displayed radio. Use "-1" for "None selected"</param>
+		/// <returns>If radio did not change value, null is returned, otherwise the new value is returned.</returns>
+		public int? OnGUIFragment(int displayedRadio)
+		{
+			GUILayout.Label(this.label, styleManager.Group.label);
+			int i = GUILayout.SelectionGrid(displayedRadio, radioContents, itemsPerRow, styleManager.Group.modMenuSelectionGrid);
+			if (i != displayedRadio)
+			{
+				MODRadio.anyRadioPressed = true;
+				return i;
+			}
+
+			return null;
+		}
+
+		public void SetContents(GUIContent[] content)
+		{
+			this.radioContents = content;
+		}
+	}
+}

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -70,7 +70,7 @@ namespace MOD.Scripts.UI
 
 			for (int i = 0; i < pix.Length; i++)
 			{
-				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.65f);
+				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.7f);
 			}
 			modGUIBackgroundTextureLight = new Texture2D(width, height);
 			modGUIBackgroundTextureLight.SetPixels(pix);

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -7,6 +7,12 @@ namespace MOD.Scripts.UI
 {
 	public class MODStyleManager
 	{
+		private static MODStyleManager _instance;
+		/// <summary>
+		/// Only call this function from within an OnGUI() context, as Unity gives an error if you try to create styles elsewhere.
+		/// </summary>
+		public static MODStyleManager OnGUIInstance => _instance ?? (_instance = new MODStyleManager());
+
 		public class StyleGroup
 		{
 			public int menuHeight;
@@ -54,10 +60,7 @@ namespace MOD.Scripts.UI
 
 		public float baseFontSize = 14;
 
-		/// <summary>
-		/// Note that this static construct is automatically created
-		/// </summary>
-		public MODStyleManager()
+		private MODStyleManager()
 		{
 			int width = 10;
 			int height = 10;

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -27,8 +27,10 @@ namespace MOD.Scripts.UI
 		// Styles used for the Mod menu
 		public GUIStyle modMenuAreaStyle;       //Used for Area widgets
 		public GUIStyle modMenuAreaStyleLight;
+		public GUIStyle modMenuAreaStyleTransparent;
 
 		public Texture2D modGUIBackgroundTexture;
+		public Texture2D modGUIBackgroundTextureTransparent;
 		public Texture2D modGUIBackgroundTextureLight;
 
 		StyleGroup style480;
@@ -57,21 +59,49 @@ namespace MOD.Scripts.UI
 		/// </summary>
 		public MODStyleManager()
 		{
-			int width = 1;
-			int height = 1;
+			int width = 10;
+			int height = 10;
 			Color[] pix = new Color[width * height];
+
 			for (int i = 0; i < pix.Length; i++)
 			{
-				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.9f);
+				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.0f);
 			}
+
+			modGUIBackgroundTextureTransparent = new Texture2D(width, height);
+			modGUIBackgroundTextureTransparent.SetPixels(pix);
+			modGUIBackgroundTextureTransparent.Apply();
+
+			for (int i = 0; i < pix.Length; i++)
+			{
+				pix[i] = new Color(0.7f, 0.7f, 0.7f);
+			}
+
+			for (int y = 2; y < height-2; y++)
+			{
+				for (int x = 2; x < width-2; x++)
+				{
+					pix[x + y * width] = new Color(0.0f, 0.0f, 0.0f, 0.9f);
+				}
+			}
+
 			modGUIBackgroundTexture = new Texture2D(width, height);
 			modGUIBackgroundTexture.SetPixels(pix);
 			modGUIBackgroundTexture.Apply();
 
 			for (int i = 0; i < pix.Length; i++)
 			{
-				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.7f);
+				pix[i] = new Color(1.0f, 1.0f, 1.0f, 0.7f);
 			}
+
+			for (int y = 2; y < height-2; y++)
+			{
+				for (int x = 2; x < width-2; x++)
+				{
+					pix[x + y * width] = new Color(0.0f, 0.0f, 0.0f, 0.7f);
+				}
+			}
+
 			modGUIBackgroundTextureLight = new Texture2D(width, height);
 			modGUIBackgroundTextureLight.SetPixels(pix);
 			modGUIBackgroundTextureLight.Apply();
@@ -139,6 +169,9 @@ namespace MOD.Scripts.UI
 
 			modMenuAreaStyleLight = new GUIStyle(modMenuAreaStyle);
 			modMenuAreaStyleLight.normal.background = modGUIBackgroundTextureLight;
+
+			modMenuAreaStyleTransparent = new GUIStyle(modMenuAreaStyle);
+			modMenuAreaStyleTransparent.normal.background = modGUIBackgroundTextureTransparent;
 		}
 
 		private StyleGroup GenerateWidgetStyles(int menuWidth, int menuHeight, float guiScale, RectOffset margin, RectOffset padding)

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -95,7 +95,7 @@ namespace MOD.Scripts.UI
 
 			style1080 = GenerateWidgetStyles(
 				menuWidth: 1200,
-				menuHeight: 800,
+				menuHeight: 950,
 				guiScale: 1.25f,
 				margin: new RectOffset(2, 2, 2, 2),
 				padding: new RectOffset(2, 2, 2, 2)

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -17,6 +17,7 @@ namespace MOD.Scripts.UI
 			public GUIStyle selectedButton;
 			public GUIStyle label;             //Used for normal Label widgets
 			public GUIStyle headingLabel;
+			public GUIStyle upperLeftHeadingLabel;
 		}
 
 		// Styles used for Toasts
@@ -24,9 +25,11 @@ namespace MOD.Scripts.UI
 		public GUIStyle smallToastLabelStyle;
 
 		// Styles used for the Mod menu
-		public GUIStyle modMenuAreaStyle;		//Used for Area widgets
+		public GUIStyle modMenuAreaStyle;       //Used for Area widgets
+		public GUIStyle modMenuAreaStyleLight;
 
 		public Texture2D modGUIBackgroundTexture;
+		public Texture2D modGUIBackgroundTextureLight;
 
 		StyleGroup style480;
 		StyleGroup style720;
@@ -64,6 +67,15 @@ namespace MOD.Scripts.UI
 			modGUIBackgroundTexture = new Texture2D(width, height);
 			modGUIBackgroundTexture.SetPixels(pix);
 			modGUIBackgroundTexture.Apply();
+
+			for (int i = 0; i < pix.Length; i++)
+			{
+				pix[i] = new Color(0.0f, 0.0f, 0.0f, 0.65f);
+			}
+			modGUIBackgroundTextureLight = new Texture2D(width, height);
+			modGUIBackgroundTextureLight.SetPixels(pix);
+			modGUIBackgroundTextureLight.Apply();
+
 
 			style480 = GenerateWidgetStyles(
 				menuWidth: 850,
@@ -124,6 +136,9 @@ namespace MOD.Scripts.UI
 			modMenuAreaStyle.normal.background = modGUIBackgroundTexture;
 			modMenuAreaStyle.normal.textColor = Color.white;
 			modMenuAreaStyle.wordWrap = true;
+
+			modMenuAreaStyleLight = new GUIStyle(modMenuAreaStyle);
+			modMenuAreaStyleLight.normal.background = modGUIBackgroundTextureLight;
 		}
 
 		private StyleGroup GenerateWidgetStyles(int menuWidth, int menuHeight, float guiScale, RectOffset margin, RectOffset padding)
@@ -153,6 +168,9 @@ namespace MOD.Scripts.UI
 			};
 			headingLabelStyle.padding.top *= 5;
 
+			GUIStyle upperLeftHeadingLabelStyle = new GUIStyle(headingLabelStyle);
+			upperLeftHeadingLabelStyle.alignment = TextAnchor.UpperLeft;
+
 			// Menu selection grid/radio
 			GUIStyle modMenuSelectionGrid = new GUIStyle(GUI.skin.button) //Copy the default style for 'box' as a base
 			{
@@ -177,6 +195,7 @@ namespace MOD.Scripts.UI
 				selectedButton = selectedButtonStyle,
 				label = labelStyle,
 				headingLabel = headingLabelStyle,
+				upperLeftHeadingLabel = upperLeftHeadingLabelStyle,
 			};
 		}
 	}

--- a/MOD.Scripts.UI/MODToaster.cs
+++ b/MOD.Scripts.UI/MODToaster.cs
@@ -12,13 +12,11 @@ namespace MOD.Scripts.UI
 	class MODToaster
 	{
 		static MODToaster Instance;
-		private MODStyleManager styleManager;
 		string toastText;
 		MODSimpleTimer toastNotificationTimer;
 
-		public MODToaster(MODStyleManager styleManager)
+		public MODToaster()
 		{
-			this.styleManager = styleManager;
 			this.toastText = "";
 			this.toastNotificationTimer = new MODSimpleTimer();
 
@@ -32,6 +30,8 @@ namespace MOD.Scripts.UI
 
 		public void OnGUIFragment()
 		{
+			MODStyleManager styleManager = MODStyleManager.OnGUIInstance;
+
 			if (toastNotificationTimer.Running())
 			{
 				// This scrolls the toast notification off the window when it's nearly finished


### PR DESCRIPTION
Adds audio switching (switching BGM/SE).

While I was creating this, I wrote some comments in Discord, which I'll paste here as "documentation".

Please note that Entry 1 is not accurate, since things were changed since I wrote it, but entry 2 describes the changes that have been made since entry 1.

I've pre-merged the meakashi-mod branch to make sure it merges well, ~~and will add another PR for that shortly~~ actually that doesn't make sense, I'll do the merge after I merge this PR.

Entry 1:

> I have added bgm switching to the DLL. I have changed how I said I would do it previously - I added two functions:
>  - ModPlayBGM
>  - ModFadeOutBGM
> 
> These work the same as the regular functions, but they have one extra argument at the end, which is the altBGMFlow when this function should be active.
> They replace using if statements around the normal playBGM and fadeBGM functions.
> 
> The reason for doing it this way is that, if you want to toggle back and forth between BGM, you need to know what BGM is playing on both BGM settings.
> To do this, the game needs to "see" all PlayBGM and FadeBGM calls, which can't happen if you use "if" statements around the PlayBGM and FadeBGM calls.
> 
> Toggling back and forth between BGM works most of the time, except after immediately after loading a save.
> This is because I don't store the complete BGM state when saving (I could do this, but it would make existing save files incompatible with this new DLL).
> Usage:
> 
> I've added a debug menu for you to see exactly what's going on, and also the normal button/keyboard shorcuts the end user will interact with.
> 
> Normal Usage:
> - Press F10 to open the menu
> - There is a new option "Choose BGM/SE". This changes the altBGM, altSE, altBGMFlow, altSEFlow flags simultaneously (all to the same value)
> - You can also toggle using the '2' key on your keyboard which does the same thign
> 
> Debug Menu:
> - At the very bottom of the menu, there is an option "toggle debug menu", which will show BGM information.
> 
> - Top left debug text:
>     - This shows, for each BGM flow, what BGM would be playing on each channel, if you have that BGM option selected
>     - NOTE: this will be invalid if you load a save, because the DLL currently doesn't save the BGM across all BGM flows (to avoid invaliding older saves, otherwise I'd do it.). But after playing for a bit it will become valid again.
> 
> - Top right debug text:
>     - Shows the last played BGM/SE/Voice/System audio, and the current BGM/SE/Voice flag and flow flag.
> Known issues:
> - There should be a prompt on startup for the user to select the BGM of their choice. This would be done in the script file, similar to how we do the "would you like console choices" options.
> - The BGM/SE buttons should be moved out of the "Advanced Options" setting to "Basic Options"
> - The description text when hovering over the BGM/SE buttons needs to be updated. Should add 
>     - "WARNING: Toggling BGM just after loading a save may produce different results than if you played from the start of the game up to that point, then toggled. This should fix itself after a scene change or two in most cases."
> - An annoying sound plays when toggling the BGM with the '2' key (annoying because it overlaps the music)
> - The added options causes the option menu to show a scroll bar, even on 1080p. not sure if should fix this.
> - The issue with the BGM not being synced after a save could be fixed, but it really only happens if you save at a time when the one BGM doesn't match the other, and then toggle. I don't think it's worth breaking save compatibility to fix this issue.

Entry 2:

> So I got it all working I think. The following have changed:
> 
> - I created a new global flag "GAudioSet" (audio version of GArtSet). This represents which preset of AltBGM/AltBGMFlow/AltSE/AltSEFlow combination you have chosen.
> - Because the "GAudioSet" can already keep track of whether you have chosen your audio settings, I've reverted all the flags to start at 0 like before (in the last release, AltBGMFlow started at 1, not 0)
>     - I've gone back to the "switchable-bgm-rebase" branch of the meakashi repository where the indexes start at 0, not 1
> - You define the Audio presets (AudioSet), BGM folders, and SE folders from the game script (in init.txt) - they are not hardcoded anymore. This includes their display names and descriptions on the GUI
> - The setup menu (at the start of flow.txt) is handled via the DLL, rather than being a normal choice in the game script. I've done it this way as it allows more information to be displayed in the setup menu, and reduces duplicated logic in the script/DLL.
>     - The setup menu can be displayed with a call like ModGenericCall("ShowSetupMenuIfRequired", "");, see flow.txt
> - Various option menus (including the setup menu) will indicate if a BGM/SE pack is missing (like if you didn't install Italo's BGM pack), and not let you select it. This would also be difficult if the setup menu were not in the DLL.
> - I added a button to force using a particular SE (for example, you can use old SE with new BGM)