### PR TITLE
Fix sliders on first boot, carret not clearing, choice button fade out, etc.

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -635,7 +635,6 @@ namespace Assets.Scripts.Core.Buriko
 			}
 			gameSystem.DisplayChoices(stringList, num);
 			gameSystem.ExecuteActions();
-			gameSystem.AddWait(new Wait(1f, WaitTypes.WaitForTime, null));
 			return null;
 		}
 

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -1,3 +1,4 @@
+using Assets.Scripts.Core.AssetManagement;
 using MOD.Scripts.Core;
 using MOD.Scripts.Core.Scene;
 using System;
@@ -874,7 +875,7 @@ namespace Assets.Scripts.Core.Scene
 			streamReader.Close();
 			for (int k = 0; k < exparray.Length; k++)
 			{
-				if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId))
+				if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId) || !MODSystem.instance.modSceneController.MODLipSyncIsEnabled())
 				{
 					break;
 				}
@@ -927,7 +928,7 @@ namespace Assets.Scripts.Core.Scene
 			for (int chunk = 0; chunk < 10 * numChunks; chunk++)
 			{
 				// Forcibly stop the lipsync animation if it's not meant to be playing at this time?
-				if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId))
+				if (!MODSystem.instance.modSceneController.MODLipSyncAnimationStillActive(character, coroutineId) || !MODSystem.instance.modSceneController.MODLipSyncIsEnabled())
 				{
 					break;
 				}
@@ -1031,7 +1032,15 @@ namespace Assets.Scripts.Core.Scene
 				}
 			}
 
-			MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
+			// Most of the time we want to reset the sprite back to the 'default' pose when lipsync finishes (even if the
+			// lipsync option is already 'disabled') to prevent having a character with their mouth stuck open.
+			//
+			// However, if artset is changed while lipsync in progress (for example to OG sprites), then we don't want to
+			// overwrite the OG sprite's texture with the Console texture.
+			if(AssetManager.Instance.CurrentArtsetIndex == 0)
+			{
+				MODSystem.instance.modSceneController.MODLipSyncProcess(character, exp4, coroutineId);
+			}
 		}
 
 		public void MODLipSyncStart(int character, int audiolayer, string audiofile, AudioClip audioClip)

--- a/Assets.Scripts.Core.TextWindow/TextController.cs
+++ b/Assets.Scripts.Core.TextWindow/TextController.cs
@@ -225,6 +225,7 @@ namespace Assets.Scripts.Core.TextWindow
 			englishtext = string.Empty;
 			japanesetext = string.Empty;
 			txt = string.Empty;
+			gameSystem.MainUIController.HideCarret();
 			AudioController.Instance.ClearVoiceQueue();
 		}
 

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -482,7 +482,7 @@ namespace Assets.Scripts.Core
 		public void LeaveChoices()
 		{
 			PopStateStack();
-			AddWait(new Wait(0.5f, WaitTypes.WaitForTime, delegate
+			AddWait(new Wait(ChoiceButton.fadeTime, WaitTypes.WaitForTime, delegate
 			{
 				ChoiceController.Destroy();
 				ChoiceController = null;

--- a/Assets.Scripts.UI.Choice/ChoiceButton.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceButton.cs
@@ -15,7 +15,11 @@ namespace Assets.Scripts.UI.Choice
 
 		public UITweener ColorTweener;
 
-		private float fadeInTime = 0.5f;
+		public static float fadeTime = .25f;
+		private float tweenTimer;
+
+		// This prevents the user selecting a choice before the choices are fully loaded
+		private float fadeInTime = fadeTime/2;
 
 		private ClickCallback clickCallback;
 
@@ -43,7 +47,8 @@ namespace Assets.Scripts.UI.Choice
 		{
 			LeanTween.cancel(base.gameObject);
 			Color color = ButtonTextMesh.color;
-			LeanTween.value(base.gameObject, UpdateAlpha, color.a, alpha, fadeInTime);
+			tweenTimer = fadeTime;
+			LeanTween.value(base.gameObject, UpdateAlpha, color.a, alpha, tweenTimer);
 		}
 
 		private void OnClick()
@@ -60,7 +65,7 @@ namespace Assets.Scripts.UI.Choice
 
 		private void OnHover(bool ishover)
 		{
-			if (GameSystem.Instance.GameState == GameState.ChoiceScreen)
+			if (GameSystem.Instance.GameState == GameState.ChoiceScreen && isEnabled)
 			{
 				if (ishover)
 				{
@@ -116,7 +121,15 @@ namespace Assets.Scripts.UI.Choice
 
 		private void Update()
 		{
-			fadeInTime -= Time.deltaTime;
+			if(tweenTimer > 0)
+			{
+				tweenTimer -= Time.deltaTime;
+			}
+
+			if(fadeInTime > 0)
+			{
+				fadeInTime -= Time.deltaTime;
+			}
 		}
 	}
 }

--- a/Assets.Scripts.UI.Config/ConfigSlider.cs
+++ b/Assets.Scripts.UI.Config/ConfigSlider.cs
@@ -27,22 +27,22 @@ namespace Assets.Scripts.UI.Config
 			switch (base.name) // All slider labels match original order, functionality in comment
 			{
 			case "0-TextSpeed": // Window Opacity:
-				num = (int)(GameSystem.Instance.MessageWindowOpacity * 100f);
+				num = BurikoMemory.Instance.GetGlobalFlag("GWindowOpacity").IntValue();
 				break;
 			case "1-AutoSpeed": // Voice Volume:
-				num = (int)(GameSystem.Instance.AudioController.VoiceVolume * 100f);
+				num = BurikoMemory.Instance.GetGlobalFlag("GVoiceVolume").IntValue();
 				break;
 			case "2-AutoPageSpeed": // BGM Volume
-				num = (int)(GameSystem.Instance.AudioController.BGMVolume * 100f);
+				num = BurikoMemory.Instance.GetGlobalFlag("GBGMVolume").IntValue();
 				break;
 			case "3-WindowOpacity": // SE Volume
-				num = (int)(GameSystem.Instance.AudioController.SoundVolume * 100f);
+				num = BurikoMemory.Instance.GetGlobalFlag("GSEVolume").IntValue();
 				break;
 			case "4-BGMVolume": // Text / Auto text speed
-				num = GameSystem.Instance.TextController.TextSpeed;
+				num = BurikoMemory.Instance.GetGlobalFlag("GMessageSpeed").IntValue();
 				break;
 			case "5-SEVolume":  // Auto Page Speed
-				num = GameSystem.Instance.TextController.AutoPageSpeed;
+				num = BurikoMemory.Instance.GetGlobalFlag("GAutoAdvSpeed").IntValue();
 				break;
 			}
 			slider.value = (float)num / 100f;


### PR DESCRIPTION
I noticed a bug (in rei, but probably also in all chapters) where the first time you start the game, the sliders will have the wrong values (they will look like they're at 100% when they're actually at 50% or 75% for voice).

If you visited the config menu the first time you boot the game, this might make you want to reset them all to 50%. since they look too high.

This appears to be because on first boot, the various volumes/opacity etc. are not synced with their flags. I just changed the sliders to take the values directly from the flags, rather than the variables.

Haven't done much testing on this, am worried this might break the sliders.

Note that I simulated "first boot" by deleting the `global.dat` file, unsure if there is some default `global.dat` file that comes with the game, or if it is generated the first time you boot the game.

See https://github.com/07th-mod/higurashi-rei/issues/13#issuecomment-1327192162