### PR TITLE
Do not patch window resize fn if libX11.so not found

### DIFF
--- a/MOD.Scripts.Core/MODUtility.cs
+++ b/MOD.Scripts.Core/MODUtility.cs
@@ -165,6 +165,25 @@ public static class MODUtility
 		// There are no higurashi games with versions between those, but the patch code should do nothing if it can't find anything.
 		bool is_broken = version < new Version(5, 6, 7);
 		Debug.Log($"Detected Unity {version}, which has {(is_broken ? "broken" : "working")} window resize");
+
+		// Extra check to see if we can actually call any X11 functions, as in some cases you will get a DllNotFoundException: libX11.so
+		if (is_broken)
+		{
+			try
+			{
+				IntPtr display = XOpenDisplay(IntPtr.Zero);
+				if (display != IntPtr.Zero)
+				{
+					XCloseDisplay(display);
+				}
+			}
+			catch (DllNotFoundException e)
+			{
+				Debug.Log($"X11 not available - assuming window resize is not broken: {e}");
+				return false;
+			}
+		}
+
 		return is_broken;
 	}
 


### PR DESCRIPTION
A user on Steam Deck, Chapter 3, reported a black screen on startup. Their logs showed this error:

```csharp
DllNotFoundException: libX11.so
  at (wrapper managed-to-native) MODUtility:XOpenDisplay (intptr)
  at MODUtility.X11ManualSetWindowSize (Int32 width, Int32 height) [0x00000] in <filename unknown>:0 
  at Assets.Scripts.Core.GameSystem.SetResolution (Int32 width, Int32 height, Boolean fullscreen) [0x00000] in <filename unknown>:0 
  at Assets.Scripts.Core.GameSystem.Initialize () [0x00000] in <filename unknown>:0 
  at Assets.Scripts.Core.GameSystem.CheckInitialization () [0x00000] in <filename unknown>:0 
  at Assets.Scripts.Core.GameSystem.Update () [0x00000] in <filename unknown>:0 
 
(Filename:  Line: -1)
```

I don't really know what causes this, but I added some code to probe whether X11 functions are available. If they're not available, I assume windowing isn't broken and don't patch the window resize fn.

The user tested this fix and it worked for them. I also re-tested this on my Manjaro setup, and I can see in the logs that it still  patches the window resize function on my own computer.

Related Issues:
- #93 
- #91
- #97