### PR TITLE
Lipsync without spectrum and lipsync caching

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -231,6 +231,7 @@
     <Compile Include="MOD.Scripts.Core.Movie\MovieInfo.cs" />
     <Compile Include="MOD.Scripts.Core.Movie\TextureMovieRenderer.cs" />
     <Compile Include="MOD.Scripts.Core.Scene\MODSceneController.cs" />
+    <Compile Include="MOD.Scripts.Core.Scene\MODLipsyncCache.cs" />
     <Compile Include="MOD.Scripts.Core.Scene\MODTextureController.cs" />
     <Compile Include="MOD.Scripts.Core.State\MODStateDisableInput.cs" />
     <Compile Include="MOD.Scripts.Core.State\StateMovie.cs" />

--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -203,6 +203,15 @@ namespace Assets.Scripts.Core.Audio
 			return audioLayerUnity.GetRemainingPlayTime();
 		}
 
+		/// <summary>
+		/// This gets the number of audio frames played so far on a particular audio channel (Unity calls these "samples")
+		/// </summary>
+		public int GetPlayTimeSamples(int channel)
+		{
+			AudioLayerUnity audioLayerUnity = channelDictionary[GetChannelByTypeChannel(AudioType.Voice, channel)];
+			return audioLayerUnity.GetPlayTimeSamples();
+		}
+
 		public void ChangeVolumeOfBGM(int channel, float volume, float time)
 		{
 			int channelByTypeChannel = GetChannelByTypeChannel(AudioType.BGM, channel);
@@ -547,11 +556,17 @@ namespace Assets.Scripts.Core.Audio
 			{
 				audio.StopAudio();
 			}
-			audio.PlayAudio(filename, AudioType.Voice, volume);
-			if (MODSystem.instance.modSceneController.MODLipSyncBoolCheck(character))
+
+			// Load the audio to be played, then play it on a coroutine.
+			// Once the audio is loaded (but before it starts playing), start the lipsync coroutine
+			audio.PlayAudio(filename, AudioType.Voice, volume, onAudioLoaded: (string audioFileName, AudioType audioType, AudioClip audioClip) =>
 			{
-				GameSystem.Instance.SceneController.MODLipSyncStart(character, channel, filename);
-			}
+				if (MODSystem.instance.modSceneController.MODLipSyncBoolCheck(character))
+				{
+					GameSystem.Instance.SceneController.MODLipSyncStart(character, channel, filename, audioClip);
+				}
+			});
+
 			if (GameSystem.Instance.IsAuto)
 			{
 				audio.OnLoadCallback(delegate

--- a/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
+++ b/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
@@ -130,7 +130,9 @@ namespace Assets.Scripts.Core.Audio
 			return audioSource.clip.length - audioSource.time;
 		}
 
-		private IEnumerator WaitForLoad(string filename, AudioType type)
+		public int GetPlayTimeSamples() => audioSource.timeSamples;
+
+		private IEnumerator WaitForLoad(string filename, AudioType type, Action<string, AudioType, AudioClip> onAudioDataLoaded = null)
 		{
 			var watch = System.Diagnostics.Stopwatch.StartNew();
 			string path = AssetManager.Instance.GetAudioFilePath(filename, type);
@@ -138,6 +140,12 @@ namespace Assets.Scripts.Core.Audio
 			yield return audioLoader;
 			loadedName = filename;
 			audioClip = audioLoader.audioClip;
+
+			if(audioClip != null && onAudioDataLoaded != null)
+			{
+				onAudioDataLoaded(filename, type, audioClip);
+			}
+
 			isLoading = false;
 			isLoaded = true;
 			loadCoroutine = null;
@@ -146,7 +154,7 @@ namespace Assets.Scripts.Core.Audio
 			OnFinishLoading();
 		}
 
-		public void PlayAudio(string filename, AudioType type, float startvolume = 1f, bool loop = false)
+		public void PlayAudio(string filename, AudioType type, float startvolume = 1f, bool loop = false, Action<string, AudioType, AudioClip> onAudioLoaded = null)
 		{
 			if (IsPlaying())
 			{
@@ -162,7 +170,7 @@ namespace Assets.Scripts.Core.Audio
 			audioType = type;
 			subVolume = startvolume;
 			isLoop = loop;
-			loadCoroutine = StartCoroutine(WaitForLoad(filename, type));
+			loadCoroutine = StartCoroutine(WaitForLoad(filename, type, onAudioLoaded));
 		}
 
 		public void OnLoadCallback(OnFinishLoad callback)

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2780,6 +2780,23 @@ namespace Assets.Scripts.Core.Buriko
 					}
 					break;
 
+				case "LipSyncSettings":
+					string[] lipSyncParams = callParameters.Split(',');
+
+					if(lipSyncParams.Length == 3 &&
+					   float.TryParse(lipSyncParams[0].Trim(), out float thresh1) &&
+					   float.TryParse(lipSyncParams[1].Trim(), out float thresh2) &&
+					   bool.TryParse(lipSyncParams[2].Trim(), out bool forceComputedLipsync))
+					{
+						GameSystem.Instance.SceneController.MODSetExpressionThresholds(thresh1, thresh2);
+						GameSystem.Instance.SceneController.MODSetForceComputedLipsync(forceComputedLipsync);
+					}
+					else
+					{
+						Debug.LogError("MODGenericCall Error: invalid format for LipSyncSettings, should be '.3, .7, true' for example");
+					}
+					break;
+
 				default:
 					Logger.Log($"WARNING: Unknown ModGenericCall ID '{callID}'");
 					break;

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2529,7 +2529,8 @@ namespace Assets.Scripts.Core.Buriko
 				wait = 0f;
 			}
 			MODSystem.instance.modTextureController.StoreLayerTexture(num3, text);
-			gameSystem.SceneController.DrawBustshot(num3, textureName2, x, y, z, oldx, oldy, oldz, move, num2, type, wait, flag);
+			// For explanation of the MODLipsyncCacheUpdate callback, see the matching call in OperationMODDrawCharacterWithFiltering()
+			gameSystem.SceneController.DrawBustshot(num3, textureName2, x, y, z, oldx, oldy, oldz, move, num2, type, wait, flag, afterLayerUpdated: (Texture2D tex) => MODLipsyncCache.MODLipsyncCacheUpdate(tex, character, num3, textureName));
 			if (flag)
 			{
 				gameSystem.ExecuteActions();
@@ -2580,7 +2581,17 @@ namespace Assets.Scripts.Core.Buriko
 				wait = 0f;
 			}
 			MODSystem.instance.modTextureController.StoreLayerTexture(layer, text);
-			gameSystem.SceneController.DrawBustshotWithFiltering(layer, textureName2, mask, x, y, z, originx, 0, oldx, oldy, oldz, move, priority, 0, wait, flag);
+
+			// I had an issue where MODLipsyncCacheUpdate() was unable to access the sprite's base texture.
+			//
+			// This is due to chained use of RegisterAction() in DrawBustshotWithFiltering(),
+			// causing the sprite texture to be updated at some unknown time in the future.
+			//
+			// To fix this, I pass in a lambda/callback which will
+			// be executed after the layer has been updated with the new texture
+			// so the cache can grab the sprite's base texture
+			gameSystem.SceneController.DrawBustshotWithFiltering(layer, textureName2, mask, x, y, z, originx, 0, oldx, oldy, oldz, move, priority, 0, wait, flag, afterLayerUpdated: (Texture2D tex) => MODLipsyncCache.MODLipsyncCacheUpdate(tex, character, layer, textureName));
+
 			if (flag)
 			{
 				gameSystem.ExecuteActions();
@@ -2794,6 +2805,18 @@ namespace Assets.Scripts.Core.Buriko
 					else
 					{
 						Debug.LogError("MODGenericCall Error: invalid format for LipSyncSettings, should be '.3, .7, true' for example");
+					}
+					break;
+
+				case "LipSyncCacheSettings":
+					string[] lipSyncCacheParams = callParameters.Split(',');
+					if (lipSyncCacheParams.Length == 1 && int.TryParse(lipSyncCacheParams[0].Trim(), out int maxAge))
+					{
+						MODLipsyncCache.SetMaxTextureAge(maxAge);
+					}
+					else
+					{
+						Debug.LogError("MODGenericCall Error: invalid format for LipSyncCacheSettings, should be '2' for example");
 					}
 					break;
 

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -372,7 +372,7 @@ namespace Assets.Scripts.Core.Scene
 			cachedStretchToFit = stretchToFit;
 		}
 
-		public void DrawLayerWithMask(string textureName, string maskName, int x, int y, Vector2? origin, bool isBustshot, int style, float wait, bool isBlocking)
+		public void DrawLayerWithMask(string textureName, string maskName, int x, int y, Vector2? origin, bool isBustshot, int style, float wait, bool isBlocking, System.Action<Texture2D> afterLayerUpdated)
 		{
 			cachedIsBustShot = isBustshot;
 			Texture2D texture2D = MODSceneController.LoadTextureWithFilters(layerID, textureName, out string texturePath);
@@ -407,7 +407,13 @@ namespace Assets.Scripts.Core.Scene
 				{
 					GameSystem.Instance.AddWait(new Wait(wait, WaitTypes.WaitForMove, FinishAll));
 				}
+				afterLayerUpdated?.Invoke(texture2D);
 			});
+		}
+
+		public void DrawLayerWithMask(string textureName, string maskName, int x, int y, Vector2? origin, bool isBustshot, int style, float wait, bool isBlocking)
+		{
+			DrawLayerWithMask(textureName, maskName, x, y, origin, isBustshot, style, wait, isBlocking, afterLayerUpdated: null);
 		}
 
 		public void FadeLayerWithMask(string maskName, int style, float time, bool isBlocking)
@@ -431,7 +437,7 @@ namespace Assets.Scripts.Core.Scene
 			});
 		}
 
-		public void DrawLayer(string textureName, int x, int y, int z, Vector2? origin, float alpha, bool isBustshot, int type, float wait, bool isBlocking)
+		public void DrawLayer(string textureName, int x, int y, int z, Vector2? origin, float alpha, bool isBustshot, int type, float wait, bool isBlocking, System.Action<Texture2D> afterLayerUpdated)
 		{
 			cachedIsBustShot = isBustshot;
 			FinishAll();
@@ -518,7 +524,13 @@ namespace Assets.Scripts.Core.Scene
 						});
 					}
 				}
+				afterLayerUpdated?.Invoke(texture2D);
 			}
+		}
+
+		public void DrawLayer(string textureName, int x, int y, int z, Vector2? origin, float alpha, bool isBustshot, int type, float wait, bool isBlocking)
+		{
+			DrawLayer(textureName, x, y, z, origin, alpha, isBustshot, type, wait, isBlocking, afterLayerUpdated: null);
 		}
 
 		public void SetAngle(float angle, float wait)
@@ -824,5 +836,7 @@ namespace Assets.Scripts.Core.Scene
 		public void MODOnlyRecompile()
 		{
 		}
+
+		public Texture2D GetPrimary() => primary;
 	}
 }

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -1,4 +1,5 @@
 using MOD.Scripts.Core;
+using MOD.Scripts.Core.Scene;
 using System;
 using System.Collections;
 using System.IO;
@@ -172,7 +173,7 @@ namespace Assets.Scripts.Core.Scene
 			});
 		}
 
-		public void DrawBustshot(int layer, string textureName, int x, int y, int z, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking)
+		public void DrawBustshot(int layer, string textureName, int x, int y, int z, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking, Action<Texture2D> afterLayerUpdated)
 		{
 			if (MODSkipImage(textureName))
 			{
@@ -191,7 +192,7 @@ namespace Assets.Scripts.Core.Scene
 				oldy = y;
 				oldz = z;
 			}
-			i.DrawLayer(textureName, oldx, oldy, oldz, null, 1f, /*isBustshot:*/ true, type, wait, isblocking);
+			i.DrawLayer(textureName, oldx, oldy, oldz, null, 1f, /*isBustshot:*/ true, type, wait, isblocking, afterLayerUpdated);
 			i.SetPriority(priority);
 			if (move)
 			{
@@ -211,6 +212,11 @@ namespace Assets.Scripts.Core.Scene
 			});
 		}
 
+		public void DrawBustshot(int layer, string textureName, int x, int y, int z, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking)
+		{
+			DrawBustshot(layer, textureName, x, y, z, oldx, oldy, oldz, move, priority, type, wait, isblocking, afterLayerUpdated: null);
+		}
+
 		public void FadeBustshotWithFiltering(int layer, string mask, int style, float wait, bool isblocking)
 		{
 			Layer layer2 = GetLayer(layer);
@@ -225,7 +231,7 @@ namespace Assets.Scripts.Core.Scene
 			});
 		}
 
-		public void DrawBustshotWithFiltering(int layer, string textureName, string mask, int x, int y, int z, int originx, int originy, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking)
+		public void DrawBustshotWithFiltering(int layer, string textureName, string mask, int x, int y, int z, int originx, int originy, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking, Action<Texture2D> afterLayerUpdated)
 		{
 			Layer i = GetLayer(layer);
 			while (i.FadingOut)
@@ -244,7 +250,7 @@ namespace Assets.Scripts.Core.Scene
 			{
 				origin = new Vector2((float)originx, (float)originy);
 			}
-			i.DrawLayerWithMask(textureName, mask, oldx, oldy, origin, /*isBustshot:*/ true, type, wait, isblocking);
+			i.DrawLayerWithMask(textureName, mask, oldx, oldy, origin, /*isBustshot:*/ true, type, wait, isblocking, afterLayerUpdated);
 			i.SetPriority(priority);
 			if (move)
 			{
@@ -262,6 +268,11 @@ namespace Assets.Scripts.Core.Scene
 					UpdateLayerMask(i, priority);
 				}
 			});
+		}
+
+		public void DrawBustshotWithFiltering(int layer, string textureName, string mask, int x, int y, int z, int originx, int originy, int oldx, int oldy, int oldz, bool move, int priority, int type, float wait, bool isblocking)
+		{
+			DrawBustshotWithFiltering(layer, textureName, mask, x, y, z, originx, originy, oldx, oldy, oldz, move, priority, type, wait, isblocking, afterLayerUpdated: null);
 		}
 
 		public void MoveBustshot(int layer, string textureName, int x, int y, int z, float wait, bool isblocking)
@@ -992,9 +1003,15 @@ namespace Assets.Scripts.Core.Scene
 		public IEnumerator MODDrawLipSync(int character, int audiolayer, string audiofile, AudioClip audioClip)
 		{
 			ulong coroutineId = MODSystem.instance.modSceneController.MODLipSyncInvalidateAndGenerateId(character);
-			Texture2D exp4 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "0");
-			Texture2D exp3 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "1");
-			Texture2D exp2 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "2");
+
+			if(!MODLipsyncCache.LoadOrUseCache(null, character, out MODLipsyncCache.TextureGroup group))
+			{
+				yield break;
+			}
+
+			Texture2D exp4 = group.baseTexture_0;
+			Texture2D exp3 = group.halfOpen_1;
+			Texture2D exp2 = group.fullOpen_2;
 
 			if (forceComputedLipsync)
 			{

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -1032,5 +1032,20 @@ namespace Assets.Scripts.Core.Scene
 
 			return false;
 		}
+
+		public void MODSetForceComputedLipsync(bool forceComputedLipsync) => this.forceComputedLipsync = forceComputedLipsync;
+		public bool MODGetForceComputedLipsync() => this.forceComputedLipsync;
+
+		public void MODSetExpressionThresholds(float threshold1, float threshold2)
+		{
+			this.expression1Threshold = threshold1;
+			this.expression2Threshold = threshold2;
+		}
+
+		public void MODGetExpressionThresholds(out float threshold1, out float threshold2)
+		{
+			threshold1 = this.expression1Threshold;
+			threshold2 = this.expression2Threshold;
+		}
 	}
 }

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -1015,7 +1015,7 @@ namespace Assets.Scripts.Core.Scene
 
 			if (forceComputedLipsync)
 			{
-				yield return MODComputedLipSync(character, audiolayer, audioClip, coroutineId, exp2, exp3, exp4);
+				yield return StartCoroutine(MODComputedLipSync(character, audiolayer, audioClip, coroutineId, exp2, exp3, exp4));
 			}
 			else // If the spectrum file doesn't exist, use the "computed lipsync" method
 			{
@@ -1023,11 +1023,11 @@ namespace Assets.Scripts.Core.Scene
 				string path = Path.Combine(Application.streamingAssetsPath, "spectrum/" + str);
 				if (File.Exists(path))
 				{
-					yield return MODBakedLipSync(path, character, coroutineId, exp2, exp3, exp4);
+					yield return StartCoroutine(MODBakedLipSync(path, character, coroutineId, exp2, exp3, exp4));
 				}
 				else
 				{
-					yield return MODComputedLipSync(character, audiolayer, audioClip, coroutineId, exp2, exp3, exp4);
+					yield return StartCoroutine(MODComputedLipSync(character, audiolayer, audioClip, coroutineId, exp2, exp3, exp4));
 				}
 			}
 

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -74,6 +74,10 @@ namespace Assets.Scripts.Core.Scene
 
 		public Scene MODActiveScene => GetActiveScene();
 
+		private float expression2Threshold = .7f;
+		private float expression1Threshold = .3f;
+		private bool forceComputedLipsync = true;
+
 		static SceneController()
 		{
 			UpperLayerRange = 32;
@@ -851,34 +855,26 @@ namespace Assets.Scripts.Core.Scene
 		{
 		}
 
-		public IEnumerator MODDrawLipSync(int character, int audiolayer, string audiofile)
+		private IEnumerator MODBakedLipSync(string path, int character, ulong coroutineId, Texture2D exp2, Texture2D exp3, Texture2D exp4)
 		{
-			ulong coroutineId = MODSystem.instance.modSceneController.MODLipSyncInvalidateAndGenerateId(character);
-			string str = audiofile.Replace(".ogg", ".txt");
-			Texture2D exp4 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "0");
-			Texture2D exp3 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "1");
-			Texture2D exp2 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "2");
-			string path = Path.Combine(Application.streamingAssetsPath, "spectrum/" + str);
-			if (File.Exists(path))
+			StreamReader streamReader = new StreamReader(path);
+			string text = streamReader.ReadLine();
+			string[] exparray = text.Split(',');
+			streamReader.Close();
+			for (int k = 0; k < exparray.Length; k++)
 			{
-				StreamReader streamReader = new StreamReader(path);
-				string text = streamReader.ReadLine();
-				string[] exparray = text.Split(',');
-				streamReader.Close();
-				for (int k = 0; k < exparray.Length; k++)
+				if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId))
 				{
-					if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId))
+					break;
+				}
+				if (exparray[k] == string.Empty)
+				{
+					exparray[k] = "0";
+				}
+				if (k > 1 && !exparray[k].Equals(exparray[k - 1]))
+				{
+					switch (exparray[k])
 					{
-						break;
-					}
-					if (exparray[k] == string.Empty)
-					{
-						exparray[k] = "0";
-					}
-					if (k > 1 && !exparray[k].Equals(exparray[k - 1]))
-					{
-						switch (exparray[k])
-						{
 						case "2":
 							MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp2, coroutineId);
 							break;
@@ -888,43 +884,142 @@ namespace Assets.Scripts.Core.Scene
 						case "0":
 							MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
 							break;
-						}
 					}
-					yield return (object)new WaitForSeconds(0.0666f);
 				}
+				yield return (object)new WaitForSeconds(0.0666f);
 			}
-			else
+		}
+
+		private IEnumerator MODComputedLipSync(int character, int audiolayer, AudioClip audioClip, ulong coroutineId, Texture2D exp2, Texture2D exp3, Texture2D exp4)
+		{
+			const float CHUNK_LENGTH_SECONDS = .05f;
+
+			int frameRate = audioClip.frequency;
+			//NOTE: Unity calls a "sample" what is usually called a "frame". Frames contain multiple channel's worth of information for a given point in time.
+			int numFrames = audioClip.samples;
+			int samplesPerFrame = audioClip.channels;
+
+			int framesPerChunk = (int)(CHUNK_LENGTH_SECONDS * frameRate);
+			int samplesPerChunk = framesPerChunk * samplesPerFrame;
+
+			// If there is a leftover chunk (this happens if there is a remainder during the below division), it will be excluded/skipped.
+			int numChunks = numFrames / framesPerChunk;
+
+			bool voiceStartedPlaying = false;
+
+			float[] rawAudioData = new float[samplesPerChunk];
+
+			WaitForSeconds waitTime = new WaitForSeconds(CHUNK_LENGTH_SECONDS);
+
+			// This for loop condition shouldn't ever be met, it's just here
+			// to set some upper limit (~10x the expected number of loops) on the number of iterations
+			for (int chunk = 0; chunk < 10 * numChunks; chunk++)
 			{
-				MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
-				yield return (object)new WaitForSeconds(0.25f);
-				MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp3, coroutineId);
-				yield return (object)new WaitForSeconds(0.25f);
-				int k = 0;
+				// Forcibly stop the lipsync animation if it's not meant to be playing at this time?
+				if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId))
+				{
+					break;
+				}
+
 				if (GameSystem.Instance.AudioController.IsVoicePlaying(audiolayer))
 				{
-					k = (int)(GameSystem.Instance.AudioController.GetRemainingVoicePlayTime(audiolayer) * 10f);
-				}
-				if (k >= 5)
-				{
-					for (int i = 0; i < k - 5; i += 5)
+					voiceStartedPlaying = true;
+
+					// If there is less than one chunk of audio left, we are finished.
+					int frameOffset = GameSystem.Instance.AudioController.GetPlayTimeSamples(audiolayer);
+					int framesLeft = numFrames - frameOffset;
+					if (framesLeft < framesPerChunk)
 					{
-						if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId))
+						break;
+					}
+
+					// Get the chunk we are interested in
+					// Note: If the audio finishes playing before the coroutine finishes, then
+					// audioClip somehow becomes null. I've added handling here in case this happens,
+					// although the above "is audio playing" checks should above should stop this from happening.
+					try
+					{
+						if (audioClip == null)
 						{
 							break;
 						}
-						MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
-						yield return (object)new WaitForSeconds(0.25f);
+						audioClip.GetData(rawAudioData, frameOffset);
+					}
+					catch (Exception)
+					{
+						break;
+					}
+
+					// Find the max value in the chunk, with some shortcuts
+					//  - We don't care about which channel the audio comes from, so just process every sample the same, even if it's a different channel
+					//  - We only check the positive maximum of the waveform (we don't need to check the negative maximum of the waveform for our application)
+					float max = 0;
+					foreach (float data in rawAudioData)
+					{
+						if (data > max)
+						{
+							max = data;
+						}
+					}
+
+					//Use the max to determine what mouth sprite should be displayed
+					if (max > expression2Threshold)
+					{
+						MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp2, coroutineId);
+					}
+					else if (max > expression1Threshold)
+					{
 						MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp3, coroutineId);
-						yield return (object)new WaitForSeconds(0.25f);
+					}
+					else
+					{
+						MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
 					}
 				}
+				else if (voiceStartedPlaying)
+				{
+					// If the voice previously was playing, but now has stopped playing, lipsync is finished.
+					// This happens if this coroutine resumes just after the audio finishes playing.
+					break;
+				}
+
+				// This delay sets the approximate rate at which the lipsync updates
+				// the exact delay time is not critical
+				yield return waitTime;
 			}
+		}
+
+		public IEnumerator MODDrawLipSync(int character, int audiolayer, string audiofile, AudioClip audioClip)
+		{
+			ulong coroutineId = MODSystem.instance.modSceneController.MODLipSyncInvalidateAndGenerateId(character);
+			Texture2D exp4 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "0");
+			Texture2D exp3 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "1");
+			Texture2D exp2 = MODSystem.instance.modSceneController.MODLipSyncPrepare(character, "2");
+
+			if (forceComputedLipsync)
+			{
+				yield return MODComputedLipSync(character, audiolayer, audioClip, coroutineId, exp2, exp3, exp4);
+			}
+			else // If the spectrum file doesn't exist, use the "computed lipsync" method
+			{
+				string str = audiofile.Replace(".ogg", ".txt");
+				string path = Path.Combine(Application.streamingAssetsPath, "spectrum/" + str);
+				if (File.Exists(path))
+				{
+					yield return MODBakedLipSync(path, character, coroutineId, exp2, exp3, exp4);
+				}
+				else
+				{
+					yield return MODComputedLipSync(character, audiolayer, audioClip, coroutineId, exp2, exp3, exp4);
+				}
+			}
+
 			MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
 		}
 
-		public void MODLipSyncStart(int character, int audiolayer, string audiofile)
+		public void MODLipSyncStart(int character, int audiolayer, string audiofile, AudioClip audioClip)
 		{
-			MODLipSyncCoroutine = MODDrawLipSync(character, audiolayer, audiofile);
+			MODLipSyncCoroutine = MODDrawLipSync(character, audiolayer, audiofile, audioClip);
 			StartCoroutine(MODLipSyncCoroutine);
 		}
 

--- a/MOD.Scripts.Core.Scene/MODLipsyncCache.cs
+++ b/MOD.Scripts.Core.Scene/MODLipsyncCache.cs
@@ -1,0 +1,308 @@
+﻿using Assets.Scripts.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.Core.Scene
+{
+    class MODLipsyncCache
+    {
+        struct LastDrawInformation
+        {
+            public readonly int layer;
+            public readonly string baseTextureName;
+
+            public LastDrawInformation(int layer, string baseTextureName)
+            {
+                this.layer = layer;
+                this.baseTextureName = baseTextureName;
+            }
+        }
+
+        class LastDrawInformationManager
+        {
+            private static bool[] infoValid = new bool[MODSceneController.MAX_CHARACTERS];
+            private static LastDrawInformation[] lastDrawInformation = new LastDrawInformation[MODSceneController.MAX_CHARACTERS];
+
+            public static bool GetLastDrawInformation(int character, out LastDrawInformation drawInformation)
+            {
+                if (character < lastDrawInformation.Length && infoValid[character])
+                {
+                    drawInformation = lastDrawInformation[character];
+                    return true;
+                }
+
+                drawInformation = new LastDrawInformation();
+                return false;
+            }
+
+            public static void SetLastDrawInformation(int character, int layer, string baseTextureName)
+            {
+                if (character < lastDrawInformation.Length)
+                {
+                    lastDrawInformation[character] = new LastDrawInformation(layer, baseTextureName);
+                    infoValid[character] = true;
+                }
+            }
+        }
+
+        public class TextureGroup
+        {
+            // Note: the textures in this class can become null at any time, if
+            // Destroy() is called somewhere else in the game code on this texture
+            // This typically happens when a ReleaseTextures() is called on a layer
+            // (when the character is cleared from the screen)
+
+            /// <summary>
+            /// The texture of the character with a closed mouth, ending with "0".
+            /// For example, "aka_def_0.png"
+            /// </summary>
+            public Texture2D baseTexture_0;
+
+            /// <summary>
+            /// The texture of the character with a half open mouth, ending with "1"
+            /// For example, "aka_def_1.png"
+            /// </summary>
+            public Texture2D halfOpen_1;
+
+            /// <summary>
+            /// The texture of the character with a fully open mouth, ending with "2"
+            /// For example, "aka_def_2.png"
+            /// </summary>
+            public Texture2D fullOpen_2;
+
+            /// <summary>
+            /// How long since this texture group has been used. This is incremented each time
+            /// any character is drawn to the screen, and reset when the texture group is used.
+            /// </summary>
+            public int age;
+
+            public TextureGroup(Texture2D baseTexture_0, Texture2D halfOpen_1, Texture2D fullOpen_2)
+            {
+                this.baseTexture_0 = baseTexture_0;
+                this.halfOpen_1 = halfOpen_1;
+                this.fullOpen_2 = fullOpen_2;
+
+                age = 0;
+            }
+
+            public bool NeedsClean()
+            {
+                return baseTexture_0 == null  || halfOpen_1 == null || fullOpen_2 == null;
+            }
+
+            // Note: it is assumed that by the time this function is called, the lipsync animation is completed/not playing
+            // In this state, the layer will contain baseTexture_0, which the game will clean up automatically
+            // We then manually clean up the other two textures.
+            //
+            // I have also tested not calling Destroy() at all, and the game seems to clean up the textures anyway,
+            // so failing to call Destroy in some circumstances is probably fine.
+            public void DestroyTextures()
+            {
+                if(halfOpen_1 != null)
+                {
+                    GameObject.Destroy(halfOpen_1);
+                }
+                if(fullOpen_2 != null)
+                {
+                    GameObject.Destroy(fullOpen_2);
+                }
+            }
+
+            private string Print(Texture2D tex)
+            {
+                if(tex != null)
+                {
+                    return tex.name;
+                }
+
+                return "texture is null";
+            }
+
+            public override string ToString()
+            {
+                return $"TG[age: {age} base: {Print(baseTexture_0)} half: {Print(halfOpen_1)} full: {Print(fullOpen_2)}]";
+            }
+        }
+
+        private static readonly Dictionary<string, TextureGroup> cache = new Dictionary<string, TextureGroup>();
+        private static int maxTextureAge = 2;
+        private static string debugLastEvent;
+
+        public static void MODLipsyncCacheUpdate(Texture2D baseTexture, int character, int layer, string baseTextureName)
+        {
+            // This must always run even if lipsync is disabled, so that the lastDrawInformation is present if enabled later
+            LastDrawInformationManager.SetLastDrawInformation(character, layer, baseTextureName);
+
+            // If lipsync not enabled, do not do any caching
+            if (!MODSystem.instance.modSceneController.MODLipSyncIsEnabled())
+            {
+                return;
+            }
+
+            // Firstly, tidy up the texture cache, by clearing any texture groups
+            // where any one of the textures in that group have been Destroy()ed
+            // Also clear any textures which are too old
+            List<string> texturesToRemove = new List<string>();
+            foreach (string key in cache.Keys)
+            {
+                TextureGroup tex = cache[key];
+
+                // NOTE: This if statement is usually never called, but I have left
+                // it in just in case the base texture is deleted when we still want to use it
+                // See the note at the top of the 'TextureGroup' class.
+                if (tex.NeedsClean())
+                {
+                    tex.DestroyTextures();
+                    texturesToRemove.Add(key);
+                }
+
+                if (tex.age > maxTextureAge)
+                {
+                    tex.DestroyTextures();
+                    texturesToRemove.Add(key);
+                }
+                else
+                {
+                    tex.age++;
+                }
+            }
+
+            foreach (string key in texturesToRemove)
+            {
+                cache.Remove(key);
+            }
+
+            // Do not cache while skipping
+            if (GameSystem.Instance.IsSkipping)
+            {
+                return;
+            }
+
+            //Now pre-load the textures for the character that is about to be drawn
+            bool _ = LoadOrUseCache(baseTexture, character, out TextureGroup _);
+        }
+
+        /// <summary>
+        /// Loads the mouth textures, attempting to load from the given layer OR cache if possible
+        ///
+        /// This function loads the mouth textures in the following manner:
+        /// - If the mouth textures already exist in the cache, it will use those
+        /// - Otherwise for the base texture (mouth closed):
+        ///   - it will try to take the texture from the "layerWithCharacter" layer
+        ///   - if that fails, it will try to load it from scratch (from disk)
+        /// - For the other mouth textures, it will just load them from disk
+        ///
+        /// NOTE: The passed in 'layer' must be a layer containing the loaded character sprite
+        /// the base texture for the character will be sourced from this layer.
+        /// You may need to use GameSystem.Instance.RegisterAction(delegate {}) to ensure things
+        /// happen in the correct order.
+        /// Set 'layer' to null if you don't want to load the base texture from an existing layer
+        /// </summary>
+        /// <param name="maybeBaseTexture">This function will use this argument as the 'base' lipsync texture.
+        /// If you don't have access to the base lipsync texture, pass in null to load it from from disk.</param>
+        /// <param name="character">The number of the character whose textures you want to load.
+        /// This is the same character number used in the game scripts.</param>
+        /// <returns></returns>
+        public static bool LoadOrUseCache(Texture2D maybeBaseTexture, int character, out TextureGroup textureGroup)
+        {
+            try
+            {
+                DebugLog($"Texture Cache count: {cache.Keys.Count}");
+
+                if(!LastDrawInformationManager.GetLastDrawInformation(character, out LastDrawInformation info))
+                {
+                    textureGroup = null;
+                    return false;
+                }
+
+                if (cache.TryGetValue(info.baseTextureName, out TextureGroup cachedTextures))
+                {
+                    DebugLog($"LoadOrUseCache() - Cache hit on [{info.baseTextureName}]");
+
+                    // This branch happens if the texture group exists in the cache, but one or more of the textures
+                    // have been Destroy()ed (set to null).
+                    //
+                    // I've managed to hit this branch once? before when skippping and clicking at the same time,
+                    // otherwise it doesn't seem to happen
+                    if (cachedTextures.NeedsClean())
+                    {
+                        Assets.Scripts.Core.Logger.LogError($"WARNING on LoadOrUseCache() - retrieved texture but it was Destroy()ed");
+
+                        // Clean up the texture, then reload it from disk
+                        cachedTextures.DestroyTextures();
+                        cache.Remove(info.baseTextureName);
+
+                        textureGroup = LoadWithoutCache(info, maybeBaseTexture);
+                        return true;
+                    }
+
+                    // Since we just used this texture, reset its age to 0
+                    cachedTextures.age = 0;
+
+                    textureGroup = cachedTextures;
+                    return true;
+                }
+                else
+                {
+                    textureGroup = LoadWithoutCache(info, maybeBaseTexture);
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"Lipsync LoadOrUseCache() ERROR: {e}");
+                textureGroup = null;
+                return false;
+            }
+        }
+        private static TextureGroup LoadWithoutCache(LastDrawInformation info, Texture2D maybeBaseTexture)
+        {
+            Texture2D baseTexture = maybeBaseTexture;
+
+            if (baseTexture == null)
+            {
+                DebugLog($"LoadOrUseCache() - loading base texture from scratch ");
+                baseTexture = MODSceneController.LoadTextureWithFilters(info.layer, info.baseTextureName + "0");
+            }
+
+            DebugLog($"LoadOrUseCache() - updating cache with texture: {info.baseTextureName} on layer {info.layer}");
+            TextureGroup textureGroup = new TextureGroup(
+                baseTexture,
+                MODSceneController.LoadTextureWithFilters(info.layer, info.baseTextureName + "1"),
+                MODSceneController.LoadTextureWithFilters(info.layer, info.baseTextureName + "2")
+            );
+
+            cache.Add(info.baseTextureName, textureGroup);
+            return textureGroup;
+        }
+
+        private static void DebugLog(string text)
+        {
+            MODUtility.FlagMonitorOnlyLog(text);
+            debugLastEvent = text;
+        }
+
+        public static string DebugInfo()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.AppendLine($"LIPSYNC CACHE [Num Entries: {cache.Count()} Max Age: {maxTextureAge}]");
+            sb.AppendLine(debugLastEvent);
+
+            foreach (KeyValuePair<string, TextureGroup> kvp in cache)
+            {
+                sb.AppendLine($"---- {kvp.Key} ----\n{kvp.Value}\n");
+            }
+
+            return sb.ToString();
+        }
+
+        public static void SetMaxTextureAge(int maxAge)
+        {
+            maxTextureAge = maxAge;
+        }
+    }
+}

--- a/MOD.Scripts.Core.Scene/MODSceneController.cs
+++ b/MOD.Scripts.Core.Scene/MODSceneController.cs
@@ -10,7 +10,7 @@ namespace MOD.Scripts.Core.Scene
 {
 	public class MODSceneController
 	{
-		private const int MAX_CHARACTERS = 100;
+		public static int MAX_CHARACTERS = 100;
 		public static int MODLipSync_Character_Audio;
 
 		public struct Filter
@@ -281,13 +281,6 @@ namespace MOD.Scripts.Core.Scene
 			MODLipSync_Priority = new int[MAX_CHARACTERS];
 			MODLipSync_Channel = new int[MAX_CHARACTERS];
 			MODLipSync_CoroutineId = new ulong[MAX_CHARACTERS];
-		}
-
-		public Texture2D MODLipSyncPrepare(int charnum, string expressionnum)
-		{
-			int num = MODLipSync_Layer[charnum];
-			string textureName = MODLipSync_Texture[charnum] + expressionnum;
-			return LoadTextureWithFilters(num, textureName);
 		}
 
 		static MODSceneController()

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -128,6 +128,8 @@ You can try the following yourself to fix the issue.
 				$"Last Played Voice Path: {AssetManager.Instance.debugLastVoice}\n" +
 				$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}");
 
+			GUILayout.Label(Core.Scene.MODLipsyncCache.DebugInfo());
+
 			if (debug)
 			{
 				if(Button(new GUIContent("Reset GAudioSet", "Set GAudioSet to 0, to force the game to do audio setup on next startup")))

--- a/MOD.Scripts.UI/MODMenuCommon.cs
+++ b/MOD.Scripts.UI/MODMenuCommon.cs
@@ -14,6 +14,11 @@ namespace MOD.Scripts.UI
 			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.label);
 		}
 
+		public static void Label(GUIContent content)
+		{
+			GUILayout.Label(content, MODStyleManager.OnGUIInstance.Group.label);
+		}
+
 		public static void HeadingLabel(string label)
 		{
 			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.headingLabel);

--- a/MOD.Scripts.UI/MODRadio.cs
+++ b/MOD.Scripts.UI/MODRadio.cs
@@ -33,6 +33,16 @@ namespace MOD.Scripts.UI
 			this.asButtons = asButtons;
 		}
 
+		public bool? OnGUIFragment(bool displayedRadio, bool hideLabel = false)
+		{
+			if(OnGUIFragment(displayedRadio ? 1 : 0, hideLabel) is int newValue)
+			{
+				return newValue != 0;
+			}
+
+			return null;
+		}
+
 		/// <summary>
 		/// NOTE: only call this function within OnGUI()
 		/// Displays the radio, calling onRadioChange when the user clicks on a different radio value.


### PR DESCRIPTION
# Description
This PR adds two features, relating to issues #62 and #66:
 - Lipsync without spectrum files (#62)
 - Lipsync texture caching (#66)

# History

For Rei, we didn't have the spectrum files available, and I took that as an opportunity to finalize the lipsync without spectrum files feature I had worked on earlier (See #62).

I also added texture caching, as I had noticed in the past that the game would load the three character sprites every time a voice played, even if they were already loaded. (See #66)

This has all been released already, and I haven't received any bug reports on Rei so far.

Yesterday, I went to apply the same features to the `mod` branch, so we could apply these changes to the other chapters. However I found that some changes were required to get everything to work properly on Onikakushi (which the `mod` branch can be used on directly).

While doing so, I fixed some bugs (which might only trigger on chapters earlier than Rei), and made changes so that the feature *should* work across all chapters, not just Rei.

This Draft PR contains the work I've done so far.

### TODO

- Re-test on all chapters (so far, only Onikakushi has been tested)
- ~~Decide whether to make lipsync without spectrum the default~~ it is now the default
    - By default, lipsync without spectrum is the 'fallback', and you need to add a line in the `init.txt` to change the default behavior to directly use lipsync without spectrum files. However I may change this we haven't had any bugs related to the lipsync (the bugs I've encountered are mainly to do with the texture caching).
    - This change is fairly inconsequential, but would mean we don't need to update the `init.txt` in every chapter, and chapters going forward don't need a special call in the `init.txt` file.