### PR TITLE
Misc Mod Fixes

### DIFF
--- a/MOD.Scripts.Core.Movie/AVProMovieRenderer.cs
+++ b/MOD.Scripts.Core.Movie/AVProMovieRenderer.cs
@@ -57,7 +57,7 @@ namespace MOD.Scripts.Core.Movie
 			mediaPlayer.m_AutoOpen = true;
 			mediaPlayer.m_AutoStart = true;
 			mediaPlayer.m_Volume = movieInfo.Volume;
-			mediaPlayer.OpenVideoFromFile(MediaPlayer.FileLocation.AbsolutePathOrURL, movieInfo.Path + ".mp4");
+			mediaPlayer.OpenVideoFromFile(MediaPlayer.FileLocation.AbsolutePathOrURL, movieInfo.PathWithExt);
 			MODApplyToMaterial mODApplyToMaterial = base.gameObject.AddComponent<MODApplyToMaterial>();
 			mODApplyToMaterial._material = movieInfo.Layer.MODMaterial;
 			mODApplyToMaterial._texturePropertyName = "_Primary";

--- a/MOD.Scripts.Core.Movie/MovieInfo.cs
+++ b/MOD.Scripts.Core.Movie/MovieInfo.cs
@@ -8,6 +8,13 @@ namespace MOD.Scripts.Core.Movie
 {
 	public class MovieInfo
 	{
+		public static string GetPathFromNameWithExt(string name, string ext)
+		{
+			return System.IO.Path.Combine(Application.streamingAssetsPath, "movies/" + name + ext);
+		}
+
+		private readonly string Ext;
+
 		public string Name
 		{
 			get;
@@ -16,13 +23,14 @@ namespace MOD.Scripts.Core.Movie
 
 		public float Volume => Math.Min(1f, 1.55f * GameSystem.Instance.AudioController.BGMVolume);
 
-		public string Path => "file:///" + System.IO.Path.Combine(Application.streamingAssetsPath, "movies/" + Name);
+		public string PathWithExt => "file:///" + GetPathFromNameWithExt(Name, Ext);
 
 		public Layer Layer => GameSystem.Instance.SceneController.MODActiveScene.BackgroundLayer;
 
-		public MovieInfo(string name)
+		public MovieInfo(string name, string ext)
 		{
 			Name = name;
+			Ext = ext;
 		}
 	}
 }

--- a/MOD.Scripts.Core.Movie/TextureMovieRenderer.cs
+++ b/MOD.Scripts.Core.Movie/TextureMovieRenderer.cs
@@ -80,7 +80,7 @@ namespace MOD.Scripts.Core.Movie
 		public void Init(MovieInfo movieInfo)
 		{
 			this.movieInfo = movieInfo;
-			www = new WWW(movieInfo.Path + ".ogv");
+			www = new WWW(movieInfo.PathWithExt);
 			audioSource = base.gameObject.AddComponent<AudioSource>();
 			audioSource.volume = this.movieInfo.Volume;
 			base.enabled = true;


### PR DESCRIPTION
This contains some miscellaneous mod fixes:

### Improved recompile

 - The current script "scripts need recompile" detection is based on the date modified of the `.txt` files and `.mg` files.  
 - This PR makes the game store the MD5 checksum, length, and date modified of the `.txt,` in a `.json` file, and then re-compile if any of those have changed since the last time the game was booted.
 - This is especially useful for translators, as their `.txt` files may be older than our `.txt` files, so when installed manually the game will not re-compile them. To get around this, translators currently have manual instructions say to delete the contents of the `CompiledUpdateScripts` folder.
 - We've also had issues with this in the past on the main mod, although it was mostly fixed by compiling scripts ourselves on the server.
 - See existing issue #85.

### Playback of `.ogv` on Windows-like Platforms

 - Currently movie playback does not work on Wine/Proton, because it cannot play back `.mp4` files. 
 - Even if we make the installer install `.ogv` files, the mod will still not play them back, because the mod will only try to play `.mp4` files on Windows (and Wine/Proton makes the mod think it is on Windows). 
 - This PR makes the mod fall back to `.ogv` playback on Windows, if the `.mp4` file does not exist. We can then make the installer install only the `.ogv` file on Wine/Proton installs.