### PR TITLE
Fix OG mode sprite rotation and offset choice buttons

### DIFF
--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -370,6 +370,13 @@ namespace Assets.Scripts.Core.Scene
 			this.alignment = alignment;
 			this.aspectRatio = (float)width / height;
 			cachedStretchToFit = stretchToFit;
+
+			// Do not rotate character sprites when using 4:3 letterboxing as current method does not handle it properly
+			if (ryukishiClamp)
+			{
+				targetAngle = 0;
+				transform.localRotation = Quaternion.AngleAxis(targetAngle, Vector3.forward);
+			}
 		}
 
 		public void DrawLayerWithMask(string textureName, string maskName, int x, int y, Vector2? origin, bool isBustshot, int style, float wait, bool isBlocking)
@@ -523,6 +530,12 @@ namespace Assets.Scripts.Core.Scene
 
 		public void SetAngle(float angle, float wait)
 		{
+			// Do not rotate character sprites when using 4:3 letterboxing as current method does not handle it properly
+			if(cachedRyukishiClamp)
+			{
+				return;
+			}
+
 			base.transform.localRotation = Quaternion.AngleAxis(targetAngle, Vector3.forward);
 			targetAngle = angle;
 			GameSystem.Instance.RegisterAction(delegate

--- a/Assets.Scripts.UI.Choice/ChoiceController.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceController.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Core;
+using Assets.Scripts.Core.Buriko;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -28,6 +29,13 @@ namespace Assets.Scripts.UI.Choice
 
 		public void Create(List<string> optstrings, int count)
 		{
+			// The text X offset is only necessary when in 16:9 mode - when in 4:3 mode just use an offset of 0
+			float GUIXOffset = GameSystem.Instance.GetGUIOffset();
+			if(BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode").IntValue() == 1)
+			{
+				GUIXOffset = 0;
+			}
+
 			GameObject gameObject = GameObject.FindGameObjectWithTag("PrimaryUIPanel");
 			for (int i = 0; i < count; i++)
 			{
@@ -44,21 +52,21 @@ namespace Assets.Scripts.UI.Choice
 					float x;
 					if (i == count - 1 && count % 2 == 1)
 					{
-						x = GameSystem.Instance.GetGUIOffset();
+						x = GUIXOffset;
 					}
 					else if (i % 2 == 0)
 					{
-						x = GameSystem.Instance.GetGUIOffset() - 300f;
+						x = GUIXOffset - 300f;
 					}
 					else
 					{
-						x = GameSystem.Instance.GetGUIOffset() + 300f;
+						x = GUIXOffset + 300f;
 					}
 					gameObject2.transform.localPosition = new Vector3(x, (float)(-75 * (i / 2) + 27 * count - 50), 0f);
 				}
 				else
 				{
-					gameObject2.transform.localPosition = new Vector3(GameSystem.Instance.GetGUIOffset(), (float)(-75 * i + 27 * count + 50), 0f);
+					gameObject2.transform.localPosition = new Vector3(GUIXOffset, (float)(-75 * i + 27 * count + 50), 0f);
 				}
 				ChoiceButton component = gameObject2.GetComponent<ChoiceButton>();
 				component.ChangeText(optstrings[i]);


### PR DESCRIPTION
This PR fixes some bugs in OG mode (4:3 mode):
 - In OG mode, when sprites are rotated, they are cropped incorrectly. This PR forces sprites not to be rotated when in 4:3 mode.
     - I wouldn't fix it this way if we used rotated sprites all the time, but since we only rotate sprites 1 or 2 times throughout the whole series, this is a sufficient fix. 
     - See #72 
 - In OG mode, the choice buttons are not centered - this makes sure they are centered in both 4:3 and 16:9 mode
     - See #57  