### PR TITLE
Fix Show Folder buttons not working on linux #83

### DIFF
--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -46,6 +46,18 @@ namespace MOD.Scripts.UI
 			GameSystem.Instance.MainUIController.TryRedrawTextWindowBackground(windowFilterTextureName);
 		}
 
+		private static string ExpandHome(string s)
+		{
+			if (s.Length > 0 && s.StartsWith("~"))
+			{
+				return Environment.GetEnvironmentVariable("HOME") + s.Remove(0, 1);
+			}
+			else
+			{
+				return s;
+			}
+		}
+
 		/// <summary>
 		/// Cycles and saves Console->MangaGamer->OG->Custom->Console...
 		/// </summary>
@@ -417,7 +429,7 @@ namespace MOD.Scripts.UI
 					{
 						// Higurashi 1-7 use the "HigurashiEp01_Data", which is one folder above the streamingAssets folder
 						// eg. C:\games\Steam\steamapps\common\Higurashi When They Cry\HigurashiEp01_Data, where log file would be output_log.txt
-						return MODUtility.CombinePaths(Application.streamingAssetsPath, "..");
+						return MODUtility.CombinePaths(Application.streamingAssetsPath, "..\\");
 					}
 
 				//eg. ~/Library/Logs/Unity, where log file would be Player.log
@@ -441,28 +453,31 @@ namespace MOD.Scripts.UI
 		{
 			ShowFile(MGHelper.GetSavePath());
 		}
+		public static void ShowCompiledScripts()
+		{
+			ShowFile(Path.Combine(Application.streamingAssetsPath, "CompiledUpdateScripts"));
+		}
 
 		//NOTE: paths might not open properly on windows if they contain backslashes
 		public static void ShowFile(string path)
 		{
-			Assets.Scripts.Core.Logger.Log($"MOD ShowFile(): Showing [{path}]");
 			try
 			{
-				switch (MODUtility.GetPlatform())
-				{
+                switch (MODUtility.GetPlatform())
+                {
+                    case MODUtility.Platform.MacOS:
+                    case MODUtility.Platform.Linux:
+						path = ExpandHome(path.Replace('\\', '/'));
+						break;
+
 					case MODUtility.Platform.Windows:
 					default:
-						Process.Start("explorer", path.Replace('/', '\\'));
-						break;
-
-					case MODUtility.Platform.MacOS:
-						Process.Start("open", path.Replace('\\', '/'));
-						break;
-
-					case MODUtility.Platform.Linux:
-						Process.Start("xdg-open", path.Replace('\\', '/'));
+						path = path.Replace('/', '\\');
 						break;
 				}
+
+				Assets.Scripts.Core.Logger.Log($"MOD ShowFile(): Showing [{path}]");
+				Application.OpenURL(path);
 			}
 			catch(Exception e)
 			{

--- a/MOD.Scripts.UI/MODMenuSupport.cs
+++ b/MOD.Scripts.UI/MODMenuSupport.cs
@@ -64,7 +64,7 @@ namespace MOD.Scripts.UI
 					"You can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\n" +
 					"Please be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.")))
 				{
-					Application.OpenURL(System.IO.Path.Combine(Application.streamingAssetsPath, "CompiledUpdateScripts"));
+					MODActions.ShowCompiledScripts();
 				}
 
 


### PR DESCRIPTION
This fixes the show folder buttons in the troubleshooting menu not working on Linux. Unfortunately, the changes I made also affect the other operating systems as I couldn't resist using Unity's built-in function.

I've tested the following:
 - Chapter 1 on Ubuntu 20.04 (this should cover all chapters)
 - Chapter 1 on Windows (this covers chapters 1-7)

Should probably re-test chapter 8/rei on Windows, and also test MacOS (should be the same for all chapters), by clicking on each of the three buttons in the support menu and checking they actually open something.