### PR TITLE
Linux gnome crash workaround

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -241,6 +241,7 @@
     <Compile Include="MOD.Scripts.Core\MODLogger.cs" />
     <Compile Include="MOD.Scripts.Core\MODSystem.cs" />
     <Compile Include="MOD.Scripts.Core\MODUtility.cs" />
+    <Compile Include="MOD.Scripts.Core\MODWindowManager.cs" />
     <Compile Include="MOD.Scripts.UI.ChapterJump\MODChapterJumpController.cs" />
     <Compile Include="MOD.Scripts.UI.Tips\MODTipsController.cs" />
     <Compile Include="MOD.Scripts.UI\MODCustomFlagPreset.cs" />

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -251,6 +251,7 @@
     <Compile Include="MOD.Scripts.UI\MODActions.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuAudioOptions.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuAudioSetup.cs" />
+    <Compile Include="MOD.Scripts.UI\MODSubMenuWindowSetup.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuSupport.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuModuleInterface.cs" />
     <Compile Include="MOD.Scripts.UI\MODMenuNormal.cs" />

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2776,6 +2776,14 @@ namespace Assets.Scripts.Core.Buriko
 			return BurikoVariable.Null;
 		}
 
+		private void ShowSetupMenuIfRequired()
+		{
+			if (MODAudioSet.Instance.HasAudioSetsDefined() && !MODAudioSet.Instance.GetCurrentAudioSet(out _))
+			{
+				GameSystem.Instance.MainUIController.modMenu.PushSubMenuAndShow(ModSubMenu.AudioSetup);
+			}
+		}
+
 		public BurikoVariable OperationMODGenericCall()
 		{
 			SetOperationType("MODGenericCall");
@@ -2784,11 +2792,7 @@ namespace Assets.Scripts.Core.Buriko
 			switch(callID)
 			{
 				case "ShowSetupMenuIfRequired":
-					if(MODAudioSet.Instance.HasAudioSetsDefined() && !MODAudioSet.Instance.GetCurrentAudioSet(out _))
-					{
-						GameSystem.Instance.MainUIController.modMenu.PushSubMenu(ModSubMenu.AudioSetup);
-						GameSystem.Instance.MainUIController.modMenu.Show();
-					}
+					ShowSetupMenuIfRequired();
 					break;
 
 				case "LipSyncSettings":

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2782,6 +2782,11 @@ namespace Assets.Scripts.Core.Buriko
 			{
 				GameSystem.Instance.MainUIController.modMenu.PushSubMenuAndShow(ModSubMenu.AudioSetup);
 			}
+
+			if (!MODWindowManager.FullscreenLockConfigured())
+			{
+				GameSystem.Instance.MainUIController.modMenu.PushSubMenuAndShow(ModSubMenu.WindowSetup);
+			}
 		}
 
 		public BurikoVariable OperationMODGenericCall()

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2786,7 +2786,7 @@ namespace Assets.Scripts.Core.Buriko
 				case "ShowSetupMenuIfRequired":
 					if(MODAudioSet.Instance.HasAudioSetsDefined() && !MODAudioSet.Instance.GetCurrentAudioSet(out _))
 					{
-						GameSystem.Instance.MainUIController.modMenu.SetSubMenu(ModSubMenu.AudioSetup);
+						GameSystem.Instance.MainUIController.modMenu.PushSubMenu(ModSubMenu.AudioSetup);
 						GameSystem.Instance.MainUIController.modMenu.Show();
 					}
 					break;

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -189,7 +189,7 @@ namespace Assets.Scripts.Core.State
 			// Fullscreen
 			if (Input.GetKeyDown(KeyCode.F))
 			{
-				MODWindowManager.FullscreenToggle();
+				MODWindowManager.FullscreenToggle(showToast: true);
 			}
 
 			// Toggle Language

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -189,7 +189,7 @@ namespace Assets.Scripts.Core.State
 			// Fullscreen
 			if (Input.GetKeyDown(KeyCode.F))
 			{
-				MODWindowManager.FullscreenTogglePressF();
+				MODWindowManager.FullscreenToggle();
 			}
 
 			// Toggle Language

--- a/Assets.Scripts.Core.State/StateNormal.cs
+++ b/Assets.Scripts.Core.State/StateNormal.cs
@@ -189,21 +189,7 @@ namespace Assets.Scripts.Core.State
 			// Fullscreen
 			if (Input.GetKeyDown(KeyCode.F))
 			{
-				if (GameSystem.Instance.IsFullscreen)
-				{
-					int num14 = PlayerPrefs.GetInt("width");
-					int num15 = PlayerPrefs.GetInt("height");
-					if (num14 == 0 || num15 == 0)
-					{
-						num14 = 640;
-						num15 = 480;
-					}
-					GameSystem.Instance.DeFullscreen(width: num14, height: num15);
-				}
-				else
-				{
-					GameSystem.Instance.GoFullscreen();
-				}
+				MODWindowManager.FullscreenTogglePressF();
 			}
 
 			// Toggle Language

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -158,10 +158,6 @@ namespace Assets.Scripts.Core
 
 		private int SystemInit = 1;
 
-		private Resolution fullscreenResolution;
-
-		private int screenModeSet = -1;
-
 		private Stack<StateEntry> stateStack = new Stack<StateEntry>();
 
 		public bool HasFocus;
@@ -178,13 +174,6 @@ namespace Assets.Scripts.Core
 
 		// Unity will attempt to deserialize public properties and these aren't in the AssetBundle,
 		// so use private ones with public accessors
-		private bool _isFullscreen;
-		public bool IsFullscreen
-		{
-			get => _isFullscreen;
-			private set => _isFullscreen = value;
-		}
-
 		private float _configMenuFontSize = 0;
 		public float ConfigMenuFontSize
 		{
@@ -255,26 +244,9 @@ namespace Assets.Scripts.Core
 			{
 				PlayerPrefs.SetInt("height", 480);
 			}
-			IsFullscreen = PlayerPrefs.GetInt("is_fullscreen", 0) == 1;
-			fullscreenResolution.width = 0;
-			fullscreenResolution.height = 0;
-			fullscreenResolution = GetFullscreenResolution();
 
-			if (IsFullscreen)
-			{
-				Screen.SetResolution(fullscreenResolution.width, fullscreenResolution.height, fullscreen: true);
-			}
-			else if (PlayerPrefs.HasKey("height") && PlayerPrefs.HasKey("width"))
-			{
-				int width = PlayerPrefs.GetInt("width");
-				int height = PlayerPrefs.GetInt("height");
-				Debug.Log("Requesting window size " + width + "x" + height + " based on config file");
-				Screen.SetResolution(width, height, fullscreen: false);
-			}
-			if ((Screen.width < 640 || Screen.height < 480) && !IsFullscreen)
-			{
-				Screen.SetResolution(640, 480, fullscreen: false);
-			}
+			MODWindowManager.GameSystemInitSetResolution();
+
 			Debug.Log("Starting compile thread...");
 			CompileThread = new Thread(CompileScripts)
 			{
@@ -326,12 +298,7 @@ namespace Assets.Scripts.Core
 		public void UpdateAspectRatio(float newratio)
 		{
 			AspectRatio = newratio;
-			if (!IsFullscreen)
-			{
-				int width = Mathf.RoundToInt((float)Screen.height * AspectRatio);
-				Screen.SetResolution(width, Screen.height, fullscreen: false);
-			}
-			PlayerPrefs.SetInt("width", Mathf.RoundToInt(PlayerPrefs.GetInt("height") * AspectRatio));
+			MODWindowManager.UpdateWindowAspect(AspectRatio);
 			MainUIController.UpdateBlackBars();
 			SceneController.UpdateScreenSize();
 		}
@@ -816,37 +783,6 @@ namespace Assets.Scripts.Core
 			});
 		}
 
-		public IEnumerator FrameWaitForFullscreen(int width, int height, bool fullscreen)
-		{
-			yield return (object)new WaitForEndOfFrame();
-			yield return (object)new WaitForFixedUpdate();
-			IsFullscreen = fullscreen;
-			PlayerPrefs.SetInt("is_fullscreen", fullscreen ? 1 : 0);
-			Screen.SetResolution(width, height, fullscreen);
-			while (Screen.width != width || Screen.height != height)
-			{
-				yield return (object)null;
-			}
-		}
-
-		public void GoFullscreen()
-		{
-			IsFullscreen = true;
-			PlayerPrefs.SetInt("is_fullscreen", 1);
-			Resolution resolution = GetFullscreenResolution();
-			Screen.SetResolution(resolution.width, resolution.height, fullscreen: true);
-			Debug.Log(resolution.width + " , " + resolution.height);
-			PlayerPrefs.SetInt("fullscreen_width", resolution.width);
-			PlayerPrefs.SetInt("fullscreen_height", resolution.height);
-		}
-
-		public void DeFullscreen(int width, int height)
-		{
-			IsFullscreen = false;
-			PlayerPrefs.SetInt("is_fullscreen", 0);
-			Screen.SetResolution(width, height, fullscreen: false);
-		}
-
 		private void OnApplicationFocus(bool focusStatus)
 		{
 			HasFocus = focusStatus;
@@ -854,17 +790,7 @@ namespace Assets.Scripts.Core
 
 		private void LateUpdate()
 		{
-			if (screenModeSet == -1)
-			{
-				screenModeSet = 0;
-				fullscreenResolution = Screen.currentResolution;
-				if (PlayerPrefs.HasKey("fullscreen_width") && PlayerPrefs.HasKey("fullscreen_height") && Screen.fullScreen)
-				{
-					fullscreenResolution.width = PlayerPrefs.GetInt("fullscreen_width");
-					fullscreenResolution.height = PlayerPrefs.GetInt("fullscreen_height");
-				}
-				Debug.Log("Fullscreen Resolution: " + fullscreenResolution.width + ", " + fullscreenResolution.height);
-			}
+			MODWindowManager.GetFullScreenResolutionLateUpdate();
 		}
 
 		private bool CheckInitialization()
@@ -1028,80 +954,6 @@ namespace Assets.Scripts.Core
 			}
 		}
 
-		public Resolution GetFullscreenResolution()
-		{
-			Resolution resolution = new Resolution();
-			string source = "";
-			// Try to guess resolution from Screen.currentResolution
-			if (!Screen.fullScreen || Application.platform == RuntimePlatform.OSXPlayer)
-			{
-				resolution.width = this.fullscreenResolution.width = Screen.currentResolution.width;
-				resolution.height = this.fullscreenResolution.height = Screen.currentResolution.height;
-				source = "Screen.currentResolution";
-			}
-			else if (this.fullscreenResolution.width > 0 && this.fullscreenResolution.height > 0)
-			{
-				resolution.width = this.fullscreenResolution.width;
-				resolution.height = this.fullscreenResolution.height;
-				source = "Stored fullscreenResolution";
-			}
-			else if (PlayerPrefs.HasKey("fullscreen_width") && PlayerPrefs.HasKey("fullscreen_height"))
-			{
-				resolution.width = PlayerPrefs.GetInt("fullscreen_width");
-				resolution.height = PlayerPrefs.GetInt("fullscreen_height");
-				source = "PlayerPrefs";
-			}
-			else
-			{
-				resolution.width = Screen.currentResolution.width;
-				resolution.height = Screen.currentResolution.height;
-				source = "Screen.currentResolution as Fallback";
-			}
-
-			// Above can be glitchy on Linux, so also check the maximum resolution of a single monitor
-			// If it's bigger than that, then switch over
-			// Note that this (from what I can tell) gives you the biggest resolution of any of your monitors,
-			// not just the one the game is running under, so it could *also* be wrong, which is why we check both methods
-			if (Screen.resolutions.Length > 0)
-			{
-				int index = 0;
-				Resolution best = Screen.resolutions[0];
-				for (int i = 1; i < Screen.resolutions.Length; i++)
-				{
-					if (Screen.resolutions[i].height * Screen.resolutions[i].width > best.height * best.width)
-					{
-						best = Screen.resolutions[i];
-						index = i;
-					}
-				}
-				if (best.width <= resolution.width && best.height <= resolution.height) {
-					resolution = best;
-					source = "Screen.resolutions #" + index;
-				}
-			}
-			if (!PlayerPrefs.HasKey("fullscreen_width_override"))
-			{
-				PlayerPrefs.SetInt("fullscreen_width_override", 0);
-			}
-			if (!PlayerPrefs.HasKey("fullscreen_height_override"))
-			{
-				PlayerPrefs.SetInt("fullscreen_height_override", 0);
-			}
-
-			if (PlayerPrefs.GetInt("fullscreen_width_override") > 0)
-			{
-				resolution.width = PlayerPrefs.GetInt("fullscreen_width_override");
-				source += " + Width Override";
-			}
-			if (PlayerPrefs.GetInt("fullscreen_height_override") > 0)
-			{
-				resolution.height = PlayerPrefs.GetInt("fullscreen_height_override");
-				source += " + Height Override";
-			}
-			Debug.Log("Using resolution " + resolution.width + "x" + resolution.height + " as the fullscreen resolution based on " + source + ".");
-			return resolution;
-		}
-
 		/// <summary>
 		/// Gets the amount you should offset gui elements to center them properly based on the current aspect ratio.
 		/// Add this number to GUI elements' positions to center them, subtract it from window positions.
@@ -1113,18 +965,7 @@ namespace Assets.Scripts.Core
 
 		~GameSystem()
 		{
-			// Fixes an issue where Unity would write garbage values to its saved state on Linux
-			// If we do this while the game is running, Unity will overwrite the values
-			// So do it in the finalizer, which will run as the game quits and the GameSystem is deallocated
-			if (PlayerPrefs.HasKey("width") && PlayerPrefs.HasKey("height"))
-			{
-				int width = PlayerPrefs.GetInt("width");
-				int height = PlayerPrefs.GetInt("height");
-				PlayerPrefs.SetInt("Screenmanager Resolution Width", width);
-				PlayerPrefs.SetInt("Screenmanager Resolution Height", height);
-				PlayerPrefs.SetInt("is_fullscreen", IsFullscreen ? 1 : 0);
-				PlayerPrefs.SetInt("Screenmanager Is Fullscreen mode", 0);
-			}
+			MODWindowManager.ScreenManagerFix();
 		}
 
 		static GameSystem()

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -236,9 +236,9 @@ namespace Assets.Scripts.Core
 			{
 				PlayerPrefs.SetInt("height", 720);
 			}
-			if (PlayerPrefs.GetInt("width") < 640)
+			if (PlayerPrefs.GetInt("width") < 853)
 			{
-				PlayerPrefs.SetInt("width", 640);
+				PlayerPrefs.SetInt("width", 853);
 			}
 			if (PlayerPrefs.GetInt("height") < 480)
 			{

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -298,7 +298,7 @@ namespace Assets.Scripts.Core
 		public void UpdateAspectRatio(float newratio)
 		{
 			AspectRatio = newratio;
-			MODWindowManager.UpdateWindowAspect(AspectRatio);
+			MODWindowManager.RefreshWindowAspect();
 			MainUIController.UpdateBlackBars();
 			SceneController.UpdateScreenSize();
 		}

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -934,6 +934,11 @@ namespace Assets.Scripts.Core
 			{
 				SteamController.Close();
 			}
+
+			if(CanExit)
+			{
+				MODWindowManager.OnApplicationReallyQuit("GameSystem.OnApplicationQuit()");
+			}
 		}
 
 		/// <summary>
@@ -965,7 +970,7 @@ namespace Assets.Scripts.Core
 
 		~GameSystem()
 		{
-			MODWindowManager.ScreenManagerFix();
+			MODWindowManager.OnApplicationReallyQuit("GameSystem Destructor");
 		}
 
 		static GameSystem()

--- a/Assets.Scripts.Core/KeyHook.cs
+++ b/Assets.Scripts.Core/KeyHook.cs
@@ -1,3 +1,4 @@
+using MOD.Scripts.Core;
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -46,14 +47,7 @@ namespace Assets.Scripts.Core
 				int num = Marshal.ReadInt32(lParam);
 				if (num == 13 && GameSystem.Instance.HasFocus)
 				{
-					if (GameSystem.Instance.IsFullscreen)
-					{
-						GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
-					}
-					else
-					{
-						GameSystem.Instance.GoFullscreen();
-					}
+					MODWindowManager.FullscreenToggleAltEnter();
 					return (IntPtr)1;
 				}
 			}

--- a/Assets.Scripts.Core/KeyHook.cs
+++ b/Assets.Scripts.Core/KeyHook.cs
@@ -47,7 +47,7 @@ namespace Assets.Scripts.Core
 				int num = Marshal.ReadInt32(lParam);
 				if (num == 13 && GameSystem.Instance.HasFocus)
 				{
-					MODWindowManager.FullscreenToggleAltEnter();
+					MODWindowManager.FullscreenToggle();
 					return (IntPtr)1;
 				}
 			}

--- a/Assets.Scripts.Core/KeyHook.cs
+++ b/Assets.Scripts.Core/KeyHook.cs
@@ -47,7 +47,7 @@ namespace Assets.Scripts.Core
 				int num = Marshal.ReadInt32(lParam);
 				if (num == 13 && GameSystem.Instance.HasFocus)
 				{
-					MODWindowManager.FullscreenToggle();
+					MODWindowManager.FullscreenToggle(showToast: true);
 					return (IntPtr)1;
 				}
 			}

--- a/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
+++ b/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
@@ -8,6 +8,9 @@ namespace Assets.Scripts.UI.Config
 	{
 		public int Width;
 
+		// This variable doesn't actually change/doesn't really relate to the game's fullscreen state
+		// It is actually used to indicate which button is labelled as "fullscreen" (it is true only for that button)
+
 		public bool IsFullscreen;
 
 		private UIButton button;
@@ -32,8 +35,14 @@ namespace Assets.Scripts.UI.Config
 
 		private void OnClick()
 		{
-			// NOTE: Currently 'IsFullscreen' is always false in this class. Not sure if this is intentional.
-			MODWindowManager.ConfigMenuButtonSetResolution(IsFullscreen, Height());
+			if(IsFullscreen)
+			{
+				MODWindowManager.GoFullscreen();
+			}
+			else
+			{
+				MODWindowManager.SetWindowed(Height());
+			}
 		}
 
 		private bool ShouldBeDown()

--- a/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
+++ b/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Core;
+using MOD.Scripts.Core;
 using UnityEngine;
 
 namespace Assets.Scripts.UI.Config
@@ -31,25 +32,15 @@ namespace Assets.Scripts.UI.Config
 
 		private void OnClick()
 		{
-			if (IsFullscreen)
-			{
-				GameSystem.Instance.GoFullscreen();
-			}
-			else
-			{
-				int height = Height();
-				int width = Mathf.RoundToInt(height * GameSystem.Instance.AspectRatio);
-				GameSystem.Instance.DeFullscreen(width: width, height: height);
-				PlayerPrefs.SetInt("width", width);
-				PlayerPrefs.SetInt("height", height);
-			}
+			// NOTE: Currently 'IsFullscreen' is always false in this class. Not sure if this is intentional.
+			MODWindowManager.ConfigMenuButtonSetResolution(IsFullscreen, Height());
 		}
 
 		private bool ShouldBeDown()
 		{
 			if (IsFullscreen)
 			{
-				return GameSystem.Instance.IsFullscreen;
+				return MODWindowManager.IsFullscreen;
 			}
 			return Screen.height == Height();
 		}

--- a/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
+++ b/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
@@ -47,10 +47,12 @@ namespace Assets.Scripts.UI.Config
 
 		private bool ShouldBeDown()
 		{
+			// Make the 'fullscreen' button always clickable because it toggles fullscreen
 			if (IsFullscreen)
 			{
-				return MODWindowManager.IsFullscreen;
+				return false;
 			}
+
 			return Screen.height == Height();
 		}
 

--- a/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
+++ b/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
@@ -37,11 +37,11 @@ namespace Assets.Scripts.UI.Config
 		{
 			if(IsFullscreen)
 			{
-				MODWindowManager.FullscreenToggle();
+				MODWindowManager.FullscreenToggle(showToast: true);
 			}
 			else
 			{
-				MODWindowManager.SetResolution(Height());
+				MODWindowManager.SetResolution(Height(), showToast: true);
 			}
 		}
 

--- a/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
+++ b/Assets.Scripts.UI.Config/ScreenSwitcherButton.cs
@@ -37,11 +37,11 @@ namespace Assets.Scripts.UI.Config
 		{
 			if(IsFullscreen)
 			{
-				MODWindowManager.GoFullscreen();
+				MODWindowManager.FullscreenToggle();
 			}
 			else
 			{
-				MODWindowManager.SetWindowed(Height());
+				MODWindowManager.SetResolution(Height());
 			}
 		}
 

--- a/Assets.Scripts.UI.Config/SwitchButton.cs
+++ b/Assets.Scripts.UI.Config/SwitchButton.cs
@@ -131,7 +131,7 @@ namespace Assets.Scripts.UI.Config
 				}
 				break;
 			case ConfigButtonType.FullscreenMode:
-				GameSystem.Instance.GoFullscreen();
+				MODWindowManager.ConfigMenuButtonGoFullscreen();
 				break;
 			case ConfigButtonType.ClickToCutVoice:
 				GameSystem.Instance.StopVoiceOnClick = !GameSystem.Instance.StopVoiceOnClick;

--- a/Assets.Scripts.UI.Config/SwitchButton.cs
+++ b/Assets.Scripts.UI.Config/SwitchButton.cs
@@ -131,7 +131,7 @@ namespace Assets.Scripts.UI.Config
 				}
 				break;
 			case ConfigButtonType.FullscreenMode:
-				MODWindowManager.ConfigMenuButtonGoFullscreen();
+				MODWindowManager.GoFullscreen();
 				break;
 			case ConfigButtonType.ClickToCutVoice:
 				GameSystem.Instance.StopVoiceOnClick = !GameSystem.Instance.StopVoiceOnClick;

--- a/Assets.Scripts.UI.Config/SwitchButton.cs
+++ b/Assets.Scripts.UI.Config/SwitchButton.cs
@@ -131,7 +131,7 @@ namespace Assets.Scripts.UI.Config
 				}
 				break;
 			case ConfigButtonType.FullscreenMode:
-				MODWindowManager.GoFullscreen();
+				MODWindowManager.GoFullscreen(showToast: true);
 				break;
 			case ConfigButtonType.ClickToCutVoice:
 				GameSystem.Instance.StopVoiceOnClick = !GameSystem.Instance.StopVoiceOnClick;

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -173,7 +173,7 @@ namespace MOD.Scripts.Core
 			Debug.Log($"PlayerPrefs:\n{string.Join("\n", prefsToPrint.Select(key => GetPrintablePlayerPrefsInt(key)).ToArray())}");
 
 			// Restore IsFullscreen variable from playerprefs
-			IsFullscreen = PlayerPrefs.GetInt("is_fullscreen", 0) == 1;
+			IsFullscreen = PlayerPrefs.GetInt("is_fullscreen", 1) == 1;
 
 			// Restore fullscreenResolution variable using GetFullscreenResolution()
 			fullscreenResolution.width = 0;

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -49,9 +49,9 @@ namespace MOD.Scripts.Core
 
 		// Set the screen resolution, where the width will be set according to the current AspectRatio
 		// The windowed/fullscreen state won't be changed.
-		public static void SetWindowed(int height)
+		public static void SetResolution(int height)
 		{
-			SetResolution(maybe_width: null, maybe_height: height, maybe_fullscreen: false);
+			SetResolution(maybe_width: null, maybe_height: height, maybe_fullscreen: null);
 		}
 
 		// Go fullscreen. The new resolution will be detected automatically.

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -1,0 +1,255 @@
+﻿using Assets.Scripts.Core;
+using MOD.Scripts.UI;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.Core
+{
+	class MODWindowManager
+	{
+		public static bool IsFullscreen;
+		private static Resolution fullscreenResolution;
+		private static int screenModeSet = -1;
+
+		public static void FullscreenToggleAltEnter()
+		{
+			if (IsFullscreen)
+			{
+				DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
+			}
+			else
+			{
+				GoFullscreen();
+			}
+		}
+
+		public static void FullscreenTogglePressF()
+		{
+			if (IsFullscreen)
+			{
+				int num14 = PlayerPrefs.GetInt("width");
+				int num15 = PlayerPrefs.GetInt("height");
+				if (num14 == 0 || num15 == 0)
+				{
+					num14 = 640;
+					num15 = 480;
+				}
+				DeFullscreen(width: num14, height: num15);
+			}
+			else
+			{
+				GoFullscreen();
+			}
+		}
+
+		public static void ConfigMenuButtonSetResolution(bool IsFullscreenArgument, int height)
+		{
+			if (IsFullscreenArgument)
+			{
+				GoFullscreen();
+			}
+			else
+			{
+				int width = Mathf.RoundToInt(height * GameSystem.Instance.AspectRatio);
+				DeFullscreen(width: width, height: height);
+				PlayerPrefs.SetInt("width", width);
+				PlayerPrefs.SetInt("height", height);
+			}
+		}
+
+		public static void ConfigMenuButtonGoFullscreen()
+		{
+			GoFullscreen();
+		}
+
+		public static void FullscreenToggleMODMenu()
+		{
+			if (IsFullscreen)
+			{
+				DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
+			}
+			else
+			{
+				GoFullscreen();
+			}
+		}
+
+		public static void UpdateWindowAspect(float AspectRatio)
+		{
+			if (!IsFullscreen)
+			{
+				int width = Mathf.RoundToInt((float)Screen.height * AspectRatio);
+				Screen.SetResolution(width, Screen.height, fullscreen: false);
+			}
+			PlayerPrefs.SetInt("width", Mathf.RoundToInt(PlayerPrefs.GetInt("height") * AspectRatio));
+		}
+
+		public static void GameSystemInitSetResolution()
+		{
+			IsFullscreen = PlayerPrefs.GetInt("is_fullscreen", 0) == 1;
+			fullscreenResolution.width = 0;
+			fullscreenResolution.height = 0;
+
+			fullscreenResolution = GetFullscreenResolution();
+			if (IsFullscreen)
+			{
+				Screen.SetResolution(fullscreenResolution.width, fullscreenResolution.height, fullscreen: true);
+			}
+			else if (PlayerPrefs.HasKey("height") && PlayerPrefs.HasKey("width"))
+			{
+				int width = PlayerPrefs.GetInt("width");
+				int height = PlayerPrefs.GetInt("height");
+				Debug.Log("Requesting window size " + width + "x" + height + " based on config file");
+				Screen.SetResolution(width, height, fullscreen: false);
+			}
+			if ((Screen.width < 640 || Screen.height < 480) && !IsFullscreen)
+			{
+				Screen.SetResolution(640, 480, fullscreen: false);
+			}
+		}
+
+		public static void GetFullScreenResolutionLateUpdate()
+		{
+			if (screenModeSet == -1)
+			{
+				screenModeSet = 0;
+				fullscreenResolution = Screen.currentResolution;
+				if (PlayerPrefs.HasKey("fullscreen_width") && PlayerPrefs.HasKey("fullscreen_height") && Screen.fullScreen)
+				{
+					fullscreenResolution.width = PlayerPrefs.GetInt("fullscreen_width");
+					fullscreenResolution.height = PlayerPrefs.GetInt("fullscreen_height");
+				}
+				Debug.Log("Fullscreen Resolution: " + fullscreenResolution.width + ", " + fullscreenResolution.height);
+			}
+		}
+
+		public static void ScreenManagerFix()
+		{
+			// Fixes an issue where Unity would write garbage values to its saved state on Linux
+			// If we do this while the game is running, Unity will overwrite the values
+			// So do it in the finalizer, which will run as the game quits and the GameSystem is deallocated
+			if (PlayerPrefs.HasKey("width") && PlayerPrefs.HasKey("height"))
+			{
+				int width = PlayerPrefs.GetInt("width");
+				int height = PlayerPrefs.GetInt("height");
+				PlayerPrefs.SetInt("Screenmanager Resolution Width", width);
+				PlayerPrefs.SetInt("Screenmanager Resolution Height", height);
+				PlayerPrefs.SetInt("is_fullscreen", IsFullscreen ? 1 : 0);
+				PlayerPrefs.SetInt("Screenmanager Is Fullscreen mode", 0);
+			}
+		}
+		public static void MODMenuSetAndSaveResolution(int height)
+		{
+			if (height < 480)
+			{
+				MODToaster.Show("Height too small - must be at least 480 pixels");
+				height = 480;
+			}
+			else if (height > 15360)
+			{
+				MODToaster.Show("Height too big - must be less than 15360 pixels");
+				height = 15360;
+			}
+
+			int width = Mathf.RoundToInt(height * 16f / 9f);
+			Screen.SetResolution(width, height, Screen.fullScreen);
+			PlayerPrefs.SetInt("width", width);
+			PlayerPrefs.SetInt("height", height);
+		}
+
+		private static void GoFullscreen()
+		{
+			IsFullscreen = true;
+			PlayerPrefs.SetInt("is_fullscreen", 1);
+			Resolution resolution = GetFullscreenResolution();
+			Screen.SetResolution(resolution.width, resolution.height, fullscreen: true);
+			Debug.Log(resolution.width + " , " + resolution.height);
+			PlayerPrefs.SetInt("fullscreen_width", resolution.width);
+			PlayerPrefs.SetInt("fullscreen_height", resolution.height);
+		}
+
+		private static void DeFullscreen(int width, int height)
+		{
+			IsFullscreen = false;
+			PlayerPrefs.SetInt("is_fullscreen", 0);
+			Screen.SetResolution(width, height, fullscreen: false);
+		}
+
+		private static Resolution GetFullscreenResolution()
+		{
+			Resolution resolution = new Resolution();
+			string source = "";
+			// Try to guess resolution from Screen.currentResolution
+			if (!Screen.fullScreen || Application.platform == RuntimePlatform.OSXPlayer)
+			{
+				resolution.width = fullscreenResolution.width = Screen.currentResolution.width;
+				resolution.height = fullscreenResolution.height = Screen.currentResolution.height;
+				source = "Screen.currentResolution";
+			}
+			else if (fullscreenResolution.width > 0 && fullscreenResolution.height > 0)
+			{
+				resolution.width = fullscreenResolution.width;
+				resolution.height = fullscreenResolution.height;
+				source = "Stored fullscreenResolution";
+			}
+			else if (PlayerPrefs.HasKey("fullscreen_width") && PlayerPrefs.HasKey("fullscreen_height"))
+			{
+				resolution.width = PlayerPrefs.GetInt("fullscreen_width");
+				resolution.height = PlayerPrefs.GetInt("fullscreen_height");
+				source = "PlayerPrefs";
+			}
+			else
+			{
+				resolution.width = Screen.currentResolution.width;
+				resolution.height = Screen.currentResolution.height;
+				source = "Screen.currentResolution as Fallback";
+			}
+
+			// Above can be glitchy on Linux, so also check the maximum resolution of a single monitor
+			// If it's bigger than that, then switch over
+			// Note that this (from what I can tell) gives you the biggest resolution of any of your monitors,
+			// not just the one the game is running under, so it could *also* be wrong, which is why we check both methods
+			if (Screen.resolutions.Length > 0)
+			{
+				int index = 0;
+				Resolution best = Screen.resolutions[0];
+				for (int i = 1; i < Screen.resolutions.Length; i++)
+				{
+					if (Screen.resolutions[i].height * Screen.resolutions[i].width > best.height * best.width)
+					{
+						best = Screen.resolutions[i];
+						index = i;
+					}
+				}
+				if (best.width <= resolution.width && best.height <= resolution.height)
+				{
+					resolution = best;
+					source = "Screen.resolutions #" + index;
+				}
+			}
+			if (!PlayerPrefs.HasKey("fullscreen_width_override"))
+			{
+				PlayerPrefs.SetInt("fullscreen_width_override", 0);
+			}
+			if (!PlayerPrefs.HasKey("fullscreen_height_override"))
+			{
+				PlayerPrefs.SetInt("fullscreen_height_override", 0);
+			}
+
+			if (PlayerPrefs.GetInt("fullscreen_width_override") > 0)
+			{
+				resolution.width = PlayerPrefs.GetInt("fullscreen_width_override");
+				source += " + Width Override";
+			}
+			if (PlayerPrefs.GetInt("fullscreen_height_override") > 0)
+			{
+				resolution.height = PlayerPrefs.GetInt("fullscreen_height_override");
+				source += " + Height Override";
+			}
+			Debug.Log("Using resolution " + resolution.width + "x" + resolution.height + " as the fullscreen resolution based on " + source + ".");
+			return resolution;
+		}
+	}
+}

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -14,6 +14,9 @@ namespace MOD.Scripts.Core
 		private static Resolution fullscreenResolution;
 		private static int screenModeSet = -1;
 
+		private static int lastSetWidth = 640;
+		private static int lastSetHeight = 480;
+
 		private static string[] prefsToPrint = {
 			"width",
 			"height",
@@ -137,28 +140,23 @@ namespace MOD.Scripts.Core
 
 			Screen.SetResolution(width, height, IsFullscreen);
 
+			lastSetWidth = width;
+			lastSetHeight = height;
+
 			// Update playerprefs (won't be saved until game exits or PlayerPrefs.Save() is called
-			SetPlayerPrefs(width, height);
+			SetPlayerPrefs();
 		}
 
 		// NOTE: this function does not save playerprefs
 		// playerprefs are saved when the game exits cleanly, or on manual calls to PlayerPrefs.Save()
-		private static void SetPlayerPrefs(int width, int height)
+		private static void SetPlayerPrefs()
 		{
-			if(IsFullscreen)
-			{
-				PlayerPrefs.SetInt("fullscreen_width", width);
-				PlayerPrefs.SetInt("fullscreen_height", height);
-			}
-			else
-			{
-				PlayerPrefs.SetInt("width", width);
-				PlayerPrefs.SetInt("height", height);
-			}
-
+			PlayerPrefs.SetInt(IsFullscreen ? "fullscreen_width" : "width", lastSetWidth);
+			PlayerPrefs.SetInt(IsFullscreen ? "fullscreen_height" : "height", lastSetHeight);
 			PlayerPrefs.SetInt("is_fullscreen", IsFullscreen ? 1 : 0);
-			PlayerPrefs.SetInt("Screenmanager Resolution Width", width);
-			PlayerPrefs.SetInt("Screenmanager Resolution Height", height);
+
+			PlayerPrefs.SetInt("Screenmanager Resolution Width", lastSetWidth);
+			PlayerPrefs.SetInt("Screenmanager Resolution Height", lastSetHeight);
 
 			// This used to be always set false, but on Linux Gnome this caused
 			// TODO: decide whether to set this to IsFullscreen, or to just always set true.
@@ -210,12 +208,7 @@ namespace MOD.Scripts.Core
 			// Fixes an issue where Unity would write garbage values to its saved state on Linux
 			// If we do this while the game is running, Unity will overwrite the values
 			// So do it in the finalizer, which will run as the game quits and the GameSystem is deallocated
-			if (PlayerPrefs.HasKey("width") && PlayerPrefs.HasKey("height"))
-			{
-				int width = PlayerPrefs.GetInt("width");
-				int height = PlayerPrefs.GetInt("height");
-				SetPlayerPrefs(width, height);
-			}
+			SetPlayerPrefs();
 
 			PrintPlayerPrefs("On Shutdown");
 		}

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -18,7 +18,7 @@ namespace MOD.Scripts.Core
 		private static Resolution fullscreenResolution;
 		private static int screenModeSet = -1;
 
-		private static int lastSetWidth = 640;
+		private static int lastSetWidth = 853;
 		private static int lastSetHeight = 480;
 
 		private static string[] prefsToPrint = {
@@ -76,7 +76,7 @@ namespace MOD.Scripts.Core
 		public static void SetResolution(int? maybe_width, int? maybe_height, bool? maybe_fullscreen, bool showToast=false)
 		{
 			int height = 480;
-			int width = 640;
+			int width = 853;
 
 			// Default to keeping current fullscreen state if fullscreen not specified
 			TrySetIsFullscreen(maybe_fullscreen ?? IsFullscreen, "SetResolution");
@@ -130,11 +130,11 @@ namespace MOD.Scripts.Core
 				height = 15360;
 			}
 
-			if (width < 640)
+			if (width < 853)
 			{
-				MODToaster.Show("Width too small - must be at least 640 pixels");
-				Debug.Log("Width too small - must be at least 640 pixels");
-				width = 640;
+				MODToaster.Show("Width too small - must be at least 853 pixels");
+				Debug.Log("Width too small - must be at least 853 pixels");
+				width = 853;
 			}
 			else if (width > 15360)
 			{

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -42,33 +42,33 @@ namespace MOD.Scripts.Core
 		// Toggle between windowed and fullscreen.
 		// Windowed mode will use the last windowed resolution.
 		// Fullscreen mode will use the detected fullscreen resolution.
-		public static void FullscreenToggle()
+		public static void FullscreenToggle(bool showToast=false)
 		{
-			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: !IsFullscreen);
+			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: !IsFullscreen, showToast: showToast);
 		}
 
 		// Set the screen resolution, where the width will be set according to the current AspectRatio
 		// The windowed/fullscreen state won't be changed.
-		public static void SetResolution(int height)
+		public static void SetResolution(int height, bool showToast = false)
 		{
-			SetResolution(maybe_width: null, maybe_height: height, maybe_fullscreen: null);
+			SetResolution(maybe_width: null, maybe_height: height, maybe_fullscreen: null, showToast: showToast);
 		}
 
 		// Go fullscreen. The new resolution will be detected automatically.
-		public static void GoFullscreen()
+		public static void GoFullscreen(bool showToast = false)
 		{
-			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: true);
+			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: true, showToast: showToast);
 		}
 
 		// This function does the following:
 		// - If full screen is enabled, the resolution will set according to the monitor resolution
 		// - If windowed, the window width will be set according to the height and AspectRatio
-		public static void RefreshWindowAspect()
+		public static void RefreshWindowAspect(bool showToast = false)
 		{
-			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: null);
+			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: null, showToast: showToast);
 		}
 
-		private static void SetResolution(int? maybe_width, int? maybe_height, bool? maybe_fullscreen)
+		private static void SetResolution(int? maybe_width, int? maybe_height, bool? maybe_fullscreen, bool showToast=false)
 		{
 			int height = 480;
 			int width = 640;
@@ -145,6 +145,11 @@ namespace MOD.Scripts.Core
 
 			// Update playerprefs (won't be saved until game exits or PlayerPrefs.Save() is called
 			SetPlayerPrefs();
+
+			if(showToast)
+			{
+				MODToaster.Show($"Set Res: {width}x{height}");
+			}
 		}
 
 		// NOTE: this function does not save playerprefs

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -73,7 +73,7 @@ namespace MOD.Scripts.Core
 			SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: null, showToast: showToast);
 		}
 
-		private static void SetResolution(int? maybe_width, int? maybe_height, bool? maybe_fullscreen, bool showToast=false)
+		public static void SetResolution(int? maybe_width, int? maybe_height, bool? maybe_fullscreen, bool showToast=false)
 		{
 			int height = 480;
 			int width = 640;
@@ -151,9 +151,14 @@ namespace MOD.Scripts.Core
 			// Update playerprefs (won't be saved until game exits or PlayerPrefs.Save() is called
 			SetPlayerPrefs();
 
-			if(showToast)
+			if (showToast)
 			{
-				MODToaster.Show($"Set Res: {width}x{height}");
+				string prefix = "Set Res";
+				if(maybe_fullscreen == false && FullscreenLocked())
+				{
+					prefix = "Fullscreen Locked";
+				}
+				MODToaster.Show($"{prefix}: {width}x{height}");
 			}
 		}
 
@@ -209,6 +214,7 @@ namespace MOD.Scripts.Core
 
 			if (PlayerPrefsNeedsReset())
 			{
+				ForceUnconfigureFullscreenLock();
 				// TODO: could fully reset playerprefs by calling PlayerPrefs.DeleteAll(), but not sure if such drastic measures are necessary?
 				GoFullscreen();
 				Debug.Log("WARNING: Crash or corrupted playerprefs detected. Reverting to fullscreen mode!");
@@ -288,6 +294,10 @@ namespace MOD.Scripts.Core
 		public static void SetFullScreenLock(bool enableLock)
 		{
 			PlayerPrefs.SetInt(FULLSCREEN_LOCK_KEY, enableLock ? 1 : 0);
+			if(FullscreenLocked())
+			{
+				GoFullscreen();
+			}
 		}
 
 		public static bool FullscreenLocked()
@@ -298,6 +308,10 @@ namespace MOD.Scripts.Core
 		public static bool FullscreenLockConfigured()
 		{
 			return PlayerPrefs.HasKey(FULLSCREEN_LOCK_KEY);
+		}
+		public static void ForceUnconfigureFullscreenLock()
+		{
+			PlayerPrefs.DeleteKey(FULLSCREEN_LOCK_KEY);
 		}
 
 		private static Resolution GetFullscreenResolution()

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -322,6 +322,11 @@ namespace MOD.Scripts.Core
 		{
 			PlayerPrefs.DeleteKey(FULLSCREEN_LOCK_KEY);
 		}
+		public static void ClearPlayerPrefsFullscreenResolution()
+		{
+			PlayerPrefs.DeleteKey("fullscreen_width");
+			PlayerPrefs.DeleteKey("fullscreen_height");
+		}
 
 		private static Resolution GetFullscreenResolution()
 		{

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -212,7 +212,16 @@ namespace MOD.Scripts.Core
 		{
 			PrintPlayerPrefs("On Startup");
 
-			if (PlayerPrefsNeedsReset())
+			// On OS other than Linux, default to disabling fullscreen lock rather than asking the user,
+			// as it doesn't help with any known bugs on Windows/MacOS
+			if (Application.platform != RuntimePlatform.LinuxPlayer && !FullscreenLockConfigured())
+			{
+				SetFullScreenLock(false);
+			}
+
+			// If crash detected on linux, force fullscreen mode, in case crash was caused by gnome windowed mode bug.
+			// Also, show the window setup menu again so user can configure fullscreen lock.
+			if (Application.platform == RuntimePlatform.LinuxPlayer && PlayerPrefsNeedsReset())
 			{
 				ForceUnconfigureFullscreenLock();
 				// TODO: could fully reset playerprefs by calling PlayerPrefs.DeleteAll(), but not sure if such drastic measures are necessary?

--- a/MOD.Scripts.Core/MODWindowManager.cs
+++ b/MOD.Scripts.Core/MODWindowManager.cs
@@ -25,6 +25,17 @@ namespace MOD.Scripts.Core
 			"Screenmanager Is Fullscreen mode"
 		};
 
+		private static void PrintPlayerPrefs(string caption)
+		{
+			string PrintPref(string key)
+			{
+				return $"{key}: {(PlayerPrefs.HasKey(key) ? PlayerPrefs.GetInt(key).ToString() : "<MISSING>")}";
+			}
+
+			// Print out certain playerprefs values for debugging
+			Debug.Log($"PlayerPrefs [{caption}]:\n{string.Join("\n", prefsToPrint.Select(key => PrintPref(key)).ToArray())}");
+		}
+
 		// Toggle between windowed and fullscreen.
 		// Windowed mode will use the last windowed resolution.
 		// Fullscreen mode will use the detected fullscreen resolution.
@@ -155,22 +166,9 @@ namespace MOD.Scripts.Core
 			PlayerPrefs.SetInt("Screenmanager Is Fullscreen mode", 1);
 		}
 
-		private static string GetPrintablePlayerPrefsInt(string key)
-		{
-			if(PlayerPrefs.HasKey(key))
-			{
-				return $"{key}: {PlayerPrefs.GetInt(key)}";
-			}
-			else
-			{
-				return $"{key}: <MISSING>";
-			}
-		}
-
 		public static void GameSystemInitSetResolution()
 		{
-			// Print out certain playerprefs values for debugging
-			Debug.Log($"PlayerPrefs:\n{string.Join("\n", prefsToPrint.Select(key => GetPrintablePlayerPrefsInt(key)).ToArray())}");
+			PrintPlayerPrefs("On Startup");
 
 			// Restore IsFullscreen variable from playerprefs
 			IsFullscreen = PlayerPrefs.GetInt("is_fullscreen", 1) == 1;
@@ -188,6 +186,8 @@ namespace MOD.Scripts.Core
 			// This prevents us from repairing the playerprefs, because the game normally only saves when the game exits cleanly
 			// To fix this, save the playerprefs immediately as soon as the game starts up
 			PlayerPrefs.Save();
+
+			PrintPlayerPrefs("After Init Resolution");
 		}
 
 		public static void GetFullScreenResolutionLateUpdate()
@@ -216,6 +216,8 @@ namespace MOD.Scripts.Core
 				int height = PlayerPrefs.GetInt("height");
 				SetPlayerPrefs(width, height);
 			}
+
+			PrintPlayerPrefs("On Shutdown");
 		}
 
 		private static Resolution GetFullscreenResolution()

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -116,6 +116,7 @@ You can try the following yourself to fix the issue.
 		{
 			defaultToolTipTimer.Update();
 			startupWatchdogTimer.Update();
+			windowSetupMenu.Update();
 		}
 
 		public void LateUpdate()

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -17,6 +17,7 @@ namespace MOD.Scripts.UI
 	{
 		Normal,
 		AudioSetup,
+		WindowSetup,
 	}
 
 	public class MODMenu
@@ -67,6 +68,7 @@ namespace MOD.Scripts.UI
 		private MODMenuNormal normalMenu;
 		private MODMenuAudioOptions audioOptionsMenu;
 		private MODMenuAudioSetup audioSetupMenu;
+		private MODSubMenuWindowSetup windowSetupMenu;
 
 		private SubMenuManager subMenuManager;
 
@@ -103,6 +105,7 @@ You can try the following yourself to fix the issue.
 			this.audioOptionsMenu = new MODMenuAudioOptions(this);
 			this.normalMenu = new MODMenuNormal(this, this.audioOptionsMenu);
 			this.audioSetupMenu = new MODMenuAudioSetup(this, this.audioOptionsMenu);
+			this.windowSetupMenu = new MODSubMenuWindowSetup(this, this.normalMenu);
 
 			subMenuManager = new SubMenuManager(this.normalMenu);
 
@@ -372,8 +375,8 @@ You can try the following yourself to fix the issue.
 					subMenuToPush = audioSetupMenu;
 					break;
 
-				case ModSubMenu.ResolutionSetup:
-					subMenuToPush = resolutionSetupMenu;
+				case ModSubMenu.WindowSetup:
+					subMenuToPush = windowSetupMenu;
 					break;
 
 				case ModSubMenu.Normal:

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -360,21 +360,33 @@ You can try the following yourself to fix the issue.
 
 		// Switch to the given submenu, without discarding any previous submenus.
 		// If the sub-menus have any state, it will be retained during switching, and even if the menu is closed and reopened.
-		public void PushSubMenu(ModSubMenu subMenu)
+		public void PushSubMenuAndShow(ModSubMenu subMenu)
 		{
 			onBeforeMenuVisibleAlreadyCalled = false;
+
+			MODMenuModuleInterface subMenuToPush = normalMenu;
 
 			switch (subMenu)
 			{
 				case ModSubMenu.AudioSetup:
-					subMenuManager.Push(audioSetupMenu);
+					subMenuToPush = audioSetupMenu;
+					break;
+
+				case ModSubMenu.ResolutionSetup:
+					subMenuToPush = resolutionSetupMenu;
 					break;
 
 				case ModSubMenu.Normal:
-				default:
-					subMenuManager.Push(normalMenu);
+					subMenuToPush = normalMenu;
 					break;
+
+				default:
+					return;
 			}
+
+			subMenuManager.Push(subMenuToPush);
+
+			Show();
 		}
 
 		// Switch to the next submenu on the stack. If only the default submenu remains, just hide the entire menu.

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -33,8 +33,7 @@ namespace MOD.Scripts.UI
 
 			if (GetGlobal("GAudioSet") != 0 && Button(new GUIContent("Click here when you're finished.")))
 			{
-				modMenu.SetSubMenu(ModSubMenu.Normal);
-				modMenu.ForceHide();
+				modMenu.PopSubMenu();
 			}
 		}
 

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -38,7 +38,7 @@ namespace MOD.Scripts.UI
 		}
 
 		public bool UserCanClose() => false;
-		public string Heading() => "First-Time Setup Menu";
+		public string Heading() => "Audio Setup Menu";
 		public string DefaultTooltip() => "Please choose the options on the left before continuing. You can hover over a button to view its description.";
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Scripts.Core;
+using MOD.Scripts.Core;
 using MOD.Scripts.Core.Audio;
 using System;
 using System.Collections.Generic;
@@ -31,6 +32,7 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioStretchBackgrounds;
 		private readonly MODRadio radioTextWindowModeAndCrop;
 		private readonly MODRadio radioForceComputedLipsync;
+		private readonly MODRadio radioFullscreenLock;
 
 		private readonly MODTabControl tabControl;
 
@@ -134,6 +136,11 @@ Sets the script censorship level
 			radioForceComputedLipsync = new MODRadio("Force Computed Lipsync", new GUIContent[] {
 				new GUIContent("As Fallback", "Only use computed lipsync if there is no baked 'spectrum' file for a given .ogg file"),
 				new GUIContent("Computed Always", "Always use computed lipsync for all voices. Any 'spectrum' files will be ignored.")
+			});
+
+			radioFullscreenLock = new MODRadio("Fullscreen Lock", new GUIContent[] {
+				new GUIContent("No Lock", "Allow switching to Windowed mode at any time"),
+				new GUIContent("Force Fullscreen Always", "Force fullscreen mode always - do not allow switching to windowed mode.")
 			});
 
 			tabControl = new MODTabControl(new List<MODTabControl.TabProperties>
@@ -282,6 +289,8 @@ Sets the script censorship level
 			HeadingLabel("Resolution");
 
 			resolutionMenu.OnGUI();
+
+			OnGUIFullscreenLock();
 		}
 
 		private void GameplayTabOnGUI()
@@ -482,6 +491,23 @@ Sets the script censorship level
 			if(this.radioForceComputedLipsync.OnGUIFragment(GameSystem.Instance.SceneController.MODGetForceComputedLipsync()) is bool newForceComputedLipsync)
 			{
 				GameSystem.Instance.SceneController.MODSetForceComputedLipsync(newForceComputedLipsync);
+			}
+		}
+
+		public void OnGUIFullscreenLock()
+		{
+			HeadingLabel("Fullscreen Lock");
+
+			int currentValue = -1;
+			if(MODWindowManager.FullscreenLockConfigured())
+			{
+				currentValue = MODWindowManager.FullscreenLocked() ? 1 : 0;
+			}
+
+			if (this.radioFullscreenLock.OnGUIFragment(currentValue) is int newFullscreenlock)
+			{
+				MODWindowManager.SetFullScreenLock(newFullscreenlock == 0 ? false : true);
+				MODToaster.Show(MODWindowManager.FullscreenLocked() ? "Fullscreen lock enabled" : "Fullscreen lock disabled");
 			}
 		}
 

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -24,7 +24,7 @@ namespace MOD.Scripts.UI
 
 		public void OnGUI()
 		{
-			Label("Resolution Settings");
+			Label($"Resolution Settings (Current: {Screen.width}x{Screen.height})");
 			{
 				GUILayout.BeginHorizontal();
 				if (Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }
@@ -51,6 +51,16 @@ namespace MOD.Scripts.UI
 					}
 				}
 				GUILayout.EndHorizontal();
+
+				if (Button(new GUIContent(
+					"Reset Fullscreen Resolution",
+					"Force re-detection of the fullscreen resolution (matching your monitor's max resolution).\n\n" +
+					"You may want to do this if you change to a monitor with a different fullscreen resolution, and the game detects the wrong resolution.")
+					))
+				{
+					MODWindowManager.ClearPlayerPrefsFullscreenResolution();
+					MODWindowManager.GoFullscreen();
+				}
 			}
 		}
 

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -38,7 +38,7 @@ namespace MOD.Scripts.UI
 
 				if(Button(buttonContent))
 				{
-					MODWindowManager.FullscreenToggleMODMenu();
+					MODWindowManager.FullscreenToggle();
 				}
 
 				screenHeightString = GUILayout.TextField(screenHeightString);
@@ -57,7 +57,7 @@ namespace MOD.Scripts.UI
 		private void SetAndSaveResolution(int height)
         {
 			screenHeightString = $"{height}";
-			MODWindowManager.MODMenuSetAndSaveResolution(height);
+			MODWindowManager.SetWindowed(height);
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -55,9 +55,9 @@ namespace MOD.Scripts.UI
 		}
 
 		private void SetAndSaveResolution(int height)
-        {
+		{
 			screenHeightString = $"{height}";
-			MODWindowManager.SetWindowed(height);
+			MODWindowManager.SetResolution(height);
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -38,7 +38,7 @@ namespace MOD.Scripts.UI
 
 				if(Button(buttonContent))
 				{
-					MODWindowManager.FullscreenToggle();
+					MODWindowManager.FullscreenToggle(showToast: true);
 				}
 
 				screenHeightString = GUILayout.TextField(screenHeightString);
@@ -57,7 +57,7 @@ namespace MOD.Scripts.UI
 		private void SetAndSaveResolution(int height)
 		{
 			screenHeightString = $"{height}";
-			MODWindowManager.SetResolution(height);
+			MODWindowManager.SetResolution(height, showToast: true);
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -25,6 +25,15 @@ namespace MOD.Scripts.UI
 		public void OnGUI()
 		{
 			Label($"Resolution Settings (Current: {Screen.width}x{Screen.height})");
+
+			// I noticed a bug on Linux where going Windowed sometimes doesn't let you change window size,
+			// probably due res settings Playerprefs that Unity reads on startup.
+			// Restarting the game after changing settings fixes this.
+			if(Application.platform == RuntimePlatform.LinuxPlayer)
+			{
+				Label($"NOTE: You may need to restart the game after changing to Windowed!");
+			}
+
 			{
 				GUILayout.BeginHorizontal();
 				if (Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Scripts.Core;
+using MOD.Scripts.Core;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -30,19 +31,14 @@ namespace MOD.Scripts.UI
 				if (Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
 				if (Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
 				if (Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
-				if (GameSystem.Instance.IsFullscreen)
+
+				GUIContent buttonContent = MODWindowManager.IsFullscreen ?
+					new GUIContent("Go Windowed", "Toggle Fullscreen") :
+					new GUIContent("Go Fullscreen", "Toggle Fullscreen");
+
+				if(Button(buttonContent))
 				{
-					if (Button(new GUIContent("Windowed", "Toggle Fullscreen")))
-					{
-						GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
-					}
-				}
-				else
-				{
-					if (Button(new GUIContent("Fullscreen", "Toggle Fullscreen")))
-					{
-						GameSystem.Instance.GoFullscreen();
-					}
+					MODWindowManager.FullscreenToggleMODMenu();
 				}
 
 				screenHeightString = GUILayout.TextField(screenHeightString);
@@ -51,21 +47,7 @@ namespace MOD.Scripts.UI
 				{
 					if (int.TryParse(screenHeightString, out int new_height))
 					{
-						if (new_height < 480)
-						{
-							MODToaster.Show("Height too small - must be at least 480 pixels");
-							new_height = 480;
-						}
-						else if (new_height > 15360)
-						{
-							MODToaster.Show("Height too big - must be less than 15360 pixels");
-							new_height = 15360;
-						}
-						screenHeightString = $"{new_height}";
-						int new_width = Mathf.RoundToInt(new_height * 16f / 9f);
-						Screen.SetResolution(new_width, new_height, Screen.fullScreen);
-						PlayerPrefs.SetInt("width", new_width);
-						PlayerPrefs.SetInt("height", new_height);
+						SetAndSaveResolution(new_height);
 					}
 				}
 				GUILayout.EndHorizontal();
@@ -73,22 +55,9 @@ namespace MOD.Scripts.UI
 		}
 
 		private void SetAndSaveResolution(int height)
-		{
-			if (height < 480)
-			{
-				MODToaster.Show("Height too small - must be at least 480 pixels");
-				height = 480;
-			}
-			else if (height > 15360)
-			{
-				MODToaster.Show("Height too big - must be less than 15360 pixels");
-				height = 15360;
-			}
+        {
 			screenHeightString = $"{height}";
-			int width = Mathf.RoundToInt(height * 16f / 9f);
-			Screen.SetResolution(width, height, Screen.fullScreen);
-			PlayerPrefs.SetInt("width", width);
-			PlayerPrefs.SetInt("height", height);
+			MODWindowManager.MODMenuSetAndSaveResolution(height);
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuSupport.cs
+++ b/MOD.Scripts.UI/MODMenuSupport.cs
@@ -99,6 +99,31 @@ namespace MOD.Scripts.UI
 				}
 
 				GUILayout.EndHorizontal();
+
+				if(Application.platform == RuntimePlatform.WindowsPlayer)
+				{
+					string playerPrefsPath = $"Computer\\HKEY_CURRENT_USER\\SOFTWARE\\{Application.companyName}\\{Application.productName}";
+					if (buttonRenderer(new GUIContent(
+							"Copy PlayerPrefs Registry Path",
+							$"Click to copy the playerprefs registry folder to clipboard. This registry folder mainly contains Unity resolution settings.\n\n" +
+							$"Paste the path into the Windows Registry Editor (regedit) to view playerprefs.\n\n" +
+							$"Registry Path: {playerPrefsPath}"
+						)))
+					{
+						GUIUtility.systemCopyBuffer = playerPrefsPath;
+					}
+				}
+				else
+				{
+					string playerPrefsPath = Application.platform == RuntimePlatform.LinuxPlayer ?
+							$"~/.config/unity3d/{Application.companyName}/{Application.productName}" :
+							"~/Library/Preferences";
+
+					if (buttonRenderer(new GUIContent("Show PlayerPrefs Folder", $"Click to show the folder containing the playerprefs config file. This config file mainly contains Unity resolution settings.\n\nPath: {playerPrefsPath}")))
+					{
+						MODActions.ShowFile(playerPrefsPath);
+					}
+				}
 			}
 
 			MODMenuCommon.Label("Support Pages");

--- a/MOD.Scripts.UI/MODSubMenuWindowSetup.cs
+++ b/MOD.Scripts.UI/MODSubMenuWindowSetup.cs
@@ -50,13 +50,21 @@ namespace MOD.Scripts.UI
 
 			GUILayout.Space(20);
 
-			if(Button(
-				new GUIContent(
-					"Click here to test Windowed Mode (may flicker)",
-					"This button will switch the game to Windowed mode.\n\n" +
-					"Please try moving the window around to see if the game crashes\n\n" +
-					"If the game freezes, you may need to force close it and open the game again."
-				)))
+			Label("NOTE: This may crash your entire desktop environment! Please save your work before this test!");
+
+			GUILayout.Space(20);
+
+			if (
+				Button(
+					new GUIContent(
+						MODWindowManager.IsFullscreen ? "Click here to test Windowed Mode (may flicker)" : "Now try dragging the window around!",
+						"This button will switch the game to Windowed mode.\n\n" +
+						"Please try moving the window around to see if the game crashes\n\n" +
+						"If the game freezes, you may need to force close it and open the game again."
+					),
+					selected: !MODWindowManager.IsFullscreen
+				)
+			)
 			{
 				MODWindowManager.SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: false, showToast: true);
 				setWindowAgainDelay.Start(1);
@@ -64,7 +72,11 @@ namespace MOD.Scripts.UI
 
 			GUILayout.Space(20);
 
-			Label("If your game crashed in windowed mode, choose 'Force Fullscreen Always'. Otherwise choose 'No Lock'");
+			Label("If your game crashed in windowed mode, choose 'Force Fullscreen Always' to avoid future crashes.");
+
+			GUILayout.Space(20);
+
+			Label("If your game runs fine even when the window is dragged, choose 'No Lock' to run the game normally.");
 
 			GUILayout.Space(20);
 

--- a/MOD.Scripts.UI/MODSubMenuWindowSetup.cs
+++ b/MOD.Scripts.UI/MODSubMenuWindowSetup.cs
@@ -1,0 +1,75 @@
+﻿using MOD.Scripts.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using static MOD.Scripts.UI.MODMenuCommon;
+
+namespace MOD.Scripts.UI
+{
+	class MODSubMenuWindowSetup : MODMenuModuleInterface
+	{
+		MODMenu modMenu;
+		MODMenuNormal normalMenu;
+
+		public MODSubMenuWindowSetup(MODMenu modMenu, MODMenuNormal normalMenu)
+		{
+			this.modMenu = modMenu;
+			this.normalMenu = normalMenu;
+		}
+
+		public void OnBeforeMenuVisible()
+		{
+
+		}
+
+		public void OnGUI()
+		{
+			HeadingLabel("Linux Resolution/Windowed Mode Setup");
+
+			GUILayout.Space(20);
+
+			Label("Some Native Linux users experience crashes or softlocks when entering windowed mode, or when moving the window around (the 'Gnome Crash Bug').\n\n" +
+				"Please click the button below to enter windowed mode, then drag the window around.");
+
+			GUILayout.Space(20);
+
+			if(Button(
+				new GUIContent(
+					"Click here to test Windowed Mode",
+					"This button will switch the game to Windowed mode.\n\n" +
+					"Please try moving the window around to see if the game crashes\n\n" +
+					"If the game freezes, you may need to force close it and open the game again."
+				)))
+			{
+				MODWindowManager.SetResolution(maybe_width: null, maybe_height: null, maybe_fullscreen: false, showToast: true);
+			}
+
+			GUILayout.Space(20);
+
+			Label("If your game crashed in windowed mode, choose 'Force Fullscreen Always'. Otherwise choose 'No Lock'");
+
+			GUILayout.Space(20);
+
+			normalMenu.OnGUIFullscreenLock();
+
+			GUILayout.Space(20);
+
+			if (MODWindowManager.FullscreenLockConfigured())
+			{
+				if(Button(new GUIContent("Click here when you're finished.")))
+				{
+					modMenu.PopSubMenu();
+				}
+			}
+			else
+			{
+				Label("You must choose an option to continue.");
+			}
+		}
+
+		public bool UserCanClose() => false;
+		public string Heading() => "Linux Resolution/Windowed Mode Setup Menu";
+		public string DefaultTooltip() => "Please choose the options on the left before continuing. You can hover over a button to view its description.";
+	}
+}


### PR DESCRIPTION
This option adds a workaround for the "Linux Gnome Windowed Mode Crash" bug

----

For info on the Linux Gnome Windowed Mode Crash bug, see: 
 - https://github.com/07th-mod/higurashi-assembly/issues/97

This PR does not fix crashing when entering Windowed mode, but makes sure that you can't get the game stuck in a state where it won't launch anymore due to being in Windowed mode (it should recover and enter fullscreen mode). The main things this PR does is:

- Add a "full screen lock" option which prevents you accidnetally entering full screen mode., plus a setup menu to tell the user to configure it on Linux
- On Linux, if the game crashes, will revert to fullscreen mode, and will re-display the "full screen lock" setup menu
    - Note that I can't detect crashes that well, so force closing the app is equivalent to a crash  
- Force the playerprefs "Screenmanager Is Fullscreen mode" to always be 1 (fullscreen) instead of 0 (windowed). We used to always force the value to 0.
- Change how/when the playerprefs is saved
- Refactor stuff internally so that the screen resolution and windowed/fullscreen mode boils down to exactly one function, rather being called differently from lots of different places

I've primarily tested on Windows and Manjaro Linux (The system which a user had reported these issues), but I should probably re-test Ubuntu to see if I have broken anything. Some of the changes I made are locked to Linux, to avoid changing working behavior on Windows, but the refactoring and stuff is across all OS's, so that could break things.

