### PR TITLE
Fix Unity killing window managers with insane window sizes

### DIFF
--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -242,7 +242,7 @@ namespace Assets.Scripts.Core
 			IGameState obj = curStateObj;
 			inputHandler = obj.InputHandler;
 			MessageBoxVisible = false;
-			hasBrokenWindowResize = MODUtility.HasBrokenWindowResize();
+			hasBrokenWindowResize = MODUtility.HasBrokenWindowResize() && MODUtility.PatchWindowResizeFunction();
 			if (!PlayerPrefs.HasKey("width"))
 			{
 				PlayerPrefs.SetInt("width", 1280);

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -186,6 +186,8 @@ namespace Assets.Scripts.Core
 			private set => _isFullscreen = value;
 		}
 
+		private bool hasBrokenWindowResize;
+
 		private float _configMenuFontSize = 0;
 		public float ConfigMenuFontSize
 		{
@@ -240,6 +242,7 @@ namespace Assets.Scripts.Core
 			IGameState obj = curStateObj;
 			inputHandler = obj.InputHandler;
 			MessageBoxVisible = false;
+			hasBrokenWindowResize = MODUtility.HasBrokenWindowResize();
 			if (!PlayerPrefs.HasKey("width"))
 			{
 				PlayerPrefs.SetInt("width", 1280);
@@ -263,18 +266,18 @@ namespace Assets.Scripts.Core
 
 			if (IsFullscreen)
 			{
-				Screen.SetResolution(fullscreenResolution.width, fullscreenResolution.height, fullscreen: true);
+				SetResolution(fullscreenResolution.width, fullscreenResolution.height, fullscreen: true);
 			}
 			else if (PlayerPrefs.HasKey("height") && PlayerPrefs.HasKey("width"))
 			{
 				int width = PlayerPrefs.GetInt("width");
 				int height = PlayerPrefs.GetInt("height");
 				Debug.Log("Requesting window size " + width + "x" + height + " based on config file");
-				Screen.SetResolution(width, height, fullscreen: false);
+				SetResolution(width, height, fullscreen: false);
 			}
 			if ((Screen.width < 640 || Screen.height < 480) && !IsFullscreen)
 			{
-				Screen.SetResolution(640, 480, fullscreen: false);
+				SetResolution(640, 480, fullscreen: false);
 			}
 			Debug.Log("Starting compile thread...");
 			CompileThread = new Thread(CompileScripts)
@@ -285,6 +288,15 @@ namespace Assets.Scripts.Core
 			if (Application.platform == RuntimePlatform.WindowsPlayer)
 			{
 				KeyHook = new KeyHook();
+			}
+		}
+
+		public void SetResolution(int width, int height, bool fullscreen)
+		{
+			Screen.SetResolution(width, height, fullscreen);
+			if (hasBrokenWindowResize)
+			{
+				MODUtility.X11ManualSetWindowSize(width, height);
 			}
 		}
 
@@ -330,7 +342,7 @@ namespace Assets.Scripts.Core
 			if (!IsFullscreen)
 			{
 				int width = Mathf.RoundToInt((float)Screen.height * AspectRatio);
-				Screen.SetResolution(width, Screen.height, fullscreen: false);
+				SetResolution(width, Screen.height, fullscreen: false);
 			}
 			PlayerPrefs.SetInt("width", Mathf.RoundToInt(PlayerPrefs.GetInt("height") * AspectRatio));
 			MainUIController.UpdateBlackBars();
@@ -823,7 +835,7 @@ namespace Assets.Scripts.Core
 			yield return (object)new WaitForFixedUpdate();
 			IsFullscreen = fullscreen;
 			PlayerPrefs.SetInt("is_fullscreen", fullscreen ? 1 : 0);
-			Screen.SetResolution(width, height, fullscreen);
+			SetResolution(width, height, fullscreen);
 			while (Screen.width != width || Screen.height != height)
 			{
 				yield return (object)null;
@@ -835,7 +847,7 @@ namespace Assets.Scripts.Core
 			IsFullscreen = true;
 			PlayerPrefs.SetInt("is_fullscreen", 1);
 			Resolution resolution = GetFullscreenResolution();
-			Screen.SetResolution(resolution.width, resolution.height, fullscreen: true);
+			SetResolution(resolution.width, resolution.height, fullscreen: true);
 			Debug.Log(resolution.width + " , " + resolution.height);
 			PlayerPrefs.SetInt("fullscreen_width", resolution.width);
 			PlayerPrefs.SetInt("fullscreen_height", resolution.height);
@@ -845,7 +857,7 @@ namespace Assets.Scripts.Core
 		{
 			IsFullscreen = false;
 			PlayerPrefs.SetInt("is_fullscreen", 0);
-			Screen.SetResolution(width, height, fullscreen: false);
+			SetResolution(width, height, fullscreen: false);
 		}
 
 		private void OnApplicationFocus(bool focusStatus)

--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -130,7 +130,7 @@ public static class MODUtility
 	/// On Other OS, *might* show the folder containing the file, but also might not work
 	/// </summary>
 	public static void ShowInFolder(string pathToshow)
-    {
+	{
 		if (Application.platform == RuntimePlatform.WindowsPlayer)
 		{
 			// Explorer doesn't like it if you use forward slashes in path
@@ -146,5 +146,142 @@ public static class MODUtility
 			Debug.Log($"Opening Folder [{folderToOpen}]");
 			Application.OpenURL(folderToOpen);
 		}
+	}
+
+	/// <summary>
+	/// Some of the linux players have a bug where the window resize function passes uninitialized stack data to X11
+	/// </summary>
+	/// <returns>Whether this unity version is has a broken resize function</returns>
+	public static bool HasBrokenWindowResize()
+	{
+		if (Application.platform != RuntimePlatform.LinuxPlayer)
+		{
+			return false;
+		}
+		string version_string = new string(Application.unityVersion.TakeWhile(x => (x >= '0' && x <= '9') || x == '.').ToArray());
+		Version version = new Version(version_string);
+
+		// 5.5.3 is broken, 5.6.7 is not.
+		// There are no higurashi games with versions between those, but the patch code should do nothing if it can't find anything.
+		bool is_broken = version < new Version(5, 6, 7);
+		Debug.Log($"Detected Unity {version}, which has {(is_broken ? "broken" : "working")} window resize");
+		return is_broken;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct XSizeHints
+	{
+		public static readonly long FlagMinSize = 1 << 4;
+		public static readonly long FlagMaxSize = 1 << 5;
+		public IntPtr flags;
+		public int x, y;
+		public int width, height;
+		public int min_width, min_height;
+		public int max_width, max_height;
+		public int width_inc, height_inc;
+		public int min_aspect_x, min_aspect_y;
+		public int max_aspect_x, max_aspect_y;
+		public int base_width, base_height;
+		public int win_gravity;
+	}
+
+	private enum XReturn : int
+	{
+		Success = 0,
+		BadRequest = 1,
+		BadValue = 2,
+		BadWindow = 3,
+	}
+
+	[DllImport("libX11")]
+	private unsafe static extern void XGetWMNormalHints(IntPtr display, IntPtr window, out XSizeHints hints, out IntPtr flags);
+	[DllImport("libX11")]
+	private static extern void XSetWMNormalHints(IntPtr display, IntPtr window, ref XSizeHints hints);
+	[DllImport("libX11")]
+	private static extern IntPtr XAllocSizeHints();
+	[DllImport("libX11")]
+	private static extern void XFree(IntPtr ptr);
+	[DllImport("libX11")]
+	private static extern IntPtr XOpenDisplay(IntPtr name);
+	[DllImport("libX11")]
+	private static extern void XCloseDisplay(IntPtr display);
+	[DllImport("libX11")]
+	private static extern void XFlush(IntPtr display);
+	[DllImport("libX11")]
+	private static extern int XScreenCount(IntPtr display);
+	[DllImport("libX11")]
+	private static extern IntPtr XRootWindow(IntPtr display, int screen);
+	[DllImport("libX11")]
+	private static extern XReturn XResizeWindow(IntPtr display, IntPtr window, int width, int height);
+	[DllImport("libX11")]
+	private static extern void XQueryTree(IntPtr display, IntPtr window, out IntPtr window_out, out IntPtr parent, out IntPtr children, out uint nchildren);
+
+	private static void X11GetChildWindows(IntPtr display, IntPtr window, ref List<IntPtr> output)
+	{
+		XQueryTree(display, window, out _, out _, out IntPtr ichildren, out uint nchildren);
+		unsafe
+		{
+			IntPtr* children = (IntPtr*)ichildren;
+			for (uint j = 0; j < nchildren; j++)
+			{
+				output.Add(children[j]);
+				X11GetChildWindows(display, children[j], ref output);
+			}
+			XFree(ichildren);
+		}
+	}
+
+	private static IntPtr[] X11GetWindows(IntPtr display)
+	{
+		List<IntPtr> windows = new List<IntPtr>();
+		int nscreens = XScreenCount(display);
+		for (int i = 0; i < nscreens; i++)
+		{
+			IntPtr root = XRootWindow(display, i);
+			X11GetChildWindows(display, root, ref windows);
+		}
+		return windows.ToArray();
+	}
+
+	/// <summary>
+	/// Unity won't tell us what the main window is, so we have to search for ourselves
+	/// </summary>
+	private static IntPtr? X11GetLikelyMainWindow(IntPtr display)
+	{
+		IntPtr[] windows = X11GetWindows(display);
+		if (windows.Length == 0)
+		{
+			return null;
+		}
+		foreach (IntPtr window in windows)
+		{
+			XGetWMNormalHints(display, window, out XSizeHints hints, out IntPtr flags);
+			if (((int)hints.flags & (XSizeHints.FlagMaxSize | XSizeHints.FlagMinSize)) != 0)
+			{
+				// Unity will set a minsize and maxsize, so expect the main window to have them
+				return window;
+			}
+		}
+		Debug.Log($"X11: Couldn't find any windows with MinSize or MaxSize (returning window 0 of {windows.Length})");
+		return windows[0];
+	}
+
+	public static void X11ManualSetWindowSize(int width, int height)
+	{
+		Debug.Log($"X11: Resizing to {width}x{height}");
+		IntPtr display = XOpenDisplay(IntPtr.Zero);
+		if (X11GetLikelyMainWindow(display) is IntPtr window)
+		{
+			XGetWMNormalHints(display, window, out XSizeHints hints, out _);
+			hints.flags = (IntPtr)((long)hints.flags | XSizeHints.FlagMinSize | XSizeHints.FlagMaxSize);
+			hints.min_width = width;
+			hints.max_width = width;
+			hints.min_height = height;
+			hints.max_height = height;
+			XSetWMNormalHints(display, window, ref hints);
+			XResizeWindow(display, window, width, height);
+			XFlush(display);
+		}
+		XCloseDisplay(display);
 	}
 }

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -63,7 +63,7 @@ namespace MOD.Scripts.UI
 						}
 						screenHeightString = $"{new_height}";
 						int new_width = Mathf.RoundToInt(new_height * 16f / 9f);
-						Screen.SetResolution(new_width, new_height, Screen.fullScreen);
+						GameSystem.Instance.SetResolution(new_width, new_height, Screen.fullScreen);
 						PlayerPrefs.SetInt("width", new_width);
 						PlayerPrefs.SetInt("height", new_height);
 					}
@@ -86,7 +86,7 @@ namespace MOD.Scripts.UI
 			}
 			screenHeightString = $"{height}";
 			int width = Mathf.RoundToInt(height * 16f / 9f);
-			Screen.SetResolution(width, height, Screen.fullScreen);
+			GameSystem.Instance.SetResolution(width, height, Screen.fullScreen);
 			PlayerPrefs.SetInt("width", width);
 			PlayerPrefs.SetInt("height", height);
 		}


### PR DESCRIPTION
Unity versions ≤ 5.5.3p3 have a broken window resize function that sends uninitialized stack data to XSetWMNormalHints, which tends to not be appreciated by window managers.

Patch the function to immediately return, and reimplement it ourselves.