### PR TITLE
"Currently playing BGM" feature

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -224,6 +224,7 @@
     <Compile Include="LTRect.cs" />
     <Compile Include="LTSpline.cs" />
     <Compile Include="MenuUIController.cs" />
+    <Compile Include="MOD.Scripts.Core.Audio\MODBGMInfo.cs" />
     <Compile Include="MOD.Scripts.Core.Config\MODConfig.cs" />
     <Compile Include="MOD.Scripts.Core.Config\MODConfigManager.cs" />
     <Compile Include="MOD.Scripts.Core.Movie\AVProMovieRenderer.cs" />

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -74,7 +74,6 @@ namespace Assets.Scripts.Core.AssetManagement
 
 		public static AssetManager Instance => _instance ?? (_instance = GameSystem.Instance.AssetManager);
 
-		public string lastBGM { get; private set; } = "No BGM played yet";
 		public string debugLastBGM { get; private set; } = "No BGM played yet";
 		public string debugLastSE { get; private set; } = "No SE played yet";
 		public string debugLastVoice { get; private set; } = "No voice played yet";
@@ -561,7 +560,6 @@ namespace Assets.Scripts.Core.AssetManagement
 			switch (type)
 			{
 				case Audio.AudioType.BGM:
-					lastBGM = relativePath;
 					debugLastBGM = debugRelativePath;
 					break;
 				case Audio.AudioType.SE:

--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -74,6 +74,7 @@ namespace Assets.Scripts.Core.AssetManagement
 
 		public static AssetManager Instance => _instance ?? (_instance = GameSystem.Instance.AssetManager);
 
+		public string lastBGM { get; private set; } = "No BGM played yet";
 		public string debugLastBGM { get; private set; } = "No BGM played yet";
 		public string debugLastSE { get; private set; } = "No SE played yet";
 		public string debugLastVoice { get; private set; } = "No voice played yet";
@@ -560,6 +561,7 @@ namespace Assets.Scripts.Core.AssetManagement
 			switch (type)
 			{
 				case Audio.AudioType.BGM:
+					lastBGM = relativePath;
 					debugLastBGM = debugRelativePath;
 					break;
 				case Audio.AudioType.SE:

--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -575,5 +575,10 @@ namespace Assets.Scripts.Core.Audio
 				});
 			}
 		}
+
+		public Dictionary<int, AudioInfo> GetCurrrentBGM()
+		{
+			return currentAudio[AudioType.BGM];
+		}
 	}
 }

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -2737,7 +2737,14 @@ namespace Assets.Scripts.Core.Buriko
 		public BurikoVariable OperationMODAddBGMset()
 		{
 			SetOperationType("MODAddBGMset");
-			MODAudioSet.Instance.AddBGMSet(ReadPathCascadeFromArgs());
+			PathCascadeList cascadeList = ReadPathCascadeFromArgs();
+
+			MODAudioSet.Instance.AddBGMSet(cascadeList);
+			foreach (string path in cascadeList.paths)
+			{
+				MODBGMInfo.LoadFromJSON(path);
+			}
+
 			return BurikoVariable.Null;
 		}
 

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -140,6 +140,7 @@ namespace Assets.Scripts.Core
 		public readonly List<Wait> WaitList = new List<Wait>();
 
 		private MenuUIController menuUIController;
+		public MenuUIController MenuUIController() => menuUIController;
 
 		private HistoryWindow historyWindow;
 

--- a/MOD.Scripts.Core.Audio/MODBGMInfo.cs
+++ b/MOD.Scripts.Core.Audio/MODBGMInfo.cs
@@ -20,14 +20,14 @@ namespace MOD.Scripts.Core
 		public string source;
 		public string url;
 
-        public BGMInfo()
-        {
+		public BGMInfo()
+		{
 			comment = "";
 			name = "";
 			source = "";
 			url = "";
-        }
-    }
+		}
+	}
 
 	public class BGMInfoDict
 	{

--- a/MOD.Scripts.Core.Audio/MODBGMInfo.cs
+++ b/MOD.Scripts.Core.Audio/MODBGMInfo.cs
@@ -1,0 +1,106 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using MOD.Scripts.UI;
+using Assets.Scripts.Core;
+
+namespace MOD.Scripts.Core
+{
+	public class BGMInfo
+	{
+		/// <summary>
+		/// A comment to store misc info about the BGM (any errata, or changes made to the BGM)
+		/// </summary>
+		public string comment;
+		/// <summary>
+		/// The English name of the song
+		/// </summary>
+		public string name;
+		/// <summary>
+		/// The Japanese name of the song (not sure if the game can display this?)
+		/// </summary>
+		public string nameJP;
+	}
+
+	public class BGMInfoDict
+	{
+		public Dictionary<string, BGMInfo> bgmList;
+
+		public BGMInfoDict()
+		{
+			bgmList = new Dictionary<string, BGMInfo>();
+		}
+	}
+
+	public class MODBGMInfo
+	{
+		/// <summary>
+		/// Dictionary of (filepath without extension relative to streamingassets) -> BGMInfo
+		/// </summary>
+		private static Dictionary<string, BGMInfo> bgmDictionary;
+		private static Dictionary<string, bool> loadedFolders;
+
+		static MODBGMInfo()
+		{
+			bgmDictionary = new Dictionary<string, BGMInfo>();
+			loadedFolders = new Dictionary<string, bool>();
+		}
+
+		public static string GetBGMName(string streamingAssetsRelativePath)
+		{
+			string pathWithoutExtension = Path.Combine(Path.GetDirectoryName(streamingAssetsRelativePath), Path.GetFileNameWithoutExtension(streamingAssetsRelativePath));
+			if(bgmDictionary.TryGetValue(pathWithoutExtension, out BGMInfo info))
+			{
+				return GameSystem.Instance.ChooseJapaneseEnglish(info.nameJP, info.name);
+			}
+			else
+			{
+				return GameSystem.Instance.ChooseJapaneseEnglish("不明 BGM", "Unknown BGM");
+			}
+		}
+
+		// Load the bgm information from the bgmInfo.json in a given BGM Folder (located in the StreamingAssets folder)
+		public static void LoadFromJSON(string BGMFolder)
+		{
+			// Skip already loaded folders
+			if(loadedFolders.ContainsKey(BGMFolder))
+			{
+				return;
+			}
+			loadedFolders[BGMFolder] = true;
+
+			string path = Path.Combine(Application.streamingAssetsPath, Path.Combine(BGMFolder, "bgmInfo.json"));
+
+			if (!File.Exists(path))
+			{
+				Debug.Log($"MODBGMInfo(): No bgmInfo.json at [{path}] - BGM will just show as filenames");
+				return;
+			}
+
+			try
+			{
+				using (var reader = new JsonTextReader(new StreamReader(path)))
+				{
+					BGMInfoDict bgmInfoDict = JsonSerializer.Create(new JsonSerializerSettings()).Deserialize<BGMInfoDict>(reader);
+					foreach(KeyValuePair<string, BGMInfo> kvp in bgmInfoDict.bgmList)
+					{
+						// Allow missing comment in JSON
+						if(kvp.Value.comment == null)
+						{
+							kvp.Value.comment = "";
+						}
+
+						string relativePathWithoutExtension = Path.Combine(BGMFolder, kvp.Key);
+						bgmDictionary[relativePathWithoutExtension] = kvp.Value;
+					}
+				}
+			}
+			catch (System.Exception e)
+			{
+				Debug.LogError($"MODBGMInfo(): Failed to read bgm info file at [{path}]: {e.Message}");
+				MODToaster.Show("bgmInfo.json fail - check logs");
+			}
+		}
+	}
+}

--- a/MOD.Scripts.Core.Audio/MODBGMInfo.cs
+++ b/MOD.Scripts.Core.Audio/MODBGMInfo.cs
@@ -14,13 +14,11 @@ namespace MOD.Scripts.Core
 		/// </summary>
 		public string comment;
 		/// <summary>
-		/// The English name of the song
+		/// The English/Japanese name of the song
 		/// </summary>
 		public string name;
-		/// <summary>
-		/// The Japanese name of the song (not sure if the game can display this?)
-		/// </summary>
-		public string nameJP;
+		public string source;
+		public string url;
 	}
 
 	public class BGMInfoDict
@@ -52,7 +50,7 @@ namespace MOD.Scripts.Core
 			string pathWithoutExtension = Path.Combine(Path.GetDirectoryName(streamingAssetsRelativePath), Path.GetFileNameWithoutExtension(streamingAssetsRelativePath));
 			if(bgmDictionary.TryGetValue(pathWithoutExtension, out BGMInfo info))
 			{
-				return GameSystem.Instance.ChooseJapaneseEnglish(info.nameJP, info.name);
+				return info.name;
 			}
 			else
 			{

--- a/MOD.Scripts.Core.Audio/MODBGMInfo.cs
+++ b/MOD.Scripts.Core.Audio/MODBGMInfo.cs
@@ -19,7 +19,15 @@ namespace MOD.Scripts.Core
 		public string name;
 		public string source;
 		public string url;
-	}
+
+        public BGMInfo()
+        {
+			comment = "";
+			name = "";
+			source = "";
+			url = "";
+        }
+    }
 
 	public class BGMInfoDict
 	{
@@ -45,16 +53,18 @@ namespace MOD.Scripts.Core
 			loadedFolders = new Dictionary<string, bool>();
 		}
 
-		public static string GetBGMName(string streamingAssetsRelativePath)
+		public static BGMInfo GetBGMName(string streamingAssetsRelativePath)
 		{
 			string pathWithoutExtension = Path.Combine(Path.GetDirectoryName(streamingAssetsRelativePath), Path.GetFileNameWithoutExtension(streamingAssetsRelativePath));
 			if(bgmDictionary.TryGetValue(pathWithoutExtension, out BGMInfo info))
 			{
-				return info.name;
+				return info;
 			}
 			else
 			{
-				return GameSystem.Instance.ChooseJapaneseEnglish("不明 BGM", "Unknown BGM");
+				var defaultInfo = new BGMInfo();
+				info.name = GameSystem.Instance.ChooseJapaneseEnglish("不明 BGM", "Unknown BGM");
+				return info;
 			}
 		}
 

--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -121,6 +122,29 @@ public static class MODUtility
 		{
 			Debug.Log(e);
 			return "Unknown Version";
+		}
+	}
+
+	/// <summary>
+	/// On Windows, will open a new Explorer window with the file highlighted
+	/// On Other OS, *might* show the folder containing the file, but also might not work
+	/// </summary>
+	public static void ShowInFolder(string pathToshow)
+    {
+		if (Application.platform == RuntimePlatform.WindowsPlayer)
+		{
+			// Explorer doesn't like it if you use forward slashes in path
+			string backslashOnlyPath = pathToshow.Replace("/", "\\");
+			string arguments = $"/select, \"{backslashOnlyPath}\"";
+			string executable = "explorer.exe";
+			Debug.Log($"Executing [{executable} {arguments}]");
+			System.Diagnostics.Process.Start(executable, arguments);
+		}
+		else
+		{
+			string folderToOpen = Path.GetDirectoryName(pathToshow);
+			Debug.Log($"Opening Folder [{folderToOpen}]");
+			Application.OpenURL(folderToOpen);
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -231,10 +231,8 @@ You can try the following yourself to fix the issue.
 			GUILayout.EndArea();
 		}
 
-		private void OnGUIExistingUIFillOverlay(float? alpha, Action onGUIInternal, ButtonPosition position = ButtonPosition.TopLeftColumn)
+		private void OnGUIRightClickMenuOverlay(float? alpha, Action onGUIInternal)
 		{
-			MODStyleManager styleManager = MODStyleManager.OnGUIInstance;
-
 			if (alpha.HasValue)
 			{
 				// Temporarily override the global tint color to get a fade in effect which matches the existing UI fade in
@@ -242,37 +240,19 @@ You can try the following yourself to fix the issue.
 				GUI.color = new Color(1.0f, 1.0f, 1.0f, alpha.Value);
 			}
 
-			float existingUIWidth = Screen.width * 3 / 4;
+			// The width of the overlay should match the right-click menu width
+			float areaWidth = Screen.width * 3 / 4;
 
-			// Figure out the width and height of the area where the overlay will be displayed
-			float areaWidth = Screen.width / 8;
-			if (position == ButtonPosition.BottomEntireUIWidth)
-			{
-				// This will overlay just the existing UI part of the screen
-				areaWidth = existingUIWidth;
-			}
-			else if (position == ButtonPosition.BottomHalfUIWidthBottomPadded)
-			{
-				areaWidth = existingUIWidth / 2;
-			}
-			else if (position == ButtonPosition.UnderSystemMenu)
-			{
-				areaWidth = Screen.width / 4;
-			}
+			// The overlay should start where the right-click menu starts
+			float xOffset = Screen.width / 8;
 
-			// Figure out the position of the overlay's top left hand corner
-			float xOffset = 0;
-			if (position == ButtonPosition.BottomEntireUIWidth || position == ButtonPosition.BottomHalfUIWidthBottomPadded || position == ButtonPosition.UnderSystemMenu)
-			{
-				// This will offset the overlay so it starts at where the existing UI starts
-				xOffset = Screen.width / 8;
-			}
-
+			// Set the y-offset so that the overlay appears under the list of controls
 			float yOffset = Screen.height * 11 / 16;
 
+			// Set the height to fill the rest of the screen, but with a little bit of margin at the bottom so it looks nicer
 			float areaHeight = Screen.height - yOffset - Screen.height / 32;
 
-			GUILayout.BeginArea(new Rect(xOffset, yOffset, areaWidth, areaHeight), styleManager.modMenuAreaStyleLight);
+			GUILayout.BeginArea(new Rect(xOffset, yOffset, areaWidth, areaHeight), MODStyleManager.OnGUIInstance.modMenuAreaStyleLight);
 			bgmInfoScrollPosition = GUILayout.BeginScrollView(bgmInfoScrollPosition);
 
 			onGUIInternal();
@@ -325,7 +305,7 @@ You can try the following yourself to fix the issue.
 
 			if (!visible && gameSystem.GameState == GameState.RightClickMenu)
 			{
-				OnGUIExistingUIFillOverlay(gameSystem.MenuUIController()?.PanelAlpha(), () =>
+				OnGUIRightClickMenuOverlay(gameSystem.MenuUIController()?.PanelAlpha(), () =>
 				{
 					HeadingLabel("BGM Info", alignLeft: true);
 					GUILayout.Space(10);
@@ -383,8 +363,7 @@ You can try the following yourself to fix the issue.
 					{
 						Label("Note: If explorer freezes\nuninstall Web Media Extensions");
 					}
-				},
-				ButtonPosition.BottomEntireUIWidth);
+				});
 			}
 			else
 			{

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -268,7 +268,7 @@ You can try the following yourself to fix the issue.
 				OnGUIExistingUIOverlay("Mod Menu\n(Hotkey: F10)", gameSystem.ConfigManager()?.PanelAlpha(), () => this.Show());
 			}
 
-			if (gameSystem.GameState == GameState.RightClickMenu)
+			if (!visible && gameSystem.GameState == GameState.RightClickMenu)
 			{
 				string lastBGM = AssetManager.Instance.lastBGM;
 				string text = $"BGM Name: {MODBGMInfo.GetBGMName(lastBGM)}\n" +

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -160,16 +160,7 @@ You can try the following yourself to fix the issue.
 			GUI.DragWindow(new Rect(0, 0, 10000, 10000));
 		}
 
-		enum ButtonPosition
-		{
-			TopLeftColumn,
-			BottomLeftColumn,
-			BottomEntireUIWidth,
-			BottomHalfUIWidthBottomPadded,
-			UnderSystemMenu,
-		}
-
-		private void OnGUIExistingUIOverlayButton(string text, float? alpha, Action action, ButtonPosition position = ButtonPosition.TopLeftColumn)
+		private void OnGUIConfigMenuButton(string text, float? alpha, Action action)
 		{
 			MODStyleManager styleManager = MODStyleManager.OnGUIInstance;
 
@@ -180,47 +171,13 @@ You can try the following yourself to fix the issue.
 				GUI.color = new Color(1.0f, 1.0f, 1.0f, alpha.Value);
 			}
 
-			float existingUIWidth = Screen.width * 3 / 4;
-
-			// Figure out the width and height of the area where the overlay will be displayed
+			// Calculate the width and height of the button
 			float areaWidth = Screen.width / 8;
-			if(position == ButtonPosition.BottomEntireUIWidth)
-			{
-				// This will overlay just the existing UI part of the screen
-				areaWidth = existingUIWidth;
-			}
-			else if(position == ButtonPosition.BottomHalfUIWidthBottomPadded)
-			{
-				areaWidth = existingUIWidth / 2;
-			}
-			else if(position == ButtonPosition.UnderSystemMenu)
-			{
-				areaWidth = Screen.width / 4;
-			}
-
 			float areaHeight = Mathf.Round(styleManager.Group.button.CalcHeight(new GUIContent(text, ""), areaWidth)) + 10;
 
 			// Figure out the position of the overlay's top left hand corner
 			float xOffset = 0;
-			if (position == ButtonPosition.BottomEntireUIWidth || position == ButtonPosition.BottomHalfUIWidthBottomPadded || position == ButtonPosition.UnderSystemMenu)
-			{
-				// This will offset the overlay so it starts at where the existing UI starts
-				xOffset = Screen.width / 8;
-			}
-
 			float yOffset = 0;
-			if(position == ButtonPosition.BottomLeftColumn || position == ButtonPosition.BottomEntireUIWidth)
-			{
-				yOffset = Screen.height - areaHeight;
-			}
-			else if(position == ButtonPosition.UnderSystemMenu)
-			{
-				yOffset = Screen.height / 16 + Screen.height / 32;
-			}
-			else if(position == ButtonPosition.BottomHalfUIWidthBottomPadded)
-			{
-				yOffset = Screen.height * 11 / 16;
-			}
 
 			GUILayout.BeginArea(new Rect(xOffset, yOffset, areaWidth, areaHeight), styleManager.modMenuAreaStyle);
 			if (GUILayout.Button(text, styleManager.Group.button))
@@ -300,7 +257,7 @@ You can try the following yourself to fix the issue.
 			// (the normal settings screen that comes with the stock game)
 			if (gameSystem.GameState == GameState.ConfigScreen)
 			{
-				OnGUIExistingUIOverlayButton("Mod Menu\n(Hotkey: F10)", gameSystem.ConfigManager()?.PanelAlpha(), () => this.Show());
+				OnGUIConfigMenuButton("Mod Menu\n(Hotkey: F10)", gameSystem.ConfigManager()?.PanelAlpha(), () => this.Show());
 			}
 
 			if (!visible && gameSystem.GameState == GameState.RightClickMenu)

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -2,6 +2,7 @@
 using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
+using MOD.Scripts.Core;
 using MOD.Scripts.Core.Audio;
 using MOD.Scripts.Core.State;
 using System;
@@ -224,7 +225,7 @@ You can try the following yourself to fix the issue.
 			if (gameSystem.GameState == GameState.RightClickMenu)
 			{
 				string lastBGM = AssetManager.Instance.lastBGM;
-				string text = $"BGM: {lastBGM}";
+				string text = $"BGM: {MODBGMInfo.GetBGMName(lastBGM)}\nFile: {lastBGM}";
 
 				// On Windows, add note about explorer .ogg file bug
 				if(lastBGMButtonPressed && Application.platform == RuntimePlatform.WindowsPlayer)

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -60,7 +60,7 @@ You can try the following yourself to fix the issue.
 
   5. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.";
 
-		bool lastBGMButtonPressed;
+		bool showBGMButtonPressed;
 		Vector2 bgmInfoScrollPosition;
 
 		public MODMenu(GameSystem gameSystem)
@@ -83,7 +83,7 @@ You can try the following yourself to fix the issue.
 
 			this.debugWindowRect = new Rect(0, 0, Screen.width / 3, Screen.height - 50);
 
-			this.lastBGMButtonPressed = false;
+			this.showBGMButtonPressed = false;
 			this.bgmInfoScrollPosition = new Vector2();
 		}
 
@@ -325,9 +325,6 @@ You can try the following yourself to fix the issue.
 
 			if (!visible && gameSystem.GameState == GameState.RightClickMenu)
 			{
-				string lastBGM = AssetManager.Instance.lastBGM;
-
-
 				OnGUIExistingUIFillOverlay(gameSystem.MenuUIController()?.PanelAlpha(), () =>
 				{
 					HeadingLabel("BGM Info", alignLeft: true);
@@ -353,15 +350,16 @@ You can try the following yourself to fix the issue.
 						// Below the BGM name, add utility buttons, all one one line
 						GUILayout.BeginHorizontal(GUILayout.ExpandWidth(false));
 						{
-							if (Button($"Copy BGM Name", options: GUILayout.ExpandWidth(false)))
+							if (Button($"  Copy BGM Name  ", options: GUILayout.ExpandWidth(false)))
 							{
 								GUIUtility.systemCopyBuffer = bgmInfo.name.Trim();
 							}
 
-							if (Button($"Show File ({audioPath})", options: GUILayout.ExpandWidth(false)))
+							if (Button($"  Show File ({audioPath})  ", options: GUILayout.ExpandWidth(false)))
 							{
-								lastBGMButtonPressed = true;
-								Application.OpenURL(Path.GetDirectoryName(Path.Combine(Application.streamingAssetsPath, lastBGM)));
+								string bgmFullPath = Path.Combine(Application.streamingAssetsPath, audioPath);
+								showBGMButtonPressed = true;
+								MODUtility.ShowInFolder(bgmFullPath);
 							}
 
 							if (!string.IsNullOrEmpty(bgmInfo.url))
@@ -381,7 +379,7 @@ You can try the following yourself to fix the issue.
 					}
 
 					// On Windows, add note about explorer .ogg file bug
-					if (lastBGMButtonPressed && Application.platform == RuntimePlatform.WindowsPlayer)
+					if (showBGMButtonPressed && Application.platform == RuntimePlatform.WindowsPlayer)
 					{
 						Label("Note: If explorer freezes\nuninstall Web Media Extensions");
 					}
@@ -390,7 +388,7 @@ You can try the following yourself to fix the issue.
 			}
 			else
 			{
-				lastBGMButtonPressed = false;
+				showBGMButtonPressed = false;
 			}
 
 			// If you need to initialize things just once before the menu opens, rather than every frame

--- a/MOD.Scripts.UI/MODMenuCommon.cs
+++ b/MOD.Scripts.UI/MODMenuCommon.cs
@@ -9,24 +9,40 @@ namespace MOD.Scripts.UI
 	static class MODMenuCommon
 	{
 		public static bool anyButtonPressed;
-		public static void Label(string label)
+		public static void Label(string label, params GUILayoutOption[] options)
 		{
-			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.label);
+			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.label, options);
 		}
 
-		public static void Label(GUIContent content)
+		public static void Label(GUIContent content, params GUILayoutOption[] options)
 		{
-			GUILayout.Label(content, MODStyleManager.OnGUIInstance.Group.label);
+			GUILayout.Label(content, MODStyleManager.OnGUIInstance.Group.label, options);
 		}
 
-		public static void HeadingLabel(string label)
+		public static void SelectableLabel(string label, params GUILayoutOption[] options)
 		{
-			GUILayout.Label(label, MODStyleManager.OnGUIInstance.Group.headingLabel);
+			GUILayout.TextArea(label, MODStyleManager.OnGUIInstance.Group.label, options);
 		}
 
-		public static bool Button(GUIContent guiContent, bool selected = false)
+		public static void HeadingLabel(string label, bool alignLeft = false, params GUILayoutOption[] options)
 		{
-			if(GUILayout.Button(guiContent, selected ? MODStyleManager.OnGUIInstance.Group.selectedButton : MODStyleManager.OnGUIInstance.Group.button))
+			GUILayout.Label(label, alignLeft ? MODStyleManager.OnGUIInstance.Group.upperLeftHeadingLabel : MODStyleManager.OnGUIInstance.Group.headingLabel, options);
+		}
+
+		public static bool Button(string label, bool selected = false, bool stlyeAsLabel = false, params GUILayoutOption[] options)
+		{
+			return Button(new GUIContent(label), selected, stlyeAsLabel, options);
+		}
+
+		public static bool Button(GUIContent guiContent, bool selected = false, bool stlyeAsLabel = false, params GUILayoutOption[] options)
+		{
+			GUIStyle style = selected ? MODStyleManager.OnGUIInstance.Group.selectedButton : MODStyleManager.OnGUIInstance.Group.button;
+			if(stlyeAsLabel)
+			{
+				style = MODStyleManager.OnGUIInstance.Group.label;
+			}
+
+			if (GUILayout.Button(guiContent, style, options))
 			{
 				anyButtonPressed = true;
 				return true;

--- a/MenuUIController.cs
+++ b/MenuUIController.cs
@@ -12,6 +12,7 @@ public class MenuUIController : MonoBehaviour
 	private float time = 0.5f;
 
 	private bool isClosing;
+	public float PanelAlpha() => Panel.alpha;
 
 	private IEnumerator LeaveMenuAnimation(MenuCloseDelegate onClose, bool showMessage)
 	{


### PR DESCRIPTION
This PR adds a feature which displays the name and filename of the currently playing BGM

----

For info on the BGM feature which was added, see: 
- https://github.com/07th-mod/higurashi-assembly/issues/90

I'm working on getting a mapping of BGM filename -> BGM names, not just for this feature, but so we can keep track of what BGM is what across our different BGM options.

Some other things which are relevant to this PR:

- https://github.com/07th-mod/higurashi-assembly/pull/1
- https://github.com/07th-mod/watanagashi/issues/87
- https://github.com/07th-mod/higurashi-assembly/issues/78
