### PR TITLE
Add "Experimental 4:3 Aspect Ratio" option

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -113,6 +113,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GStretchBackgrounds", 527);
 			variableReference.Add("GBackgroundSet", 528);
 			variableReference.Add("GAudioSet", 529);
+			variableReference.Add("GRyukishiMode43Aspect", 530);
 
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);

--- a/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptFile.cs
@@ -1910,6 +1910,7 @@ namespace Assets.Scripts.Core.Buriko
 			SetOperationType("SetScreenAspect");
 			string s = ReadVariable().StringValue();
 			float newratio = 1f / float.Parse(s, CultureInfo.InvariantCulture);
+			gameSystem.SetDefaultAspect(newratio);
 			gameSystem.UpdateAspectRatio(newratio);
 			return BurikoVariable.Null;
 		}

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -334,16 +334,42 @@ namespace Assets.Scripts.Core.Scene
 			bool stretchToFit = false;
 			if (texturePath != null)
 			{
-				// We want to clamp sprites to 4:3 if you are using the OG backgrounds, and you are not stretching the background
-				ryukishiClamp = isBustShot &&
-					Buriko.BurikoMemory.Instance.GetGlobalFlag("GBackgroundSet").IntValue() == 1 &&      // Using OG Backgrounds AND
-					Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 0 && // Not stretching backgrounds AND
-					(texturePath.Contains("sprite/") ||
-					texturePath.Contains("sprite\\") ||
-					texturePath.Contains("portrait/") ||
-					texturePath.Contains("portrait\\")); // Is a sprite or portrait image. I don't think we can rely only on isBustShot, as sometimes non-sprites are drawn with isBustShot
+				bool isSpriteOrPortrait = texturePath.Contains("sprite/") ||
+						texturePath.Contains("sprite\\") ||
+						texturePath.Contains("portrait/") ||
+						texturePath.Contains("portrait\\");
 
-				stretchToFit = Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 1 && texturePath.Contains("OGBackgrounds");
+				if (Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+				{
+					// When using true 4:3 mode, we don't need to clamp the sprites, as they are automatically cut off by the viewport
+					ryukishiClamp = false;
+
+					// When using true 4:3 aspect mode, any 16:9 images (except for sprites) should be squished to 4:3.
+					// This make sure any text or other images don't get cut off
+					// We could letter-box the images, but in some cases whatever is behind the image may show up? Not sure.
+					stretchToFit = !isSpriteOrPortrait;
+
+					// Do not stretch if the image is more than 5% off a 16:9 aspect ratio.
+					// Likely these are special images like credits images or effect images.
+					float targetAspect = 16f / 9f;
+					float imageAspect = (float)width / (float)height;
+					Debug.Log($"{texturePath}: aspect: {imageAspect} ref: {targetAspect}");
+					if(imageAspect > targetAspect * 1.05 || imageAspect < targetAspect * .95f)
+					{
+						stretchToFit = false;
+					}
+				}
+				else
+				{
+					// We want to clamp sprites to 4:3 if you are using the OG backgrounds, and you are not stretching the background
+					ryukishiClamp = isBustShot &&
+						Buriko.BurikoMemory.Instance.GetGlobalFlag("GBackgroundSet").IntValue() == 1 &&      // Using OG Backgrounds AND
+						Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 0 && // Not stretching backgrounds AND
+						isSpriteOrPortrait; // Is a sprite or portrait image. I don't think we can rely only on isBustShot, as sometimes non-sprites are drawn with isBustShot
+
+					// When using old backgrounds with stretch backgrounds enabled, stretch old 4:3 backgrounds to 16:9 to fill the screen
+					stretchToFit = Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 1 && texturePath.Contains("OGBackgrounds");
+				}
 			}
 
 			if (mesh == null ||

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -188,6 +188,8 @@ namespace Assets.Scripts.Core
 
 		private bool hasBrokenWindowResize;
 
+		private float defaultAspect;
+
 		private float _configMenuFontSize = 0;
 		public float ConfigMenuFontSize
 		{
@@ -336,9 +338,23 @@ namespace Assets.Scripts.Core
 			MainUIController.InitializeModMenu(this);
 		}
 
+		public void SetDefaultAspect(float defaultAspect)
+		{
+			this.defaultAspect = defaultAspect;
+		}
+
+		public void UpdateAspectRatio() => UpdateAspectRatio(defaultAspect);
+
 		public void UpdateAspectRatio(float newratio)
 		{
 			AspectRatio = newratio;
+
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+			{
+				AspectRatio = 4f / 3f;
+				MODActions.SetTextWindowAppearance((MODActions.ModPreset) MODActions.GetADVNVLRyukishiModeFromFlags(), showInfoToast: false);
+			}
+
 			if (!IsFullscreen)
 			{
 				int width = Mathf.RoundToInt((float)Screen.height * AspectRatio);

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -352,8 +352,10 @@ namespace Assets.Scripts.Core
 			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
 			{
 				AspectRatio = 4f / 3f;
-				MODActions.SetTextWindowAppearance((MODActions.ModPreset) MODActions.GetADVNVLRyukishiModeFromFlags(), showInfoToast: false);
 			}
+
+			// Text window may need to be resized to fit different screen size due to aspect ratio change
+			MODActions.SetTextWindowAppearance((MODActions.ModPreset)MODActions.GetADVNVLRyukishiModeFromFlags(), showInfoToast: false);
 
 			if (!IsFullscreen)
 			{

--- a/Assets.Scripts.UI.Choice/ChoiceButton.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceButton.cs
@@ -131,5 +131,8 @@ namespace Assets.Scripts.UI.Choice
 				fadeInTime -= Time.deltaTime;
 			}
 		}
+
+		public float GetFontSize() => ButtonTextMesh.fontSize;
+		public void SetFontSize(float fontSize) => ButtonTextMesh.fontSize = fontSize;
 	}
 }

--- a/Assets.Scripts.UI.Choice/ChoiceController.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceController.cs
@@ -70,6 +70,10 @@ namespace Assets.Scripts.UI.Choice
 				}
 				ChoiceButton component = gameObject2.GetComponent<ChoiceButton>();
 				component.ChangeText(optstrings[i]);
+				if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+				{
+					component.SetFontSize(component.GetFontSize() * .75f);
+				}
 				component.SetCallback(this, delegate
 				{
 					GameSystem.Instance.ScriptSystem.SetFlag("SelectResult", id);

--- a/MOD.Scripts.UI/MODActions.cs
+++ b/MOD.Scripts.UI/MODActions.cs
@@ -105,6 +105,10 @@ namespace MOD.Scripts.UI
 		{
 			MODMainUIController mODMainUIController = new MODMainUIController();
 
+			// Always reset experimental 4:3 mode when setting any preset
+			BurikoMemory.Instance.SetGlobalFlag("GRyukishiMode43Aspect", 0);
+			GameSystem.Instance.UpdateAspectRatio();
+
 			BurikoMemory.Instance.GetCustomFlagPresetInstance().DisablePresetAndSavePresetToMemory();
 			if (setting == ModPreset.Console)
 			{

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -260,8 +260,8 @@ namespace MOD.Scripts.UI
 			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
 			{
 				aDVModeWindowPosX = RyukishiModeWindowPosX - 20;
-				aDVModeWindowSizeX = RyukishiModeWindowSizeX + 15;
-				aDVModeFontSize = ADVModeFontSize * 9 / 10;
+				aDVModeWindowSizeX = RyukishiModeWindowSizeX - 60;
+				aDVModeFontSize = ADVModeFontSize * 85 / 100;
 			}
 
 			GameSystem.Instance.TextController.NameFormat = aDVModeNameFormat;

--- a/MOD.Scripts.UI/MODMainUIController.cs
+++ b/MOD.Scripts.UI/MODMainUIController.cs
@@ -144,6 +144,12 @@ namespace MOD.Scripts.UI
 
 		public void WideGuiPositionStore()
 		{
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+			{
+				RyukishiGuiPositionStore();
+				return;
+			}
+
 			GameSystem.Instance.MainUIController.UpdateGuiPosition(WideModeGuiPosX, WideModeGuiPosY);
 		}
 
@@ -250,6 +256,14 @@ namespace MOD.Scripts.UI
 			int aDVModeCharSpacing = ADVModeCharSpacing;
 			int aDVModeLineSpacing = ADVModeLineSpacing;
 			int aDVModeFontSize = ADVModeFontSize;
+
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+			{
+				aDVModeWindowPosX = RyukishiModeWindowPosX - 20;
+				aDVModeWindowSizeX = RyukishiModeWindowSizeX + 15;
+				aDVModeFontSize = ADVModeFontSize * 9 / 10;
+			}
+
 			GameSystem.Instance.TextController.NameFormat = aDVModeNameFormat;
 			GameSystem.Instance.MainUIController.SetWindowPos(aDVModeWindowPosX, aDVModeWindowPosY);
 			GameSystem.Instance.MainUIController.SetWindowSize(aDVModeWindowSizeX, aDVModeWindowSizeY);
@@ -275,6 +289,13 @@ namespace MOD.Scripts.UI
 			int nVLModeCharSpacing = NVLModeCharSpacing;
 			int nVLModeLineSpacing = NVLModeLineSpacing;
 			int nVLModeFontSize = NVLModeFontSize;
+
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+			{
+				nVLModeWindowPosX = RyukishiModeWindowPosX;
+				nVLModeWindowSizeX = RyukishiModeWindowSizeX - 100;
+			}
+
 			GameSystem.Instance.TextController.NameFormat = nVLModeNameFormat;
 			GameSystem.Instance.MainUIController.SetWindowPos(nVLModeWindowPosX, nVLModeWindowPosY);
 			GameSystem.Instance.MainUIController.SetWindowSize(nVLModeWindowSizeX, nVLModeWindowSizeY);
@@ -287,6 +308,12 @@ namespace MOD.Scripts.UI
 
 		public void NVLADVModeSettingStore()
 		{
+			if (BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+			{
+				RyukishiModeSettingStore();
+				return;
+			}
+
 			string nVLADVModeNameFormat = NVLADVModeNameFormat;
 			int nVLADVModeWindowPosX = NVLADVModeWindowPosX;
 			int nVLADVModeWindowPosY = NVLADVModeWindowPosY;

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -180,6 +180,13 @@ You can try the following yourself to fix the issue.
 
 			// Position the top-left x so the button is aligned with the config menu background, with a small margin
 			float xOffset = Screen.width / 8 + Screen.width / 64;
+
+			// Reposition button in 4:3 mode otherwise it would overlap the settings text
+			if(BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+			{
+				xOffset = 7 * Screen.width / 128;
+			}
+
 			// Position the top-left y to vertically center the button
 			float yOffset = Screen.height / 2 - areaHeight/2;
 
@@ -344,8 +351,10 @@ You can try the following yourself to fix the issue.
 			{
 				float totalAreaWidth = styleManager.Group.menuWidth;
 
-				float areaWidth = Mathf.Round(totalAreaWidth * 9/16);
-				float toolTipWidth = Mathf.Round(totalAreaWidth * 7/16);
+				float toolTipSubtraction = totalAreaWidth * styleManager.Group.toolTipShrinkage;
+
+				float areaWidth = Mathf.Round(totalAreaWidth * 9/16) + toolTipSubtraction;
+				float toolTipWidth = Mathf.Round(totalAreaWidth * 7/16) - toolTipSubtraction;
 
 				float areaHeight = styleManager.Group.menuHeight;
 

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Scripts.Core;
+using Assets.Scripts.Core.Buriko;
 using MOD.Scripts.Core.Audio;
 using System;
 using System.Collections.Generic;
@@ -31,6 +32,7 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioStretchBackgrounds;
 		private readonly MODRadio radioTextWindowModeAndCrop;
 		private readonly MODRadio radioForceComputedLipsync;
+		private readonly MODRadio radioRyukishiExperimentalAspect;
 
 		private readonly MODTabControl tabControl;
 
@@ -142,6 +144,18 @@ Sets the script censorship level
 				new MODTabControl.TabProperties("Graphics", "Sprites, Backgrounds, CGs, Resolution", GraphicsTabOnGUI),
 				new MODTabControl.TabProperties("Audio", "BGM and SE options", AudioTabOnGUI),
 				new MODTabControl.TabProperties("Troubleshooting", "Tools to help you if something goes wrong", TroubleShootingTabOnGUI),
+			});
+
+			radioRyukishiExperimentalAspect = new MODRadio("Original/Ryukishi Experimental 4:3 Aspect Ratio", new GUIContent[]{
+				new GUIContent("16:9 (default)", "The game's aspect ratio will be 16:9.\n\n" +
+				"When playing in OG mode, the left and right of the screen will be padded to 4:3 with black bars."),
+				new GUIContent("4:3", "The game's aspect ratio will be 4:3, however this may cause some issues when playing our mod.\n" +
+				"Only use this option if your monitor is 4:3 aspect ratio, like an old CRT monitor.\n\n" +
+				"Please note the following:\n\n" +
+				" - You should enable the Original/Ryukishi preset before enabling this option. Using other settings should all work, but are not well tested.\n\n" +
+				" - 16:9 images will be squished to fit in 4:3 so they don't get cut off. This includes text images, and PS3 CG images if enabled.\n\n" +
+				" - You may see graphical artifacts just after this is enabled - they should fix after the next character transition or text clear\n\n"
+				),
 			});
 
 			customFlagPreset = Assets.Scripts.Core.Buriko.BurikoMemory.Instance.GetCustomFlagPresetInstance();
@@ -258,12 +272,14 @@ Sets the script censorship level
 				if (this.radioBackgrounds.OnGUIFragment(GetGlobal("GBackgroundSet")) is int background)
 				{
 					MODActions.SetFlagFromUserInput("GBackgroundSet", background, showInfoToast: false);
+					GameSystem.Instance.UpdateAspectRatio();
 					GameSystem.Instance.SceneController.ReloadAllImages();
 				}
 
 				if (this.radioStretchBackgrounds.OnGUIFragment(GetGlobal("GStretchBackgrounds")) is int stretchBackgrounds)
 				{
 					MODActions.SetFlagFromUserInput("GStretchBackgrounds", stretchBackgrounds, showInfoToast: false);
+					GameSystem.Instance.UpdateAspectRatio();
 					GameSystem.Instance.SceneController.ReloadAllImages();
 				}
 			}
@@ -271,6 +287,13 @@ Sets the script censorship level
 			if (this.radioTextWindowModeAndCrop.OnGUIFragment(MODActions.GetADVNVLRyukishiModeFromFlags()) is int windowMode)
 			{
 				MODActions.SetTextWindowAppearance((MODActions.ModPreset) windowMode, showInfoToast: false);
+				GameSystem.Instance.SceneController.ReloadAllImages();
+			}
+
+			if (this.radioRyukishiExperimentalAspect.OnGUIFragment(GetGlobal("GRyukishiMode43Aspect")) is int experimentalAspect)
+			{
+				SetGlobal("GRyukishiMode43Aspect", experimentalAspect);
+				GameSystem.Instance.UpdateAspectRatio();
 				GameSystem.Instance.SceneController.ReloadAllImages();
 			}
 

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -62,7 +62,7 @@ namespace MOD.Scripts.UI
 							new_height = 15360;
 						}
 						screenHeightString = $"{new_height}";
-						int new_width = Mathf.RoundToInt(new_height * 16f / 9f);
+						int new_width = Mathf.RoundToInt(new_height * GameSystem.Instance.AspectRatio);
 						GameSystem.Instance.SetResolution(new_width, new_height, Screen.fullScreen);
 						PlayerPrefs.SetInt("width", new_width);
 						PlayerPrefs.SetInt("height", new_height);
@@ -85,7 +85,7 @@ namespace MOD.Scripts.UI
 				height = 15360;
 			}
 			screenHeightString = $"{height}";
-			int width = Mathf.RoundToInt(height * 16f / 9f);
+			int width = Mathf.RoundToInt(height * GameSystem.Instance.AspectRatio);
 			GameSystem.Instance.SetResolution(width, height, Screen.fullScreen);
 			PlayerPrefs.SetInt("width", width);
 			PlayerPrefs.SetInt("height", height);

--- a/MOD.Scripts.UI/MODStyleManager.cs
+++ b/MOD.Scripts.UI/MODStyleManager.cs
@@ -17,6 +17,7 @@ namespace MOD.Scripts.UI
 		{
 			public int menuHeight;
 			public int menuWidth;
+			public float toolTipShrinkage;
 			public GUIStyle modMenuSelectionGrid;   // Used for SelectionGrid widgets
 			public GUIStyle errorLabel;
 			public GUIStyle button;
@@ -39,22 +40,38 @@ namespace MOD.Scripts.UI
 		public Texture2D modGUIBackgroundTextureTransparent;
 		public Texture2D modGUIBackgroundTextureLight;
 
-		StyleGroup style480;
-		StyleGroup style720;
-		StyleGroup style1080;
+		// These style groups use the naming convention:
+		// style[VERTICAL_SCREEN_HEIGHT]_[MENU_WIDTH]x[MENU_HEIGHT]
+		StyleGroup style1080_1200x950;
+		StyleGroup style720_1000x660;
+		StyleGroup style720_960x660;
+		StyleGroup style480_850x480;
+		StyleGroup style480_640x480;
+
 		public StyleGroup Group
 		{
-			get {
-				if (Screen.height >= 1080)
+			get
+			{
+				if (Screen.height >= 1080 && Screen.width >= 1200)
 				{
-					return style1080;
+					return style1080_1200x950;
 				}
-				else if (Screen.height >= 720)
+				else if (Screen.height >= 720 && Screen.width >= 1000)
 				{
-					return style720;
+					return style720_1000x660;
 				}
-
-				return style480;
+				else if(Screen.height >= 720 && Screen.width >= 960)
+				{
+					return style720_960x660;
+				}
+				else if(Screen.height >= 480 && Screen.width >= 850)
+				{
+					return style480_850x480;
+				}
+				else
+				{
+					return style480_640x480;
+				}
 			}
 		}
 
@@ -110,7 +127,16 @@ namespace MOD.Scripts.UI
 			modGUIBackgroundTextureLight.Apply();
 
 
-			style480 = GenerateWidgetStyles(
+			style480_640x480 = GenerateWidgetStyles(
+				menuWidth: 640,
+				menuHeight: 480,
+				guiScale: .8f,
+				margin: new RectOffset(0, 0, 0, 0),
+				padding: new RectOffset(0, 0, 0, 0),
+				toolTipShrinkage: .15f
+			);
+
+			style480_850x480 = GenerateWidgetStyles(
 				menuWidth: 850,
 				menuHeight: 480,
 				guiScale: .9f,
@@ -118,7 +144,15 @@ namespace MOD.Scripts.UI
 				padding: new RectOffset(0, 0, 0, 0)
 			);
 
-			style720 = GenerateWidgetStyles(
+			style720_960x660 = GenerateWidgetStyles(
+				menuWidth: 960,
+				menuHeight: 660,
+				guiScale: 1.1f,
+				margin: new RectOffset(1, 1, 1, 1),
+				padding: new RectOffset(1, 1, 1, 1)
+			);
+
+			style720_1000x660 = GenerateWidgetStyles(
 				menuWidth: 1000,
 				menuHeight: 660,
 				guiScale: 1.1f,
@@ -126,7 +160,7 @@ namespace MOD.Scripts.UI
 				padding: new RectOffset(1, 1, 1, 1)
 			);
 
-			style1080 = GenerateWidgetStyles(
+			style1080_1200x950 = GenerateWidgetStyles(
 				menuWidth: 1200,
 				menuHeight: 950,
 				guiScale: 1.25f,
@@ -177,7 +211,7 @@ namespace MOD.Scripts.UI
 			modMenuAreaStyleTransparent.normal.background = modGUIBackgroundTextureTransparent;
 		}
 
-		private StyleGroup GenerateWidgetStyles(int menuWidth, int menuHeight, float guiScale, RectOffset margin, RectOffset padding)
+		private StyleGroup GenerateWidgetStyles(int menuWidth, int menuHeight, float guiScale, RectOffset margin, RectOffset padding, float toolTipShrinkage = 0)
 		{
 			// Button style
 			GUIStyle buttonStyle = new GUIStyle(GUI.skin.button);
@@ -232,6 +266,7 @@ namespace MOD.Scripts.UI
 				label = labelStyle,
 				headingLabel = headingLabelStyle,
 				upperLeftHeadingLabel = upperLeftHeadingLabelStyle,
+				toolTipShrinkage = toolTipShrinkage,
 			};
 		}
 	}


### PR DESCRIPTION
 This adds an option which runs the game in 4:3 resolution for use on monitors with 4:3 resolution (or less than 16:9 aspect)


# TODO

## Warped Spiral Mask

- [x] One episodes 5 and up, Sprial fade and other effects are squished more than they should be - these may be better cropped or use the original 4:3 version (but probably can't replace the file directly as non-4:3 OG mode uses these files as well?)

After some investigation:
for the question arcs (or at least episode 1), we have stretched all the masks, so the normal mod spiral mask looks like this:

![image](https://user-images.githubusercontent.com/1249449/213355954-7c4ceea1-6004-426c-ac16-5818aeac2494.png)

But for the answer arcs, the same spiral mask is cropped, and  looks like this:

![image](https://user-images.githubusercontent.com/1249449/213355975-44ee6505-e4cc-45e2-b217-e9b0471c7ee8.png)


So the engine actually behaves the same, it's just the actual mask image is different

so for question arcs it works out because the image is stretched and then un-stretched, but for the answer arcs it doesn't work 

because it is is cropped and then un-stretched

Here is the unmodded game's spiral:
![image](https://user-images.githubusercontent.com/1249449/213355987-d8bb13f5-0725-44dd-bfc8-60af473fd849.png)

this does mean our normal modded game is warped for the question arcs, and furthermore it's not consistent between question and answer arcs

----

Here is a pack containing all the OG masks (some are created from modded masks if no OG exists):

[og-mask-pack.zip](https://github.com/07th-mod/higurashi-assembly/files/10462509/og-mask-pack.zip)

## ADV textbox arrow cut off:

- [x] ADV textbox arrow cut off:
![image](https://user-images.githubusercontent.com/1249449/213324260-a6d6dda2-1987-4d4c-bcaa-1d4e6c6cfcdb.png)


# Squashed Commits:
- Reset 4:3 mode when choosing a preset
- Simplify conditions for 4:3 mode
- Squish 16:9 images to 4:3 - any 16:9 images will be squished to fit in 4:3 so they don't get cut off - This fixes movie playback also
- Don't clamp sprites if using true 4:3 mode
- Do not stretch sprites in 4:3 mode
- Make sure aspect is set before redraw to avoid temporary graphics artifacts
- Automatically set Original textbox when 4:3 mode enabled
- Update 4:3 mode hover description
- Fix mod menu resolution buttons resetting aspect ratio
- Fix mod menu at low 4:3 resolutions
- Fix ADV mode textbox when using true 4:3 mode
- Fix images drawn as bustshots not being resized
- Fix mod menu button overlapping settings text
- Fix choice text overflowing screen
- Do not stretch odd aspect ratio images
- Fix NVL mode and NVL-in-ADV mode 862b60eab63e1e9e2829f813c71a58d74475d5a0