### PR TITLE
Fix NGUI based buttons when using touchscreen

### DIFF
--- a/Assets.Scripts.UI.CGGallery/GalleryButton.cs
+++ b/Assets.Scripts.UI.CGGallery/GalleryButton.cs
@@ -18,7 +18,7 @@ namespace Assets.Scripts.UI.CGGallery
 			{
 				gameSystem = GameSystem.Instance;
 			}
-			if (gameSystem.GameState == GameState.CGGallery && !(time > 0f) && UICamera.currentTouchID == -1)
+			if (gameSystem.GameState == GameState.CGGallery && !(time > 0f) && UICamera.currentTouchID >= -1)
 			{
 				gameSystem.PopStateStack();
 				BurikoMemory.Instance.SetFlag("LOCALWORK_NO_RESULT", cgslot);

--- a/Assets.Scripts.UI.ChapterJump/ChapterJumpButton.cs
+++ b/Assets.Scripts.UI.ChapterJump/ChapterJumpButton.cs
@@ -49,7 +49,7 @@ namespace Assets.Scripts.UI.ChapterJump
 
 		private void OnClick()
 		{
-			if (isActive && UICamera.currentTouchID == -1 && GameSystem.Instance.GameState == GameState.ChapterJumpScreen)
+			if (isActive && UICamera.currentTouchID >= -1 && GameSystem.Instance.GameState == GameState.ChapterJumpScreen)
 			{
 				StateChapterJump stateChapterJump = GameSystem.Instance.GetStateObject() as StateChapterJump;
 				if (stateChapterJump != null)

--- a/Assets.Scripts.UI.ChapterPreview/ChapterPreviewButton.cs
+++ b/Assets.Scripts.UI.ChapterPreview/ChapterPreviewButton.cs
@@ -16,7 +16,7 @@ namespace Assets.Scripts.UI.ChapterPreview
 
 		public void OnClick()
 		{
-			if (UICamera.currentTouchID == -1 && GameSystem.Instance.GameState == GameState.ChapterPreview)
+			if (UICamera.currentTouchID >= -1 && GameSystem.Instance.GameState == GameState.ChapterPreview)
 			{
 				StateChapterPreview stateChapterPreview = GameSystem.Instance.GetStateObject() as StateChapterPreview;
 				if (stateChapterPreview != null)

--- a/Assets.Scripts.UI.ChapterScreen/ChapterButton.cs
+++ b/Assets.Scripts.UI.ChapterScreen/ChapterButton.cs
@@ -26,7 +26,7 @@ namespace Assets.Scripts.UI.ChapterScreen
 
 		private void OnClick()
 		{
-			if (isActive && UICamera.currentTouchID == -1 && GameSystem.Instance.GameState == GameState.ChapterScreen)
+			if (isActive && UICamera.currentTouchID >= -1 && GameSystem.Instance.GameState == GameState.ChapterScreen)
 			{
 				StateChapterScreen stateChapterScreen = GameSystem.Instance.GetStateObject() as StateChapterScreen;
 				if (stateChapterScreen != null)

--- a/Assets.Scripts.UI.Choice/ChoiceButton.cs
+++ b/Assets.Scripts.UI.Choice/ChoiceButton.cs
@@ -53,7 +53,7 @@ namespace Assets.Scripts.UI.Choice
 
 		private void OnClick()
 		{
-			if (GameSystem.Instance.GameState == GameState.ChoiceScreen && !(fadeInTime > 0f) && isEnabled && UICamera.currentTouchID == -1)
+			if (GameSystem.Instance.GameState == GameState.ChoiceScreen && !(fadeInTime > 0f) && isEnabled && UICamera.currentTouchID >= -1)
 			{
 				if (clickCallback != null)
 				{

--- a/Assets.Scripts.UI.Config/ArrowButton.cs
+++ b/Assets.Scripts.UI.Config/ArrowButton.cs
@@ -10,7 +10,7 @@ namespace Assets.Scripts.UI.Config
 
 		private void OnClick()
 		{
-			if (UICamera.currentTouchID == -1)
+			if (UICamera.currentTouchID >= -1)
 			{
 				Slider.Changestep(StepChange);
 			}

--- a/Assets.Scripts.UI.Config/SwitchButtonObj.cs
+++ b/Assets.Scripts.UI.Config/SwitchButtonObj.cs
@@ -15,7 +15,7 @@ namespace Assets.Scripts.UI.Config
 
 		private void OnClick()
 		{
-			if (!(cooldown > 0f) && UICamera.currentTouchID == -1)
+			if (!(cooldown > 0f) && UICamera.currentTouchID >= -1)
 			{
 				AudioController.Instance.PlaySystemSound("wa_038.ogg", 1);
 				controller.Click();

--- a/Assets.Scripts.UI.Extra/ExtraButton.cs
+++ b/Assets.Scripts.UI.Extra/ExtraButton.cs
@@ -28,7 +28,7 @@ namespace Assets.Scripts.UI.Extra
 
 		private void OnClick()
 		{
-			if (isActive && UICamera.currentTouchID == -1 && GameSystem.Instance.GameState == GameState.ExtraScreen)
+			if (isActive && UICamera.currentTouchID >= -1 && GameSystem.Instance.GameState == GameState.ExtraScreen)
 			{
 				StateExtraScreen stateExtraScreen = GameSystem.Instance.GetStateObject() as StateExtraScreen;
 				if (stateExtraScreen != null)

--- a/Assets.Scripts.UI.Menu/MenuUIButton.cs
+++ b/Assets.Scripts.UI.Menu/MenuUIButton.cs
@@ -27,7 +27,7 @@ namespace Assets.Scripts.UI.Menu
 			{
 				return;
 			}
-			if (gameSystem.GameState == GameState.RightClickMenu && !(time > 0f) && UICamera.currentTouchID == -1 && isEnabled)
+			if (gameSystem.GameState == GameState.RightClickMenu && !(time > 0f) && UICamera.currentTouchID >= -1 && isEnabled)
 			{
 				switch (base.name)
 				{

--- a/Assets.Scripts.UI.Prompt/PromptButton.cs
+++ b/Assets.Scripts.UI.Prompt/PromptButton.cs
@@ -22,7 +22,7 @@ namespace Assets.Scripts.UI.Prompt
 
 		private void OnClick()
 		{
-			if (isEnabled && GameSystem.Instance.GameState == GameState.DialogPrompt && !(time > 0f) && UICamera.currentTouchID == -1)
+			if (isEnabled && GameSystem.Instance.GameState == GameState.DialogPrompt && !(time > 0f) && UICamera.currentTouchID >= -1)
 			{
 				switch (base.name)
 				{

--- a/Assets.Scripts.UI.SaveLoad/SaveLoadButton.cs
+++ b/Assets.Scripts.UI.SaveLoad/SaveLoadButton.cs
@@ -27,7 +27,7 @@ namespace Assets.Scripts.UI.SaveLoad
 			{
 				gameSystem = GameSystem.Instance;
 			}
-			if (gameSystem.GameState == GameState.SaveLoadScreen && !(time > 0f) && UICamera.currentTouchID == -1 && isEnabled)
+			if (gameSystem.GameState == GameState.SaveLoadScreen && !(time > 0f) && UICamera.currentTouchID >= -1 && isEnabled)
 			{
 				StateSaveLoad state = gameSystem.GetStateObject() as StateSaveLoad;
 				if (state != null)

--- a/Assets.Scripts.UI.Tips/TipsButton.cs
+++ b/Assets.Scripts.UI.Tips/TipsButton.cs
@@ -39,7 +39,7 @@ namespace Assets.Scripts.UI.Tips
 				return;
 			}
 			GameSystem instance = GameSystem.Instance;
-			if (instance.GameState == GameState.TipsScreen && isEnabled && manager.isActive && UICamera.currentTouchID == -1)
+			if (instance.GameState == GameState.TipsScreen && isEnabled && manager.isActive && UICamera.currentTouchID >= -1)
 			{
 				StateViewTips stateViewTips = instance.GetStateObject() as StateViewTips;
 				if (stateViewTips != null)

--- a/Assets.Scripts.UI.Tips/TipsEntry.cs
+++ b/Assets.Scripts.UI.Tips/TipsEntry.cs
@@ -46,7 +46,7 @@ namespace Assets.Scripts.UI.Tips
 
 		private void OnClick()
 		{
-			if (UICamera.currentTouchID == -1 && tip != null && manager.isActive && GameSystem.Instance.GameState == GameState.TipsScreen)
+			if (UICamera.currentTouchID >= -1 && tip != null && manager.isActive && GameSystem.Instance.GameState == GameState.TipsScreen)
 			{
 				(GameSystem.Instance.GetStateObject() as StateViewTips)?.OpenTips(tip.Script);
 			}

--- a/Assets.Scripts.UI.TitleScreen/TitleScreenButton.cs
+++ b/Assets.Scripts.UI.TitleScreen/TitleScreenButton.cs
@@ -31,7 +31,7 @@ namespace Assets.Scripts.UI.TitleScreen
 
 			if(gameSystem.MODIgnoreInputs()) { return; }
 
-			if (gameSystem.GameState == GameState.TitleScreen && !(time > 0f) && UICamera.currentTouchID == -1)
+			if (gameSystem.GameState == GameState.TitleScreen && !(time > 0f) && UICamera.currentTouchID >= -1)
 			{
 				StateTitle stateTitle = gameSystem.GetStateObject() as StateTitle;
 				if (stateTitle != null)

--- a/Assets.Scripts.UI/SlideBoxButton.cs
+++ b/Assets.Scripts.UI/SlideBoxButton.cs
@@ -17,7 +17,7 @@ namespace Assets.Scripts.UI
 
 		private void OnClick()
 		{
-			if (UICamera.currentTouchID == -1 && !(cooldown > 0f))
+			if (UICamera.currentTouchID >= -1 && !(cooldown > 0f))
 			{
 				switch (Type)
 				{

--- a/ConfigButton.cs
+++ b/ConfigButton.cs
@@ -11,7 +11,7 @@ public class ConfigButton : MonoBehaviour
 
 	private void OnClick()
 	{
-		if (!(cooldown > 0f) && UICamera.currentTouchID == -1)
+		if (!(cooldown > 0f) && UICamera.currentTouchID >= -1)
 		{
 			switch (base.name)
 			{


### PR DESCRIPTION
## Problem

A user reported that touchscreen doesn't work properly with the mod.

When you try to click a button on the title menu, it would flash as if you hovered over it, but would not do anything.

Only certain buttons (which turned out to be NGUI based) have this issue.

I tested and this issue happens even on the unmodded game (as I expected, as we have not modified input handling much in our mod)

## Reason

This is because the input handling for NGUI based buttons in the game code first checks whether it is a left click, via the UICamera.currentTouchID variable with the code `UICamera.currentTouchID == -1` (-1 indicates mouse left click)

For example:
```
private void OnClick()
{
    if (UICamera.currentTouchID == -1 && !(cooldown > 0f))
    {
...
```

However, when you touch a touchscreen, it returns a zero-or-higher number (eg 0,1,2,3 ...) representing the "fingerID". This causes the touch to be ignored.

See https://docs.unity3d.com/ScriptReference/Touch-fingerId.html

You're supposed to use this fingerID as in index to lookup the properties of the current touch

## Fix

Changing to `UICamera.currentTouchID >= -1` should allow both mouse left clicks, and any touches to activate NGUI buttons.

However there may be other places in the code which have similar problems, I haven't checked or tested it.

## NGUI `UICamera.currentTouchID` mapping

I think the mapping of the `UICamera.currentTouchID` variable (from NGUI) is something like:

-3 = middle mouse
-2 = right mouse click
-1 = left mouse click
0 = touch index 0
1 = touch index 1
etc...
