### PR TITLE
Add Mod Menu Localization

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -239,6 +239,7 @@
     <Compile Include="MOD.Scripts.Core.State\StateMovie.cs" />
     <Compile Include="MOD.Scripts.Core.TextWindow\MODTextController.cs" />
     <Compile Include="MOD.Scripts.Core\MODLocalization.cs" />
+    <Compile Include="MOD.Scripts.Core\MODLocalizationData.cs" />
     <Compile Include="MOD.Scripts.Core\MODLogger.cs" />
     <Compile Include="MOD.Scripts.Core\MODSystem.cs" />
     <Compile Include="MOD.Scripts.Core\MODUtility.cs" />

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -12,7 +12,7 @@ using Assets.Scripts.UI.CGGallery;
 using Assets.Scripts.UI.Choice;
 using Assets.Scripts.UI.Config;
 using Assets.Scripts.UI.Prompt;
-using MOD.Scripts.Core;
+using MOD.Scripts.Core.Localization;
 using MOD.Scripts.UI;
 using System;
 using System.Collections;

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -232,7 +232,7 @@ namespace Assets.Scripts.Core
 		{
 			Logger.Log($"GameSystem: Starting GameSystem - DLL Version: {MODUtility.InformationalVersion()}");
 			MainUIController.InitializeToaster();
-			MODLocalization.LoadFromJSON();
+			Loc.LoadFromJSON();
 			IsInitialized = true;
 			AssetManager = new AssetManager();
 			AudioController = new AudioController();

--- a/Assets.Scripts.UI.SaveLoad/SaveLoadButton.cs
+++ b/Assets.Scripts.UI.SaveLoad/SaveLoadButton.cs
@@ -4,6 +4,7 @@ using Assets.Scripts.Core.Audio;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
 using Assets.Scripts.UI.Prompt;
+using MOD.Scripts.Core.Localization;
 using System.IO;
 using UnityEngine;
 
@@ -67,7 +68,7 @@ namespace Assets.Scripts.UI.SaveLoad
 							{
 								string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(d.Path);
 								Texture2D image = AssetManager.Instance.LoadScreenshot(fileNameWithoutExtension + ".png");
-								promptController.SetScreenshotDetails(image, d.Time.ToString("ddd MMM dd, yyyy h:mm tt"), d.Text, d.TextJp);
+								promptController.SetScreenshotDetails(image, d.Time.ToString(Loc.dateTimeFormat, Loc.cultureInfo), d.Text, d.TextJp);
 							}
 						});
 						gameSystem.ExecuteActions();
@@ -92,7 +93,7 @@ namespace Assets.Scripts.UI.SaveLoad
 							{
 								string fileNameWithoutExtension2 = Path.GetFileNameWithoutExtension(d2.Path);
 								Texture2D image2 = AssetManager.Instance.LoadScreenshot(fileNameWithoutExtension2 + ".png");
-								promptController2.SetScreenshotDetails(image2, d2.Time.ToString("ddd MMM dd, yyyy h:mm tt"), d2.Text, d2.TextJp);
+								promptController2.SetScreenshotDetails(image2, d2.Time.ToString(Loc.dateTimeFormat, Loc.cultureInfo), d2.Text, d2.TextJp);
 							}
 						});
 						gameSystem.ExecuteActions();
@@ -118,7 +119,7 @@ namespace Assets.Scripts.UI.SaveLoad
 							{
 								string fileNameWithoutExtension3 = Path.GetFileNameWithoutExtension(d3.Path);
 								Texture2D image3 = AssetManager.Instance.LoadScreenshot(fileNameWithoutExtension3 + ".png");
-								promptController3.SetScreenshotDetails(image3, d3.Time.ToString("ddd MMM dd, yyyy h:mm tt"), d3.Text, d3.TextJp);
+								promptController3.SetScreenshotDetails(image3, d3.Time.ToString(Loc.dateTimeFormat, Loc.cultureInfo), d3.Text, d3.TextJp);
 							}
 						});
 						break;

--- a/Assets.Scripts.UI.SaveLoad/SaveLoadManager.cs
+++ b/Assets.Scripts.UI.SaveLoad/SaveLoadManager.cs
@@ -2,6 +2,7 @@ using Assets.Scripts.Core;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
 using Assets.Scripts.UI.Prompt;
+using MOD.Scripts.Core.Localization;
 using System;
 using System.Collections;
 using UnityEngine;
@@ -90,7 +91,7 @@ namespace Assets.Scripts.UI.SaveLoad
 							DateTime now = DateTime.Now;
 							string fullText = GameSystem.Instance.TextController.GetFullText(1);
 							string fullText2 = GameSystem.Instance.TextController.GetFullText(0);
-							p.SetScreenshotDetails(tex, now.ToString("ddd MMM dd, yyyy h:mm tt"), fullText, fullText2);
+							p.SetScreenshotDetails(tex, now.ToString(Loc.dateTimeFormat, Loc.cultureInfo), fullText, fullText2);
 						});
 					}
 				});

--- a/Assets.Scripts.UI.SaveLoad/SaveLoadQSave.cs
+++ b/Assets.Scripts.UI.SaveLoad/SaveLoadQSave.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Core.Buriko;
+using MOD.Scripts.Core.Localization;
 using UnityEngine;
 
 namespace Assets.Scripts.UI.SaveLoad
@@ -15,11 +16,13 @@ namespace Assets.Scripts.UI.SaveLoad
 
 		private bool isEnabled = true;
 
+
+
 		public void EnableEntry(SaveEntry entry)
 		{
 			SaveButton.isEnabled = false;
 			LoadButton.isEnabled = true;
-			BottomLabel.text = entry.Time.ToString("MMM dd, yyyy h:mm tt");
+			BottomLabel.text = entry.Time.ToString(Loc.dateTimeFormat, Loc.cultureInfo);
 			// Save button is never useful so hide it
 			SaveButton.gameObject.SetActive(false);
 		}

--- a/Assets.Scripts.UI/SlideBoxButton.cs
+++ b/Assets.Scripts.UI/SlideBoxButton.cs
@@ -4,6 +4,7 @@ using Assets.Scripts.Core.Audio;
 using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
 using Assets.Scripts.UI.Prompt;
+using MOD.Scripts.Core.Localization;
 using System.IO;
 using UnityEngine;
 
@@ -67,7 +68,7 @@ namespace Assets.Scripts.UI
 							Texture2D image = AssetManager.Instance.LoadScreenshot(fileNameWithoutExtension + ".png");
 							Debug.Log(promptController);
 							Debug.Log(d);
-							promptController.SetScreenshotDetails(image, d.Time.ToString("ddd MMM dd, yyyy h:mm tt"), d.Text, d.TextJp);
+							promptController.SetScreenshotDetails(image, d.Time.ToString(Loc.dateTimeFormat, Loc.cultureInfo), d.Text, d.TextJp);
 						}
 					});
 					GameSystem.Instance.ExecuteActions();

--- a/MOD.Scripts.Core/MODLocalization.cs
+++ b/MOD.Scripts.Core/MODLocalization.cs
@@ -24,7 +24,7 @@ namespace MOD.Scripts.Core
 		}
 	}
 
-	public class MODLocalization
+	public class Loc
 	{
 		private static bool initializeAttempted;
 		private static readonly LocalizationEntry notInitializedEntry;
@@ -32,7 +32,7 @@ namespace MOD.Scripts.Core
 		private static readonly LocalizationInfo fallbackInfo;
 		private static LocalizationInfo info;
 
-		static MODLocalization()
+		static Loc()
 		{
 			// This entry is shown if you try to access this class too early (before GameSystem has inititalized).
 			notInitializedEntry = new LocalizationEntry()

--- a/MOD.Scripts.Core/MODLocalization.cs
+++ b/MOD.Scripts.Core/MODLocalization.cs
@@ -14,7 +14,20 @@ namespace MOD.Scripts.Core.Localization
 
 		public string comment = defaultValue;
 		public string text = defaultValue;
-		public string textJP = defaultValue;
+
+		// Japanese Mode Note: For now, if no japanese text specified, just use the english text instead.
+		private string _textJP = null;
+		public string textJP
+		{
+			get
+			{
+				return _textJP ?? text;
+			}
+			set
+			{
+				_textJP = value;
+			}
+		}
 
 		public bool TextHasValue() => text != null && text != defaultValue;
 	}
@@ -48,14 +61,12 @@ namespace MOD.Scripts.Core.Localization
 			{
 				comment = "This shows if LoadFromJSON() has not been called yet",
 				text = "#NOT INITIALIZED#",
-				textJP = "#NOT INITIALIZED#",
 			};
 
 			defaultEntry = new LocalizationEntry()
 			{
 				comment = "This localization entry is missing!",
 				text = "#TEXT MISSING#",
-				textJP = "#TEXT MISSING#",
 			};
 
 			info = new LocalizationInfo();
@@ -81,7 +92,7 @@ namespace MOD.Scripts.Core.Localization
 
 		private static void addFallbackEntry(string name, string text)
 		{
-			addFallbackEntry(name, "#TEXT MISSING#", text, "#JP TEXT MISSING#");
+			addFallbackEntry(name, "#TEXT MISSING#", text, null);
 		}
 
 		private static LocalizationEntry GetEntry(string name)

--- a/MOD.Scripts.Core/MODLocalization.cs
+++ b/MOD.Scripts.Core/MODLocalization.cs
@@ -4,14 +4,19 @@ using System.IO;
 using UnityEngine;
 using Assets.Scripts.Core;
 using MOD.Scripts.UI;
+using System.Globalization;
 
-namespace MOD.Scripts.Core
+namespace MOD.Scripts.Core.Localization
 {
 	public class LocalizationEntry
 	{
-		public string comment;
-		public string text;
-		public string textJP;
+		public const string defaultValue = "#NOT SET#";
+
+		public string comment = defaultValue;
+		public string text = defaultValue;
+		public string textJP = defaultValue;
+
+		public bool TextHasValue() => text != null && text != defaultValue;
 	}
 
 	public class LocalizationInfo
@@ -24,13 +29,17 @@ namespace MOD.Scripts.Core
 		}
 	}
 
-	public class Loc
+	public partial class Loc
 	{
 		private static bool initializeAttempted;
 		private static readonly LocalizationEntry notInitializedEntry;
 		private static readonly LocalizationEntry defaultEntry;
 		private static readonly LocalizationInfo fallbackInfo;
 		private static LocalizationInfo info;
+
+		// These are used when displaying datetimes (eg d.Time.ToString(Loc.DateTimeFormat, Loc.cultureInfo))
+		public static CultureInfo cultureInfo = CultureInfo.CurrentCulture;
+		public static string dateTimeFormat = "ddd MMM dd, yyyy h:mm tt";
 
 		static Loc()
 		{
@@ -52,16 +61,6 @@ namespace MOD.Scripts.Core
 			info = new LocalizationInfo();
 			fallbackInfo = new LocalizationInfo();
 
-			void addFallbackEntry(string name, string comment, string text, string textJP)
-			{
-				fallbackInfo.allChapters[name] = new LocalizationEntry()
-				{
-					comment = comment,
-					text = text,
-					textJP = textJP,
-				};
-			}
-
 			addFallbackEntry(
 				name: "no-tips-available",
 				comment: "This text appears at the top of the tips menu when there are no tips available",
@@ -70,30 +69,66 @@ namespace MOD.Scripts.Core
 			);
 		}
 
+		private static void addFallbackEntry(string name, string comment, string text, string textJP)
+		{
+			fallbackInfo.allChapters[name] = new LocalizationEntry()
+			{
+				comment = comment,
+				text = text,
+				textJP = textJP,
+			};
+		}
+
+		private static void addFallbackEntry(string name, string text)
+		{
+			addFallbackEntry(name, "#TEXT MISSING#", text, "#JP TEXT MISSING#");
+		}
+
 		private static LocalizationEntry GetEntry(string name)
 		{
-			if(!initializeAttempted)
+			bool _ = GetEntry(name, out LocalizationEntry entry);
+			return entry;
+		}
+
+		// Returns true if any entry was found at all (even if it was a fallback entry)
+		// Returns false if no entry was found, or if not yet initialized (entry will
+		// be populated with the 'default' entry showing #TEXT MISSING# or #NOT INITIALIZED# correspondingly)
+		public static bool GetEntry(string name, out LocalizationEntry entry)
+		{
+			if (!initializeAttempted)
 			{
-				return notInitializedEntry;
+				entry = notInitializedEntry;
+				return false;
 			}
 
-			if (info.allChapters.TryGetValue(name, out LocalizationEntry entry))
+			if (info.allChapters.TryGetValue(name, out entry))
 			{
-				return entry;
+				return true;
 			}
 
-			if (fallbackInfo.allChapters.TryGetValue(name, out LocalizationEntry fallbackEntry))
+			if (fallbackInfo.allChapters.TryGetValue(name, out entry))
 			{
-				return fallbackEntry;
+				return true;
 			}
 
-			return defaultEntry;
+			entry = defaultEntry;
+			return false;
+		}
+
+		public static string Get(string name, string defaultValue)
+		{
+			if(!GetEntry(name, out LocalizationEntry entry) && !string.IsNullOrEmpty(defaultValue))
+			{
+				addFallbackEntry(name, defaultValue);
+				entry = GetEntry(name);
+			}
+
+			return GameSystem.Instance.UseEnglishText ? entry.text : entry.textJP;
 		}
 
 		public static string Get(string name)
 		{
-			LocalizationEntry entry = GetEntry(name);
-			return GameSystem.Instance.UseEnglishText ? entry.text : entry.textJP;
+			return Get(name, null);
 		}
 
 		public static void LoadFromJSON()
@@ -118,6 +153,31 @@ namespace MOD.Scripts.Core
 			{
 				Debug.LogError($"MODLocalizationController(): Failed to read localization file at [{localizationPath}]: {e.Message}");
 				MODToaster.Show("localization.json fail - check logs");
+			}
+
+			try
+			{
+				if (Loc.GetEntry("CultureInfo", out LocalizationEntry localizationEntry))
+				{
+					// Make sure a value for 'text' is provided before using it
+					if (localizationEntry.TextHasValue())
+					{
+						Loc.cultureInfo = new CultureInfo(localizationEntry.text);
+					}
+				}
+
+				if (Loc.GetEntry("DateTimeFormat", out LocalizationEntry timeFormatEntry))
+				{
+					if (timeFormatEntry.TextHasValue())
+					{
+						Loc.dateTimeFormat = timeFormatEntry.text;
+					}
+				}
+			}
+			catch (System.Exception e)
+			{
+				Debug.LogError($"MODLocalizationController(): Failed to set CultureInfo or DateTimeFormat: {e.Message}");
+				MODToaster.Show("localization.json cultureInfo fail - check logs");
 			}
 		}
 	}

--- a/MOD.Scripts.Core/MODLocalizationData.cs
+++ b/MOD.Scripts.Core/MODLocalizationData.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MOD.Scripts.Core.Localization
+{
+	public partial class Loc
+	{
+		// Note: The default strings here are only used if the localization.json file is missing from the game folder (As of 2023-10-15, our mod does not ship with a localization.json file.
+		// For an example of this file, see the tools/localization.json file.
+
+		// The below entries are for the F10 mod menu, in the file MOD.Scripts.UI/MODMenu.cs. NOTE: some of these are the debug menu strings.
+		public static string MODMenu_0 => Get("MODMenu_0", "[Audio Tracking] - indicates what would play on each BGM flow");
+		public static string MODMenu_1 => Get("MODMenu_1", "[Audio Flags and last played audio]");
+		public static string MODMenu_2 => Get("MODMenu_2", "Reset GAudioSet");
+		public static string MODMenu_3 => Get("MODMenu_3", "Set GAudioSet to 0, to force the game to do audio setup on next startup");
+		public static string MODMenu_4 => Get("MODMenu_4", "Close");
+		public static string MODMenu_5 => Get("MODMenu_5", "Close the debug menu");
+		public static string MODMenu_6 => Get("MODMenu_6", "Developer Debug Window (click to drag)");
+		public static string MODMenu_7 => Get("MODMenu_7", "Mod Menu\n(Hotkey: F10)");
+		public static string MODMenu_8 => Get("MODMenu_8", "BGM Info");
+		public static string MODMenu_9 => Get("MODMenu_9", "Copy BGM Name");
+		public static string MODMenu_10 => Get("MODMenu_10", "Show File");
+		public static string MODMenu_11 => Get("MODMenu_11", "Open In Youtube");
+		public static string MODMenu_12 => Get("MODMenu_12", "Note: If explorer freezes\nuninstall Web Media Extensions");
+		public static string MODMenu_13 => Get("MODMenu_13", "X");
+		public static string MODMenu_14 => Get("MODMenu_14", "Close the Mod menu");
+		public static string MODMenu_15 => Get("MODMenu_15", "Please close the current menu and try again");
+		public static string MODMenu_16 => Get("MODMenu_16", "It looks like there was a problem starting up\n\nPlease send the developers your log file (output_log.txt or Player.log).\n\nYou can try the following yourself to fix the issue.\n  1. Try waiting 30 seconds for the game to progress. If nothing happens, try restarting the game\n\n  2. Use the buttons under 'Troubleshooting' on the bottom left to show your save files, log files, and compiled scripts.\n\n  3. If the log indicates you have corrupt save files, you may wish to delete the offending save file (or all of them).\n\n  4. You can try to clear your compiled script files, then restart the game.\n\n  5. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.");
+
+		// Most of the localization for the F10 menu
+		public static string MODMenuNormal_0 => Get("MODMenuNormal_0", "Lip Sync for Console Sprites (Hotkey: 7)");
+		public static string MODMenuNormal_1 => Get("MODMenuNormal_1", "Lip Sync (NOTE: Select 'Console' sprites or preset to enable)");
+		public static string MODMenuNormal_2 => Get("MODMenuNormal_2", "Console");
+		public static string MODMenuNormal_3 => Get("MODMenuNormal_3", "Use the Console sprites");
+		public static string MODMenuNormal_4 => Get("MODMenuNormal_4", "MangaGamer");
+		public static string MODMenuNormal_5 => Get("MODMenuNormal_5", "Use Mangagamer's remake sprites");
+		public static string MODMenuNormal_6 => Get("MODMenuNormal_6", "Original");
+		public static string MODMenuNormal_7 => Get("MODMenuNormal_7", "Use Original/Ryukishi sprites");
+		public static string MODMenuNormal_8 => Get("MODMenuNormal_8", "Voice Matching Level (Hotkey: F2)");
+		public static string MODMenuNormal_9 => Get("MODMenuNormal_9", "Censorship level 0 - Equivalent to PC");
+		public static string MODMenuNormal_10 => Get("MODMenuNormal_10", "Censorship level 1");
+		public static string MODMenuNormal_11 => Get("MODMenuNormal_11", "Censorship level 2 (this is the default/recommended value)");
+		public static string MODMenuNormal_12 => Get("MODMenuNormal_12", "Censorship level 3");
+		public static string MODMenuNormal_13 => Get("MODMenuNormal_13", "Censorship level 4");
+		public static string MODMenuNormal_14 => Get("MODMenuNormal_14", "Censorship level 5 - Equivalent to Console");
+		public static string MODMenuNormal_15 => Get("MODMenuNormal_15", "Lip Sync Off");
+		public static string MODMenuNormal_16 => Get("MODMenuNormal_16", "Disables Lip Sync for Console Sprites");
+		public static string MODMenuNormal_17 => Get("MODMenuNormal_17", "Lip Sync On");
+		public static string MODMenuNormal_18 => Get("MODMenuNormal_18", "Enables Lip Sync for Console Sprites");
+		public static string MODMenuNormal_19 => Get("MODMenuNormal_19", "Lip Sync Off (Inactive)");
+		public static string MODMenuNormal_20 => Get("MODMenuNormal_20", "Disables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites");
+		public static string MODMenuNormal_21 => Get("MODMenuNormal_21", "Lip Sync On (Inactive)");
+		public static string MODMenuNormal_22 => Get("MODMenuNormal_22", "Enables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites");
+		public static string MODMenuNormal_23 => Get("MODMenuNormal_23", "Opening Movies (Hotkey: Shift-F12)");
+		public static string MODMenuNormal_24 => Get("MODMenuNormal_24", "Disabled");
+		public static string MODMenuNormal_25 => Get("MODMenuNormal_25", "Disables all opening videos");
+		public static string MODMenuNormal_26 => Get("MODMenuNormal_26", "Enabled");
+		public static string MODMenuNormal_27 => Get("MODMenuNormal_27", "Enables opening videos\n\nNOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\nWe have setup openings this way to avoid spoilers.");
+		public static string MODMenuNormal_28 => Get("MODMenuNormal_28", "Launch + In-Game");
+		public static string MODMenuNormal_29 => Get("MODMenuNormal_29", "WARNING: There is usually no need to set this manually.\n\nIf openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\nThat is, after the opening is played the first time, from then on openings will play every time the game launches");
+		public static string MODMenuNormal_30 => Get("MODMenuNormal_30", "Show/Hide CGs");
+		public static string MODMenuNormal_31 => Get("MODMenuNormal_31", "Show CGs");
+		public static string MODMenuNormal_32 => Get("MODMenuNormal_32", "Shows CGs (You probably want this enabled for Console ADV/NVL mode)");
+		public static string MODMenuNormal_33 => Get("MODMenuNormal_33", "Hide CGs");
+		public static string MODMenuNormal_34 => Get("MODMenuNormal_34", "Disables all CGs (mainly for use with the Original/Ryukishi preset)");
+		public static string MODMenuNormal_35 => Get("MODMenuNormal_35", "Background Style");
+		public static string MODMenuNormal_36 => Get("MODMenuNormal_36", "Console BGs");
+		public static string MODMenuNormal_37 => Get("MODMenuNormal_37", "Use Console backgrounds");
+		public static string MODMenuNormal_38 => Get("MODMenuNormal_38", "Original BGs");
+		public static string MODMenuNormal_39 => Get("MODMenuNormal_39", "Use Original/Ryukishi backgrounds.");
+		public static string MODMenuNormal_40 => Get("MODMenuNormal_40", "Background Stretching");
+		public static string MODMenuNormal_41 => Get("MODMenuNormal_41", "BG Stretching Off");
+		public static string MODMenuNormal_42 => Get("MODMenuNormal_42", "Makes backgrounds as big as possible without any stretching (Keep Aspect Ratio)");
+		public static string MODMenuNormal_43 => Get("MODMenuNormal_43", "BG Stretching On");
+		public static string MODMenuNormal_44 => Get("MODMenuNormal_44", "Stretches backgrounds to fit the screen (Ignore Aspect Ratio)\n\nMainly for use with the Original BGs, which are in 4:3 aspect ratio.");
+		public static string MODMenuNormal_45 => Get("MODMenuNormal_45", "Sprite Style");
+		public static string MODMenuNormal_46 => Get("MODMenuNormal_46", "Text Window Appearance");
+		public static string MODMenuNormal_47 => Get("MODMenuNormal_47", "ADV Mode");
+		public static string MODMenuNormal_48 => Get("MODMenuNormal_48", "This option:\n- Makes text show at the bottom of the screen in a textbox\n- Shows the name of the current character on the textbox\n");
+		public static string MODMenuNormal_49 => Get("MODMenuNormal_49", "NVL Mode");
+		public static string MODMenuNormal_50 => Get("MODMenuNormal_50", "This option:\n- Makes text show across the whole screen\n");
+		public static string MODMenuNormal_51 => Get("MODMenuNormal_51", "Original");
+		public static string MODMenuNormal_52 => Get("MODMenuNormal_52", "This option:\n- Darkens the whole screen to emulate the original game\n- Makes text show only in a 4:3 section of the screen (narrower than NVL mode)\n");
+		public static string MODMenuNormal_53 => Get("MODMenuNormal_53", "Force Computed Lipsync");
+		public static string MODMenuNormal_54 => Get("MODMenuNormal_54", "As Fallback");
+		public static string MODMenuNormal_55 => Get("MODMenuNormal_55", "Only use computed lipsync if there is no baked 'spectrum' file for a given .ogg file");
+		public static string MODMenuNormal_56 => Get("MODMenuNormal_56", "Computed Always");
+		public static string MODMenuNormal_57 => Get("MODMenuNormal_57", "Always use computed lipsync for all voices. Any 'spectrum' files will be ignored.");
+		public static string MODMenuNormal_58 => Get("MODMenuNormal_58", "Gameplay");
+		public static string MODMenuNormal_59 => Get("MODMenuNormal_59", "Voice Matching and Opening Videos");
+		public static string MODMenuNormal_60 => Get("MODMenuNormal_60", "Graphics");
+		public static string MODMenuNormal_61 => Get("MODMenuNormal_61", "Sprites, Backgrounds, CGs, Resolution");
+		public static string MODMenuNormal_62 => Get("MODMenuNormal_62", "Audio");
+		public static string MODMenuNormal_63 => Get("MODMenuNormal_63", "BGM and SE options");
+		public static string MODMenuNormal_64 => Get("MODMenuNormal_64", "Troubleshooting");
+		public static string MODMenuNormal_65 => Get("MODMenuNormal_65", "Tools to help you if something goes wrong");
+		public static string MODMenuNormal_66 => Get("MODMenuNormal_66", "Original/Ryukishi Experimental 4:3 Aspect Ratio");
+		public static string MODMenuNormal_67 => Get("MODMenuNormal_67", "16:9 (default)");
+		public static string MODMenuNormal_68 => Get("MODMenuNormal_68", "The game's aspect ratio will be 16:9.\n\nWhen playing in OG mode, the left and right of the screen will be padded to 4:3 with black bars.");
+		public static string MODMenuNormal_69 => Get("MODMenuNormal_69", "The game's aspect ratio will be 4:3, however this may cause some issues when playing our mod.\nOnly use this option if your monitor is 4:3 aspect ratio, like an old CRT monitor.\n\nPlease note the following:\n\n - You should enable the Original/Ryukishi preset before enabling this option. Using other settings should all work, but are not well tested.\n\n - 16:9 images will be squished to fit in 4:3 so they don't get cut off. This includes text images, and PS3 CG images if enabled.\n\n - You may see graphical artifacts just after this is enabled - they should fix after the next character transition or text clear\n\n");
+		public static string MODMenuNormal_70 => Get("MODMenuNormal_70", "Graphics Presets (Hotkey: F1)");
+		public static string MODMenuNormal_71 => Get("MODMenuNormal_71", "Console");
+		public static string MODMenuNormal_72 => Get("MODMenuNormal_72", "This preset:\n- Makes text show at the bottom of the screen in a textbox\n- Shows the name of the current character on the textbox\n- Uses the console sprites (with lipsync) and console backgrounds\n- Displays in 16:9 widescreen\n\nNote that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available");
+		public static string MODMenuNormal_73 => Get("MODMenuNormal_73", "MangaGamer");
+		public static string MODMenuNormal_74 => Get("MODMenuNormal_74", "This preset:\n- Makes text show across the whole screen\n- Uses the Mangagamer remake sprites and Console backgrounds\n- Displays in 16:9 widescreen\n\nNote that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available");
+		public static string MODMenuNormal_75 => Get("MODMenuNormal_75", "Original/Ryukishi");
+		public static string MODMenuNormal_76 => Get("MODMenuNormal_76", "This preset makes the game behave similarly to the unmodded game:\n- Displays backgrounds in 4:3 'standard' aspect\n- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n- Switches to original sprites and backgrounds\n\nNote that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available");
+		public static string MODMenuNormal_77 => Get("MODMenuNormal_77", "Custom");
+		public static string MODMenuNormal_78 => Get("MODMenuNormal_78", "Your own custom preset, using the options below.\n\nThis custom preset will be saved, even when you switch to the other presets.");
+		public static string MODMenuNormal_79 => Get("MODMenuNormal_79", "Advanced Options");
+		public static string MODMenuNormal_80 => Get("MODMenuNormal_80", "WARNING: You have ADV mode enabled, but you are in a forced-NVL section, so the game will display in NVL mode temporarily!");
+		public static string MODMenuNormal_81 => Get("MODMenuNormal_81", "Resolution");
+		public static string MODMenuNormal_82 => Get("MODMenuNormal_82", "Advanced Options");
+		public static string MODMenuNormal_83 => Get("MODMenuNormal_83", "Experimental Gameplay Tools");
+		public static string MODMenuNormal_84 => Get("MODMenuNormal_84", "Game Clear Forced!");
+		public static string MODMenuNormal_85 => Get("MODMenuNormal_85", "All Progress Reset!");
+		public static string MODMenuNormal_86 => Get("MODMenuNormal_86", "Please reload menu/game!");
+		public static string MODMenuNormal_87 => Get("MODMenuNormal_87", "Reset All Progress");
+		public static string MODMenuNormal_88 => Get("MODMenuNormal_88", "Force Game Clear");
+		public static string MODMenuNormal_89 => Get("MODMenuNormal_89", "Click");
+		public static string MODMenuNormal_90 => Get("MODMenuNormal_90", "more times");
+		public static string MODMenuNormal_91 => Get("MODMenuNormal_91", "WARNING: This option will toggle your game clear status:\n - If you haven't finished the game, it will unlock everything.\n - If you have already finished the game, it will reset all your progress!\n\nThis toggles the EXTRAS menu, including all TIPS, and all chapter jump chapters.\n\nYou may need to reload the current menu or restart the game before you can see the changes.\n\nSaves shouldn't be affected.");
+		public static string MODMenuNormal_92 => Get("MODMenuNormal_92", "No");
+		public static string MODMenuNormal_93 => Get("MODMenuNormal_93", "Yes");
+		public static string MODMenuNormal_94 => Get("MODMenuNormal_94", "Game Cleared?: ");
+		public static string MODMenuNormal_95 => Get("MODMenuNormal_95", "Highest Chapter: ");
+		public static string MODMenuNormal_96 => Get("MODMenuNormal_96", "Developer Tools");
+		public static string MODMenuNormal_97 => Get("MODMenuNormal_97", "Developer Debug Menu");
+		public static string MODMenuNormal_98 => Get("MODMenuNormal_98", "Toggle debug menu (Shift-F9)");
+		public static string MODMenuNormal_99 => Get("MODMenuNormal_99", "Toggle the debug menu");
+		public static string MODMenuNormal_100 => Get("MODMenuNormal_100", "Toggle flag menu (Shift-F10)");
+		public static string MODMenuNormal_101 => Get("MODMenuNormal_101", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.");
+		public static string MODMenuNormal_102 => Get("MODMenuNormal_102", "Show Developer Tools: Only click if asked by developers");
+		public static string MODMenuNormal_103 => Get("MODMenuNormal_103", "Show the Developer Tools.\n\nOnly click this button if you're asked to by the developers.");
+		public static string MODMenuNormal_104 => Get("MODMenuNormal_104", "Flag Unlocks");
+		public static string MODMenuNormal_105 => Get("MODMenuNormal_105", "Toggle GFlag_GameClear is ");
+		public static string MODMenuNormal_106 => Get("MODMenuNormal_106", "Toggle the 'GFlag_GameClear' flag which is normally activated when you complete the game. Unlocks things like the All-cast review.");
+		public static string MODMenuNormal_107 => Get("MODMenuNormal_107", "Toggle GHighestChapter 0 <-> 999 | Is ");
+		public static string MODMenuNormal_108 => Get("MODMenuNormal_108", "Toggle the 'GHighestChapter' flag which indicates the highest chapter you have completed.\n\nWhen >= 1, unlocks the extras menu.\nAlso unlocks other things like which chapters are shown on the chapter jump menu, etc.");
+		public static string MODMenuNormal_109 => Get("MODMenuNormal_109", "Restart Pending");
+		public static string MODMenuNormal_110 => Get("MODMenuNormal_110", "Restore Settings");
+		public static string MODMenuNormal_111 => Get("MODMenuNormal_111", "ADV defaults");
+		public static string MODMenuNormal_112 => Get("MODMenuNormal_112", "This restores flags to the defaults for NVL mode\nNOTE: Requires you to relaunch the game 2 times to come into effect");
+		public static string MODMenuNormal_113 => Get("MODMenuNormal_113", "NVL defaults");
+		public static string MODMenuNormal_114 => Get("MODMenuNormal_114", "This restores flags to the defaults for NVL mode\nNOTE: Requires you to relaunch the game 2 times to come into effect");
+		public static string MODMenuNormal_115 => Get("MODMenuNormal_115", "Vanilla Defaults");
+		public static string MODMenuNormal_116 => Get("MODMenuNormal_116", "This restores flags to the same settings as the unmodded game.\nNOTE: Requires a relaunch to come into effect. After this, uninstall the mod.");
+		public static string MODMenuNormal_117 => Get("MODMenuNormal_117", "Cancel Pending Restore");
+		public static string MODMenuNormal_118 => Get("MODMenuNormal_118", "Click this to stop restoring defaults on next game launch");
+		public static string MODMenuNormal_119 => Get("MODMenuNormal_119", "Computed Lipsync Options");
+		public static string MODMenuNormal_120 => Get("MODMenuNormal_120", "LipSync Thresh 1: ");
+		public static string MODMenuNormal_121 => Get("MODMenuNormal_121", "Above this threshold, expression 1 will be used.\n\nBelow or equal to this threshold, expression 0 will be used.\n\nOnly saved until the game restarts");
+		public static string MODMenuNormal_122 => Get("MODMenuNormal_122", "LipSync Thresh 2: ");
+		public static string MODMenuNormal_123 => Get("MODMenuNormal_123", "Above this thireshold, expression 2 will be used\n\nOnly saved until the game restarts");
+		public static string MODMenuNormal_124 => Get("MODMenuNormal_124", "Set");
+		public static string MODMenuNormal_125 => Get("MODMenuNormal_125", "Tries to set the given lipsync thresholds\n\n");
+		public static string MODMenuNormal_126 => Get("MODMenuNormal_126", "Invalid thresholds - each threshold should be a value between 0 and 1");
+		public static string MODMenuNormal_127 => Get("MODMenuNormal_127", "Mod Options Menu");
+		public static string MODMenuNormal_128 => Get("MODMenuNormal_128", "\n\nSets the script censorship level\n- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.\n- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.\n  - 5: Use voiced lines from PS3 script as much as possible (censored at parts)\n  - 2: Default - most balanced option\n  - 0: Original PC Script with voices where it fits (fully uncensored), but uncensored scenes may be missing voices");
+		public static string MODMenuNormal_129 => Get("MODMenuNormal_129", "Hover over a button on the left panel for its description.\n\n[Vanilla Hotkeys]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF, Alt-Enter : FullScreen\nSpace : Hide Text\nL : Swap Language\n\n[MOD Hotkeys]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level (Not Used)\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Mod Menu\nM : Increase Voice Volume\nN : Decrease Voice Volume\nP : Cycle through art styles\n2 : Cycle through BGM/SE\n7 : Enable/Disable Lip-Sync\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MINN");
+
+		// The resolution part of the F10 menu
+		public static string MODMenuResolution_0 => Get("MODMenuResolution_0", "Set a custom fullscreen resolution\n\nUse this option only if the fullscreen resolution is detected incorrectly (such as on some Linux systems)\nYou can manually type in a resolution to use below.\n\nClick 'Clear Override' to let the game automatically determine the fullscreen resolution");
+		public static string MODMenuResolution_1 => Get("MODMenuResolution_1", "Windowed Resolution Settings");
+		public static string MODMenuResolution_2 => Get("MODMenuResolution_2", "480p");
+		public static string MODMenuResolution_3 => Get("MODMenuResolution_3", "Set resolution to 853 x 480");
+		public static string MODMenuResolution_4 => Get("MODMenuResolution_4", "720p");
+		public static string MODMenuResolution_5 => Get("MODMenuResolution_5", "Set resolution to 1280 x 720");
+		public static string MODMenuResolution_6 => Get("MODMenuResolution_6", "1080p");
+		public static string MODMenuResolution_7 => Get("MODMenuResolution_7", "Set resolution to 1920 x 1080");
+		public static string MODMenuResolution_8 => Get("MODMenuResolution_8", "1440p");
+		public static string MODMenuResolution_9 => Get("MODMenuResolution_9", "Set resolution to 2560 x 1440");
+		public static string MODMenuResolution_10 => Get("MODMenuResolution_10", "Set");
+		public static string MODMenuResolution_11 => Get("MODMenuResolution_11", "Sets a custom resolution - mainly for windowed mode.\n\nHeight set automatically to maintain 16:9 aspect ratio.");
+		public static string MODMenuResolution_12 => Get("MODMenuResolution_12", "Height too small - must be at least 480 pixels");
+		public static string MODMenuResolution_13 => Get("MODMenuResolution_13", "Height too big - must be less than 15360 pixels");
+		public static string MODMenuResolution_14 => Get("MODMenuResolution_14", "Click here to go Windowed to change these settings");
+		public static string MODMenuResolution_15 => Get("MODMenuResolution_15", "Toggle Fullscreen");
+		public static string MODMenuResolution_16 => Get("MODMenuResolution_16", "Go Fullscreen");
+		public static string MODMenuResolution_17 => Get("MODMenuResolution_17", "Toggle Fullscreen");
+		public static string MODMenuResolution_18 => Get("MODMenuResolution_18", "Off");
+		public static string MODMenuResolution_19 => Get("MODMenuResolution_19", "Fullscreen Resolution Override (Detected: ");
+		public static string MODMenuResolution_20 => Get("MODMenuResolution_20", " Override: ");
+		public static string MODMenuResolution_21 => Get("MODMenuResolution_21", "Width:");
+		public static string MODMenuResolution_22 => Get("MODMenuResolution_22", "Height:");
+		public static string MODMenuResolution_23 => Get("MODMenuResolution_23", "Click repeatedly to override");
+		public static string MODMenuResolution_24 => Get("MODMenuResolution_24", "Override Fullscreen Resolution");
+		public static string MODMenuResolution_25 => Get("MODMenuResolution_25", "Invalid Height");
+		public static string MODMenuResolution_26 => Get("MODMenuResolution_26", "Invalid Width");
+		public static string MODMenuResolution_27 => Get("MODMenuResolution_27", "Clear Override");
+		public static string MODMenuResolution_28 => Get("MODMenuResolution_28", "Height too small - must be at least 480 pixels");
+		public static string MODMenuResolution_29 => Get("MODMenuResolution_29", "Height too big - must be less than 15360 pixels");
+
+		// The below entries are for the audio options section of the F10 mod menu, in the file MOD.Scripts.UI/MODMenuAudioOptions.cs
+		public static string MODMenuAudioOptions_0 => Get("MODMenuAudioOptions_0", "Audio Presets (Hotkey: 2)");
+		public static string MODMenuAudioOptions_1 => Get("MODMenuAudioOptions_1", "Override SE");
+		public static string MODMenuAudioOptions_2 => Get("MODMenuAudioOptions_2", "Invalid BGM cascade");
+		public static string MODMenuAudioOptions_3 => Get("MODMenuAudioOptions_3", "Invalid SE cascade");
+		public static string MODMenuAudioOptions_4 => Get("MODMenuAudioOptions_4", " (NOT INSTALLED)");
+		public static string MODMenuAudioOptions_5 => Get("MODMenuAudioOptions_5", "\n\nWARNING: This audio set is not installed! You can try to run the installer again to update your mod with this option.\nYou're missing the BGM or SE folder in the StreamingAssets folder:");
+		public static string MODMenuAudioOptions_6 => Get("MODMenuAudioOptions_6", "Force enable the following sound effects (ignore preset SE): ");
+		public static string MODMenuAudioOptions_7 => Get("MODMenuAudioOptions_7", "The patch supports different Background Music (BGM) and Sound Effects(SE). Please click the button below for more information.");
+		public static string MODMenuAudioOptions_8 => Get("MODMenuAudioOptions_8", "Open BGM/SE FAQ: 07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/");
+		public static string MODMenuAudioOptions_9 => Get("MODMenuAudioOptions_9", "Click here to open the  Background Music (BGM) and Sound Effects (SE) FAQ in your browser.\n\nThe BGM/SE FAQ contains information on the settings below.");
+		public static string MODMenuAudioOptions_10 => Get("MODMenuAudioOptions_10", "https://07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/");
+		public static string MODMenuAudioOptions_11 => Get("MODMenuAudioOptions_11", "To continue, please choose a BGM/SE option below (hover button for info).\nYou can change this option later via the mod menu.");
+		public static string MODMenuAudioOptions_12 => Get("MODMenuAudioOptions_12", "Option Not Installed!");
+
+		// The below entries are for the audio setup optiosn which appear the first time you launch the game, in the file MOD.Scripts.UI/MODMenuAudioSetup.cs
+		public static string MODMenuAudioSetup_0 => Get("MODMenuAudioSetup_0", "Click here when you're finished.");
+		public static string MODMenuAudioSetup_1 => Get("MODMenuAudioSetup_1", "First-Time Setup Menu");
+		public static string MODMenuAudioSetup_2 => Get("MODMenuAudioSetup_2", "Please choose the options on the left before continuing. You can hover over a button to view its description.");
+
+		// The below entries are for the support section of the F10 mod menu, in the file MOD.Scripts.UI/MODMenuSupport.cs
+		public static string MODMenuSupport_0 => Get("MODMenuSupport_0", "Please hover over a button for more information");
+		public static string MODMenuSupport_1 => Get("MODMenuSupport_1", "Save Files and Log Files");
+		public static string MODMenuSupport_2 => Get("MODMenuSupport_2", "Show output_log.txt / Player.log");
+		public static string MODMenuSupport_3 => Get("MODMenuSupport_3", "This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n- This file records errors that occur during gameplay, and during game startup\n- This file helps when the game fails start, for example\n  - a corrupted save file\n  - the wrong UI (sharedassets0.assets) file\n- Note that each time the game starts up, the current log file is replaced");
+		public static string MODMenuSupport_4 => Get("MODMenuSupport_4", "Show Saves");
+		public static string MODMenuSupport_5 => Get("MODMenuSupport_5", "Click to open the save folder, which includes saves, quicksaves, and global save data\n\nClearing your save files can fix some issues with game startup, and resets all mod flags.\n\n- WARNING: Steam cloud will restore your saves if you manually delete them! Therefore, remember to disable steam cloud, otherwise your saves will magically reappear!\n- The 'global.dat' file stores your global unlock process and mod flags\n- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n- It's recommended to take a backup of all your saves before you modify them");
+		public static string MODMenuSupport_6 => Get("MODMenuSupport_6", "Quick Access to Game Folders");
+		public static string MODMenuSupport_7 => Get("MODMenuSupport_7", "Show .assets Folder");
+		public static string MODMenuSupport_8 => Get("MODMenuSupport_8", "Click to open the game's main data folder, which contains the .assets files.\n\nFonts, certain textures, and other game data is kept in the sharedassets0.assets file.");
+		public static string MODMenuSupport_9 => Get("MODMenuSupport_9", "Show StreamingAssets Folder");
+		public static string MODMenuSupport_10 => Get("MODMenuSupport_10", "Click to open the StreamingAssets folder, which contains most of the game assets.\n\n- Most Images/Textures, including Sprites, Backgrounds, Text Images, and Filter effects\n- Voices, Background Music, and Sound Effects\n- Game Scripts and Compiled Game Scripts\n- Movies\n- Other Misc Game Data");
+		public static string MODMenuSupport_11 => Get("MODMenuSupport_11", "Show DLL Folder");
+		public static string MODMenuSupport_12 => Get("MODMenuSupport_12", "Click to open the 'Managed' folder, which contains our modded 'Assembly-CSharp.dll'");
+		public static string MODMenuSupport_13 => Get("MODMenuSupport_13", "Managed");
+		public static string MODMenuSupport_14 => Get("MODMenuSupport_14", "Show Compiled Scripts");
+		public static string MODMenuSupport_15 => Get("MODMenuSupport_15", "Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\nYou can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\nPlease be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.");
+		public static string MODMenuSupport_16 => Get("MODMenuSupport_16", "Support Pages");
+		public static string MODMenuSupport_17 => Get("MODMenuSupport_17", "Open Support Page: 07th-mod.com/wiki/Higurashi/support");
+		public static string MODMenuSupport_18 => Get("MODMenuSupport_18", "If you have problems with the game, the information on this site may help.\n\nThere are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly");
+		public static string MODMenuSupport_19 => Get("MODMenuSupport_19", "https://07th-mod.com/wiki/Higurashi/support/");
+
+
+
+
+	}
+}

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -5,6 +5,7 @@ using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.State;
 using MOD.Scripts.Core;
 using MOD.Scripts.Core.Audio;
+using MOD.Scripts.Core.Localization;
 using MOD.Scripts.Core.State;
 using System;
 using System.Collections.Generic;
@@ -45,20 +46,7 @@ namespace MOD.Scripts.UI
 
 		string lastToolTip = String.Empty;
 
-		string startupFailureToolTip = @"It looks like there was a problem starting up
-
-Please send the developers your log file (output_log.txt or Player.log).
-
-You can try the following yourself to fix the issue.
-  1. Try waiting 30 seconds for the game to progress. If nothing happens, try restarting the game
-
-  2. Use the buttons under 'Troubleshooting' on the bottom left to show your save files, log files, and compiled scripts.
-
-  3. If the log indicates you have corrupt save files, you may wish to delete the offending save file (or all of them).
-
-  4. You can try to clear your compiled script files, then restart the game.
-
-  5. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.";
+		string startupFailureToolTip = Loc.MODMenu_16; //It looks like there was a problem starting up\n\nPlease send the developers your log file (output_log.txt or Player.log).\n\nYou can try the following yourself to fix the issue.\n  1. Try waiting 30 seconds for the game to progress. If nothing happens, try restarting the game\n\n  2. Use the buttons under 'Troubleshooting' on the bottom left to show your save files, log files, and compiled scripts.\n\n  3. If the log indicates you have corrupt save files, you may wish to delete the offending save file (or all of them).\n\n  4. You can try to clear your compiled script files, then restart the game.\n\n  5. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support.
 
 		bool showBGMButtonPressed;
 		Vector2 bgmInfoScrollPosition;
@@ -116,24 +104,21 @@ You can try the following yourself to fix the issue.
 			{
 				leftDebugColumnScrollPosition = GUILayout.BeginScrollView(leftDebugColumnScrollPosition, GUILayout.Width(Screen.width / 3), GUILayout.Height(Screen.height*9/10));
 			}
-			GUILayout.Label($"[Audio Tracking] - indicates what would play on each BGM flow", styleManager.Group.upperLeftHeadingLabel);
+			GUILayout.Label(Loc.MODMenu_0, styleManager.Group.upperLeftHeadingLabel); //[Audio Tracking] - indicates what would play on each BGM flow
 			GUILayout.Label($"{MODAudioTracking.Instance}", styleManager.Group.upperLeftHeadingLabel);
 
-			GUILayout.Label($"[Audio Flags and last played audio]", styleManager.Group.upperLeftHeadingLabel);
-			GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetDisplayName()})\n" +
-				"\n" +
+			GUILayout.Label(Loc.MODMenu_1, styleManager.Group.upperLeftHeadingLabel); //[Audio Flags and last played audio]
+			GUILayout.Label($"Audio Set: {GetGlobal("GAudioSet")} ({MODAudioSet.Instance.GetCurrentAudioSetDisplayName()})\n\n" +
 				$"AltBGM: {GetGlobal("GAltBGM")}\n" +
 				$"AltBGMFlow: {GetGlobal("GAltBGMflow")} ({MODAudioSet.Instance.GetBGMFlowName(GetGlobal("GAltBGMflow"))})\n" +
 				$"Last Played BGM: {AssetManager.Instance.debugLastBGM}\n" +
-				$"BGM Cascade: [{string.Join(":", BGMCascade.paths)}] ({BGMCascade.nameEN}) {(bgmFlagOK ? "" : "9Warning: Using default due to unknown flag)")}\n" +
-				"\n" +
+				$"BGM Cascade: [{string.Join(":", BGMCascade.paths)}] ({BGMCascade.nameEN}) {(bgmFlagOK ? "" : "9Warning: Using default due to unknown flag)")}\n\n" +
 				$"AltSE:  {GetGlobal("GAltSE")}\n" +
 				$"AltSEFlow: {GetGlobal("GAltSEflow")}\n" +
 				$"Last Played SE Path: {AssetManager.Instance.debugLastSE}\n" +
 				$"SE Cascade: [{string.Join(":", SECascade.paths)}] ({SECascade.nameEN}) {(seFlagOK ? "" : "(Warning: Using default due to unknown flag)")}\n" +
 				$"Voice: {GetGlobal("GAltVoice")}\n" +
-				$"Priority: {GetGlobal("GAltVoicePriority")}\n" +
-				"\n" +
+				$"Priority: {GetGlobal("GAltVoicePriority")}\n\n" +
 				$"Last Played Voice Path: {AssetManager.Instance.debugLastVoice}\n" +
 				$"Other Last Played Path: {AssetManager.Instance.debugLastOtherAudio}");
 
@@ -141,13 +126,13 @@ You can try the following yourself to fix the issue.
 
 			if (debug)
 			{
-				if(Button(new GUIContent("Reset GAudioSet", "Set GAudioSet to 0, to force the game to do audio setup on next startup")))
+				if(Button(new GUIContent(Loc.MODMenu_2, Loc.MODMenu_3))) //Reset GAudioSet | Set GAudioSet to 0, to force the game to do audio setup on next startup
 				{
 					SetGlobal("GAudioSet", 0);
 				}
 			}
 
-			if (Button(new GUIContent("Close", "Close the debug menu")))
+			if (Button(new GUIContent(Loc.MODMenu_4, Loc.MODMenu_5))) //Close | Close the debug menu
 			{
 				ToggleDebugMenu();
 			}
@@ -240,7 +225,7 @@ You can try the following yourself to fix the issue.
 
 			if (debug && AssetManager.Instance != null)
 			{
-				debugWindowRect = GUILayout.Window(DEBUG_WINDOW_ID, debugWindowRect, OnGUIDebugWindow, "Developer Debug Window (click to drag)", styleManager.modMenuAreaStyleLight);
+				debugWindowRect = GUILayout.Window(DEBUG_WINDOW_ID, debugWindowRect, OnGUIDebugWindow, Loc.MODMenu_6, styleManager.modMenuAreaStyleLight); //Developer Debug Window (click to drag)
 			}
 
 			GUI.depth = 0;
@@ -268,14 +253,14 @@ You can try the following yourself to fix the issue.
 			// (the normal settings screen that comes with the stock game)
 			if (gameSystem.GameState == GameState.ConfigScreen)
 			{
-				OnGUIConfigMenuButton("Mod Menu\n(Hotkey: F10)", gameSystem.ConfigManager()?.PanelAlpha(), () => this.Show());
+				OnGUIConfigMenuButton(Loc.MODMenu_7, gameSystem.ConfigManager()?.PanelAlpha(), () => this.Show()); //Mod Menu\n(Hotkey: F10)
 			}
 
 			if (!visible && gameSystem.GameState == GameState.RightClickMenu)
 			{
 				OnGUIRightClickMenuOverlay(gameSystem.MenuUIController()?.PanelAlpha(), () =>
 				{
-					HeadingLabel("BGM Info", alignLeft: true);
+					HeadingLabel(Loc.MODMenu_8, alignLeft: true); //BGM Info
 					GUILayout.Space(10);
 
 					// It is possible multiple BGM play at the same time (although secondary BGM are usually just background noises rather than actualBGM)
@@ -298,12 +283,12 @@ You can try the following yourself to fix the issue.
 						// Below the BGM name, add utility buttons, all one one line
 						GUILayout.BeginHorizontal(GUILayout.ExpandWidth(false));
 						{
-							if (ButtonNoExpandWithPadding($"Copy BGM Name"))
+							if (ButtonNoExpandWithPadding(Loc.MODMenu_9)) //Copy BGM Name
 							{
 								GUIUtility.systemCopyBuffer = bgmInfo.name.Trim();
 							}
 
-							if (ButtonNoExpandWithPadding($"Show File ({audioPath})"))
+							if (ButtonNoExpandWithPadding(Loc.MODMenu_10 + $" ({audioPath})")) //Show File
 							{
 								string bgmFullPath = Path.Combine(Application.streamingAssetsPath, audioPath);
 								showBGMButtonPressed = true;
@@ -312,7 +297,7 @@ You can try the following yourself to fix the issue.
 
 							if (!string.IsNullOrEmpty(bgmInfo.url))
 							{
-								if (ButtonNoExpandWithPadding("Open In Youtube"))
+								if (ButtonNoExpandWithPadding(Loc.MODMenu_11)) //Open In Youtube
 								{
 									Application.OpenURL($"https://www.youtube.com/watch?v={bgmInfo.url}");
 								}
@@ -329,7 +314,7 @@ You can try the following yourself to fix the issue.
 					// On Windows, add note about explorer .ogg file bug
 					if (showBGMButtonPressed && Application.platform == RuntimePlatform.WindowsPlayer)
 					{
-						Label("Note: If explorer freezes\nuninstall Web Media Extensions");
+						Label(Loc.MODMenu_12); //Note: If explorer freezes\nuninstall Web Media Extensions
 					}
 				});
 			}
@@ -429,7 +414,7 @@ You can try the following yourself to fix the issue.
 					if (currentMenu.UserCanClose())
 					{
 						GUILayout.BeginArea(new Rect(toolTipPosX + toolTipWidth - exitButtonWidth - innerMargin, innerMargin, exitButtonWidth, exitButtonHeight));
-						if (Button(new GUIContent("X", "Close the Mod menu")))
+						if (Button(new GUIContent(Loc.MODMenu_13, Loc.MODMenu_14))) //X | Close the Mod menu
 						{
 							this.UserHide();
 						}
@@ -486,7 +471,7 @@ You can try the following yourself to fix the issue.
 
 			if (gameSystem.GameState == GameState.SaveLoadScreen)
 			{
-				MODToaster.Show("Please close the current menu and try again");
+				MODToaster.Show(Loc.MODMenu_15); //Please close the current menu and try again
 			}
 			else if (gameSystem.GameState == GameState.ConfigScreen)
 			{

--- a/MOD.Scripts.UI/MODMenuAudioOptions.cs
+++ b/MOD.Scripts.UI/MODMenuAudioOptions.cs
@@ -1,4 +1,5 @@
 ﻿using MOD.Scripts.Core.Audio;
+using MOD.Scripts.Core.Localization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,8 +18,8 @@ namespace MOD.Scripts.UI
 		{
 			this.modMenu = m;
 
-			this.radioBGMSESet = new MODRadio("Audio Presets (Hotkey: 2)", new GUIContent[] { }, itemsPerRow: 2, asButtons: true);
-			this.radioSE = new MODRadio("Override SE", new GUIContent[] { },  itemsPerRow: 2);
+			this.radioBGMSESet = new MODRadio(Loc.MODMenuAudioOptions_0, new GUIContent[] { }, itemsPerRow: 2, asButtons: true); //Audio Presets (Hotkey: 2)
+			this.radioSE = new MODRadio(Loc.MODMenuAudioOptions_1, new GUIContent[] { },  itemsPerRow: 2); //Override SE
 		}
 
 		public void ReloadMenu()
@@ -34,21 +35,20 @@ namespace MOD.Scripts.UI
 				// Append message to button text/tooltip if audioSet is not installed
 				if (!audioSet.IsInstalledCached())
 				{
-					string bgmPrimaryInfo = "Invalid BGM cascade";
+					string bgmPrimaryInfo = Loc.MODMenuAudioOptions_2; //Invalid BGM cascade
 					if (audioSet.BGMCascade(out var bgmCascade) && bgmCascade.PrimaryFolder(out string bgmPrimary))
 					{
 						bgmPrimaryInfo = bgmPrimary;
 					}
 
-					string sePrimaryInfo = "Invalid SE cascade";
+					string sePrimaryInfo = Loc.MODMenuAudioOptions_3; //Invalid SE cascade
 					if (audioSet.SECascade(out var seCascade) && seCascade.PrimaryFolder(out string sePrimary))
 					{
 						sePrimaryInfo = sePrimary;
 					}
 
-					buttonText += " (NOT INSTALLED)";
-					tooltipText += $"\n\nWARNING: This audio set is not installed! You can try to run the installer again to update your mod with this option.\n" +
-						$"You're either missing the BGM folder '{bgmPrimaryInfo}' or the SE folder '{sePrimaryInfo}' in the StreamingAssets folder.";
+					buttonText += Loc.MODMenuAudioOptions_4; //(NOT INSTALLED)
+					tooltipText += Loc.MODMenuAudioOptions_5 + $" '{bgmPrimaryInfo}'/'{sePrimaryInfo}'"; //\n\nWARNING: This audio set is not installed! You can try to run the installer again to update your mod with this option.\nYou're missing the BGM or SE folder in the StreamingAssets folder:
 				}
 
 				buttonContents.Add(new GUIContent(buttonText, tooltipText));
@@ -58,7 +58,7 @@ namespace MOD.Scripts.UI
 
 			this.radioSE.SetContents(
 				MODAudioSet.Instance.SECascades.Select(
-					c => new GUIContent(c.nameEN, $"This allows you to use the '{c.nameEN}' sound effects, regardless of what the audio preset would use.")
+					c => new GUIContent(c.nameEN, Loc.MODMenuAudioOptions_6 + $"'{c.nameEN}'") //Force enable the following sound effects (ignore preset SE):
 				).ToArray()
 			);
 		}
@@ -72,7 +72,7 @@ namespace MOD.Scripts.UI
 		{
 			bool hideLabel = setupMenu;
 
-			Label("The patch supports different Background Music (BGM) and Sound Effects(SE). Please click the button below for more information.");
+			Label(Loc.MODMenuAudioOptions_7); //The patch supports different Background Music (BGM) and Sound Effects(SE). Please click the button below for more information.
 
 			// Add extra spacing on setup menu so it looks nicer
 			if(setupMenu)
@@ -80,17 +80,16 @@ namespace MOD.Scripts.UI
 				GUILayout.Space(20);
 			}
 
-			if (Button(new GUIContent("Open BGM/SE FAQ: 07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/", "Click here to open the  Background Music (BGM) and Sound Effects (SE) FAQ in your browser.\n\nThe BGM/SE FAQ contains information on the settings below.")))
+			if (Button(new GUIContent(Loc.MODMenuAudioOptions_8, Loc.MODMenuAudioOptions_9))) //Open BGM/SE FAQ: 07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/ | Click here to open the  Background Music (BGM) and Sound Effects (SE) FAQ in your browser.\n\nThe BGM/SE FAQ contains information on the settings below.
 			{
-				Application.OpenURL("https://07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/");
+				Application.OpenURL(Loc.MODMenuAudioOptions_10); //https://07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/
 			}
 
 			GUILayout.Space(20);
 
 			if (setupMenu)
 			{
-				Label("To continue, please choose a BGM/SE option below (hover button for info).\n" +
-					"You can change this option later via the mod menu.");
+				Label(Loc.MODMenuAudioOptions_11); //To continue, please choose a BGM/SE option below (hover button for info).\nYou can change this option later via the mod menu.
 			}
 
 			if (MODAudioSet.Instance.HasAudioSetsDefined())
@@ -107,7 +106,7 @@ namespace MOD.Scripts.UI
 						}
 						else
 						{
-							MODToaster.Show("Option Not Installed!", maybeSound: null);
+							MODToaster.Show(Loc.MODMenuAudioOptions_12, maybeSound: null); //Option Not Installed!
 							this.modMenu.OverrideClickSound(GUISound.Disable);
 						}
 					}

--- a/MOD.Scripts.UI/MODMenuAudioSetup.cs
+++ b/MOD.Scripts.UI/MODMenuAudioSetup.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MOD.Scripts.Core.Localization;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
@@ -28,7 +29,7 @@ namespace MOD.Scripts.UI
 
 			GUILayout.Space(20);
 
-			if (GetGlobal("GAudioSet") != 0 && Button(new GUIContent("Click here when you're finished.")))
+			if (GetGlobal("GAudioSet") != 0 && Button(new GUIContent(Loc.MODMenuAudioSetup_0))) //Click here when you're finished.
 			{
 				modMenu.SetSubMenu(ModSubMenu.Normal);
 				modMenu.ForceHide();
@@ -36,7 +37,7 @@ namespace MOD.Scripts.UI
 		}
 
 		public bool UserCanClose() => false;
-		public string Heading() => "First-Time Setup Menu";
-		public string DefaultTooltip() => "Please choose the options on the left before continuing. You can hover over a button to view its description.";
+		public string Heading() => Loc.MODMenuAudioSetup_1; //First-Time Setup Menu
+		public string DefaultTooltip() => Loc.MODMenuAudioSetup_2; //Please choose the options on the left before continuing. You can hover over a button to view its description.
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -1,6 +1,7 @@
 ﻿using Assets.Scripts.Core;
 using Assets.Scripts.Core.Buriko;
 using MOD.Scripts.Core.Audio;
+using MOD.Scripts.Core.Localization;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -21,8 +22,8 @@ namespace MOD.Scripts.UI
 
 		private readonly MODRadio radioCensorshipLevel;
 		private readonly MODRadio radioLipSync;
-		private readonly string radioLipSyncLabelActive = "Lip Sync for Console Sprites (Hotkey: 7)";
-		private readonly string radioLipSyncLabelInactive = "Lip Sync (NOTE: Select 'Console' sprites or preset to enable)";
+		private readonly string radioLipSyncLabelActive = Loc.MODMenuNormal_0; //Lip Sync for Console Sprites (Hotkey: 7)
+		private readonly string radioLipSyncLabelInactive = Loc.MODMenuNormal_1; //Lip Sync (NOTE: Select 'Console' sprites or preset to enable)
 		private readonly GUIContent[] radioLipSyncActive;
 		private readonly GUIContent[] radioLipSyncInactive;
 		private readonly MODRadio radioOpenings;
@@ -54,107 +55,84 @@ namespace MOD.Scripts.UI
 			hasOGBackgrounds = MODActions.HasOGBackgrounds();
 
 			defaultArtsetDescriptions = new GUIContent[] {
-				new GUIContent("Console", "Use the Console sprites"),
-				new GUIContent("MangaGamer", "Use Mangagamer's remake sprites"),
-				new GUIContent("Original", "Use Original/Ryukishi sprites"),
+				new GUIContent(Loc.MODMenuNormal_2, Loc.MODMenuNormal_3), //Console | Use the Console sprites
+				new GUIContent(Loc.MODMenuNormal_4, Loc.MODMenuNormal_5), //MangaGamer | Use Mangagamer's remake sprites
+				new GUIContent(Loc.MODMenuNormal_6, Loc.MODMenuNormal_7), //Original | Use Original/Ryukishi sprites
 			};
 
-			string baseCensorshipDescription = @"
+			string baseCensorshipDescription = Loc.MODMenuNormal_128; //\n\nSets the script censorship level\n- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.\n- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.\n  - 5: Use voiced lines from PS3 script as much as possible (censored at parts)\n  - 2: Default - most balanced option\n  - 0: Original PC Script with voices where it fits (fully uncensored), but uncensored scenes may be missing voices
 
-Sets the script censorship level
-- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.
-- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.
-  - 5: Full PS3 script fully voiced (most censored)
-  - 2: Default - most balanced option
-  - 0: Original PC Script with voices where it fits (fully uncensored), but uncensored scenes may be missing voices";
-
-			radioCensorshipLevel = new MODRadio("Voice Matching Level (Hotkey: F2)", new GUIContent[] {
-				new GUIContent("0", "Censorship level 0 - Equivalent to PC" + baseCensorshipDescription),
-				new GUIContent("1", "Censorship level 1" + baseCensorshipDescription),
-				new GUIContent("2*", "Censorship level 2 (this is the default/recommended value)" + baseCensorshipDescription),
-				new GUIContent("3", "Censorship level 3" + baseCensorshipDescription),
-				new GUIContent("4", "Censorship level 4" + baseCensorshipDescription),
-				new GUIContent("5", "Censorship level 5 - Equivalent to Console" + baseCensorshipDescription),
+			radioCensorshipLevel = new MODRadio(Loc.MODMenuNormal_8, new GUIContent[] { //Voice Matching Level (Hotkey: F2)
+				new GUIContent("0", Loc.MODMenuNormal_9 + baseCensorshipDescription), //Censorship level 0 - Equivalent to PC
+				new GUIContent("1", Loc.MODMenuNormal_10 + baseCensorshipDescription), //Censorship level 1
+				new GUIContent("2*", Loc.MODMenuNormal_11 + baseCensorshipDescription), //Censorship level 2 (this is the default/recommended value)
+				new GUIContent("3", Loc.MODMenuNormal_12 + baseCensorshipDescription), //Censorship level 3
+				new GUIContent("4", Loc.MODMenuNormal_13 + baseCensorshipDescription), //Censorship level 4
+				new GUIContent("5", Loc.MODMenuNormal_14 + baseCensorshipDescription), //Censorship level 5 - Equivalent to Console
 				});
 
 			radioLipSyncActive = new GUIContent[]
 			{
-				new GUIContent("Lip Sync Off", "Disables Lip Sync for Console Sprites"),
-				new GUIContent("Lip Sync On", "Enables Lip Sync for Console Sprites"),
+				new GUIContent(Loc.MODMenuNormal_15, Loc.MODMenuNormal_16), //Lip Sync Off | Disables Lip Sync for Console Sprites
+				new GUIContent(Loc.MODMenuNormal_17, Loc.MODMenuNormal_18), //Lip Sync On | Enables Lip Sync for Console Sprites
 			};
 
 			radioLipSyncInactive = new GUIContent[]
 			{
-				new GUIContent("Lip Sync Off (Inactive)", "Disables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites"),
-				new GUIContent("Lip Sync On (Inactive)", "Enables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites"),
+				new GUIContent(Loc.MODMenuNormal_19, Loc.MODMenuNormal_20), //Lip Sync Off (Inactive) | Disables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites
+				new GUIContent(Loc.MODMenuNormal_21, Loc.MODMenuNormal_22), //Lip Sync On (Inactive) | Enables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites
 			};
 
 			radioLipSync = new MODRadio(radioLipSyncLabelActive, radioLipSyncActive);
 
-			radioOpenings = new MODRadio("Opening Movies (Hotkey: Shift-F12)", new GUIContent[]
+			radioOpenings = new MODRadio(Loc.MODMenuNormal_23, new GUIContent[] //Opening Movies (Hotkey: Shift-F12)
 			{
-				new GUIContent("Disabled", "Disables all opening videos"),
-				new GUIContent("Enabled", "Enables opening videos\n\n" +
-				"NOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\n" +
-				"We have setup openings this way to avoid spoilers."),
-				new GUIContent("Launch + In-Game", "WARNING: There is usually no need to set this manually.\n\n" +
-				"If openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\n" +
-				"That is, after the opening is played the first time, from then on openings will play every time the game launches"),
+				new GUIContent(Loc.MODMenuNormal_24, Loc.MODMenuNormal_25), //Disabled | Disables all opening videos
+				new GUIContent(Loc.MODMenuNormal_26, Loc.MODMenuNormal_27), //Enabled | Enables opening videos\n\nNOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\nWe have setup openings this way to avoid spoilers.
+				new GUIContent(Loc.MODMenuNormal_28, Loc.MODMenuNormal_29), //Launch + In-Game | WARNING: There is usually no need to set this manually.\n\nIf openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\nThat is, after the opening is played the first time, from then on openings will play every time the game launches
 			});
 
-			radioHideCG = new MODRadio("Show/Hide CGs", new GUIContent[]
+			radioHideCG = new MODRadio(Loc.MODMenuNormal_30, new GUIContent[] //Show/Hide CGs
 			{
-				new GUIContent("Show CGs", "Shows CGs (You probably want this enabled for Console ADV/NVL mode)"),
-				new GUIContent("Hide CGs", "Disables all CGs (mainly for use with the Original/Ryukishi preset)"),
+				new GUIContent(Loc.MODMenuNormal_31, Loc.MODMenuNormal_32), //Show CGs | Shows CGs (You probably want this enabled for Console ADV/NVL mode)
+				new GUIContent(Loc.MODMenuNormal_33, Loc.MODMenuNormal_34), //Hide CGs | Disables all CGs (mainly for use with the Original/Ryukishi preset)
 			});
 
-			radioBackgrounds = new MODRadio("Background Style", new GUIContent[]{
-				new GUIContent("Console BGs", "Use Console backgrounds"),
-				new GUIContent("Original BGs", "Use Original/Ryukishi backgrounds."),
+			radioBackgrounds = new MODRadio(Loc.MODMenuNormal_35, new GUIContent[]{ //Background Style
+				new GUIContent(Loc.MODMenuNormal_36, Loc.MODMenuNormal_37), //Console BGs | Use Console backgrounds
+				new GUIContent(Loc.MODMenuNormal_38, Loc.MODMenuNormal_39), //Original BGs | Use Original/Ryukishi backgrounds.
 			}, itemsPerRow: 2);
 
-			radioStretchBackgrounds = new MODRadio("Background Stretching", new GUIContent[]
+			radioStretchBackgrounds = new MODRadio(Loc.MODMenuNormal_40, new GUIContent[] //Background Stretching
 			{
-				new GUIContent("BG Stretching Off", "Makes backgrounds as big as possible without any stretching (Keep Aspect Ratio)"),
-				new GUIContent("BG Stretching On", "Stretches backgrounds to fit the screen (Ignore Aspect Ratio)\n\n" +
-				"Mainly for use with the Original BGs, which are in 4:3 aspect ratio."),
+				new GUIContent(Loc.MODMenuNormal_41, Loc.MODMenuNormal_42), //BG Stretching Off | Makes backgrounds as big as possible without any stretching (Keep Aspect Ratio)
+				new GUIContent(Loc.MODMenuNormal_43, Loc.MODMenuNormal_44), //BG Stretching On | Stretches backgrounds to fit the screen (Ignore Aspect Ratio)\n\nMainly for use with the Original BGs, which are in 4:3 aspect ratio.
 			});
 
-			radioArtSet = new MODRadio("Sprite Style", defaultArtsetDescriptions, itemsPerRow: 3);
+			radioArtSet = new MODRadio(Loc.MODMenuNormal_45, defaultArtsetDescriptions, itemsPerRow: 3); //Sprite Style
 
-			radioTextWindowModeAndCrop = new MODRadio("Text Window Appearance", new GUIContent[]{
-				new GUIContent("ADV Mode", "This option:\n" +
-				"- Makes text show at the bottom of the screen in a textbox\n" +
-				"- Shows the name of the current character on the textbox\n"),
-				new GUIContent("NVL Mode", "This option:\n" +
-				"- Makes text show across the whole screen\n"),
-				new GUIContent("Original", "This option:\n" +
-				"- Darkens the whole screen to emulate the original game\n" +
-				"- Makes text show only in a 4:3 section of the screen (narrower than NVL mode)\n"),
+			radioTextWindowModeAndCrop = new MODRadio(Loc.MODMenuNormal_46, new GUIContent[]{ //Text Window Appearance
+				new GUIContent(Loc.MODMenuNormal_47, Loc.MODMenuNormal_48), //ADV Mode | This option:\n- Makes text show at the bottom of the screen in a textbox\n- Shows the name of the current character on the textbox\n
+				new GUIContent(Loc.MODMenuNormal_49, Loc.MODMenuNormal_50), //NVL Mode | This option:\n- Makes text show across the whole screen\n
+				new GUIContent(Loc.MODMenuNormal_51, Loc.MODMenuNormal_52), //Original | This option:\n- Darkens the whole screen to emulate the original game\n- Makes text show only in a 4:3 section of the screen (narrower than NVL mode)\n
 			}, itemsPerRow: 2);
 
-			radioForceComputedLipsync = new MODRadio("Force Computed Lipsync", new GUIContent[] {
-				new GUIContent("As Fallback", "Only use computed lipsync if there is no baked 'spectrum' file for a given .ogg file"),
-				new GUIContent("Computed Always", "Always use computed lipsync for all voices. Any 'spectrum' files will be ignored.")
+			radioForceComputedLipsync = new MODRadio(Loc.MODMenuNormal_53, new GUIContent[] { //Force Computed Lipsync
+				new GUIContent(Loc.MODMenuNormal_54, Loc.MODMenuNormal_55), //As Fallback | Only use computed lipsync if there is no baked 'spectrum' file for a given .ogg file
+				new GUIContent(Loc.MODMenuNormal_56, Loc.MODMenuNormal_57) //Computed Always | Always use computed lipsync for all voices. Any 'spectrum' files will be ignored.
 			});
 
 			tabControl = new MODTabControl(new List<MODTabControl.TabProperties>
 			{
-				new MODTabControl.TabProperties("Gameplay", "Voice Matching and Opening Videos", GameplayTabOnGUI),
-				new MODTabControl.TabProperties("Graphics", "Sprites, Backgrounds, CGs, Resolution", GraphicsTabOnGUI),
-				new MODTabControl.TabProperties("Audio", "BGM and SE options", AudioTabOnGUI),
-				new MODTabControl.TabProperties("Troubleshooting", "Tools to help you if something goes wrong", TroubleShootingTabOnGUI),
+				new MODTabControl.TabProperties(Loc.MODMenuNormal_58, Loc.MODMenuNormal_59, GameplayTabOnGUI), //Gameplay | Voice Matching and Opening Videos
+				new MODTabControl.TabProperties(Loc.MODMenuNormal_60, Loc.MODMenuNormal_61, GraphicsTabOnGUI), //Graphics | Sprites, Backgrounds, CGs, Resolution
+				new MODTabControl.TabProperties(Loc.MODMenuNormal_62, Loc.MODMenuNormal_63, AudioTabOnGUI), //Audio | BGM and SE options
+				new MODTabControl.TabProperties(Loc.MODMenuNormal_64, Loc.MODMenuNormal_65, TroubleShootingTabOnGUI), //Troubleshooting | Tools to help you if something goes wrong
 			});
 
-			radioRyukishiExperimentalAspect = new MODRadio("Original/Ryukishi Experimental 4:3 Aspect Ratio", new GUIContent[]{
-				new GUIContent("16:9 (default)", "The game's aspect ratio will be 16:9.\n\n" +
-				"When playing in OG mode, the left and right of the screen will be padded to 4:3 with black bars."),
-				new GUIContent("4:3", "The game's aspect ratio will be 4:3, however this may cause some issues when playing our mod.\n" +
-				"Only use this option if your monitor is 4:3 aspect ratio, like an old CRT monitor.\n\n" +
-				"Please note the following:\n\n" +
-				" - You should enable the Original/Ryukishi preset before enabling this option. Using other settings should all work, but are not well tested.\n\n" +
-				" - 16:9 images will be squished to fit in 4:3 so they don't get cut off. This includes text images, and PS3 CG images if enabled.\n\n" +
-				" - You may see graphical artifacts just after this is enabled - they should fix after the next character transition or text clear\n\n"
+			radioRyukishiExperimentalAspect = new MODRadio(Loc.MODMenuNormal_66, new GUIContent[]{ //Original/Ryukishi Experimental 4:3 Aspect Ratio
+				new GUIContent(Loc.MODMenuNormal_67, Loc.MODMenuNormal_68), //16:9 (default) | The game's aspect ratio will be 16:9.\n\nWhen playing in OG mode, the left and right of the screen will be padded to 4:3 with black bars.
+				new GUIContent("4:3", Loc.MODMenuNormal_69 //The game's aspect ratio will be 4:3, however this may cause some issues when playing our mod.\nOnly use this option if your monitor is 4:3 aspect ratio, like an old CRT monitor.\n\nPlease note the following:\n\n - You should enable the Original/Ryukishi preset before enabling this option. Using other settings should all work, but are not well tested.\n\n - 16:9 images will be squished to fit in 4:3 so they don't get cut off. This includes text images, and PS3 CG images if enabled.\n\n - You may see graphical artifacts just after this is enabled - they should fix after the next character transition or text clear\n\n
 				),
 			});
 
@@ -193,43 +171,29 @@ Sets the script censorship level
 
 		private void GraphicsTabOnGUI()
 		{
-			Label("Graphics Presets (Hotkey: F1)");
+			Label(Loc.MODMenuNormal_70); //Graphics Presets (Hotkey: F1)
 			{
 				GUILayout.BeginHorizontal();
 
 				int advNVLRyukishiMode = MODActions.GetADVNVLRyukishiModeFromFlags(out bool presetModified);
 
-				if (Button(new GUIContent("Console", "This preset:\n" +
-				"- Makes text show at the bottom of the screen in a textbox\n" +
-				"- Shows the name of the current character on the textbox\n" +
-				"- Uses the console sprites (with lipsync) and console backgrounds\n" +
-				"- Displays in 16:9 widescreen\n\n" +
-				"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: !customFlagPreset.Enabled && !presetModified && advNVLRyukishiMode == 0))
+				if (Button(new GUIContent(Loc.MODMenuNormal_71, Loc.MODMenuNormal_72), selected: !customFlagPreset.Enabled && !presetModified && advNVLRyukishiMode == 0)) //Console | This preset:\n- Makes text show at the bottom of the screen in a textbox\n- Shows the name of the current character on the textbox\n- Uses the console sprites (with lipsync) and console backgrounds\n- Displays in 16:9 widescreen\n\nNote that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available
 				{
 					MODActions.SetGraphicsPreset(MODActions.ModPreset.Console, showInfoToast: false);
 				}
 
-				if (this.hasMangaGamerSprites && Button(new GUIContent("MangaGamer", "This preset:\n" +
-					"- Makes text show across the whole screen\n" +
-					"- Uses the Mangagamer remake sprites and Console backgrounds\n" +
-					"- Displays in 16:9 widescreen\n\n" +
-					"Note that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: !customFlagPreset.Enabled && !presetModified && advNVLRyukishiMode == 1))
+				if (this.hasMangaGamerSprites && Button(new GUIContent(Loc.MODMenuNormal_73, Loc.MODMenuNormal_74), selected: !customFlagPreset.Enabled && !presetModified && advNVLRyukishiMode == 1)) //MangaGamer | This preset:\n- Makes text show across the whole screen\n- Uses the Mangagamer remake sprites and Console backgrounds\n- Displays in 16:9 widescreen\n\nNote that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available
 				{
 					MODActions.SetGraphicsPreset(MODActions.ModPreset.MangaGamer, showInfoToast: false);
 				}
 
 				if (this.hasOGBackgrounds &&
-					Button(new GUIContent("Original/Ryukishi", "This preset makes the game behave similarly to the unmodded game:\n" +
-					"- Displays backgrounds in 4:3 'standard' aspect\n" +
-					"- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n" +
-					"- Switches to original sprites and backgrounds\n\n" +
-					"Note that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"), selected: !customFlagPreset.Enabled && !presetModified && advNVLRyukishiMode == 2))
+					Button(new GUIContent(Loc.MODMenuNormal_75, Loc.MODMenuNormal_76), selected: !customFlagPreset.Enabled && !presetModified && advNVLRyukishiMode == 2)) //Original/Ryukishi | This preset makes the game behave similarly to the unmodded game:\n- Displays backgrounds in 4:3 'standard' aspect\n- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n- Switches to original sprites and backgrounds\n\nNote that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available
 				{
 					MODActions.SetGraphicsPreset(MODActions.ModPreset.OG, showInfoToast: false);
 				}
 
-				if (Button(new GUIContent("Custom", "Your own custom preset, using the options below.\n\n" +
-					"This custom preset will be saved, even when you switch to the other presets."), selected: customFlagPreset.Enabled))
+				if (Button(new GUIContent(Loc.MODMenuNormal_77, Loc.MODMenuNormal_78), selected: customFlagPreset.Enabled)) //Custom | Your own custom preset, using the options below.\n\nThis custom preset will be saved, even when you switch to the other presets.
 				{
 					MODActions.LoadCustomGraphicsPreset(showInfoToast: false);
 				}
@@ -237,7 +201,7 @@ Sets the script censorship level
 				GUILayout.EndHorizontal();
 			}
 
-			HeadingLabel("Advanced Options");
+			HeadingLabel(Loc.MODMenuNormal_79); //Advanced Options
 
 
 			// Show warning message if lip sync would have no effect
@@ -299,10 +263,10 @@ Sets the script censorship level
 
 			if (Assets.Scripts.Core.Buriko.BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)
 			{
-				Label("WARNING: You have ADV mode enabled, but you are in a forced-NVL section, so the game will display in NVL mode temporarily!");
+				Label(Loc.MODMenuNormal_80); //WARNING: You have ADV mode enabled, but you are in a forced-NVL section, so the game will display in NVL mode temporarily!
 			}
 
-			HeadingLabel("Resolution");
+			HeadingLabel(Loc.MODMenuNormal_81); //Resolution
 
 			resolutionMenu.OnGUI();
 		}
@@ -325,14 +289,14 @@ Sets the script censorship level
 		{
 			this.audioOptionsMenu.OnGUI();
 
-			HeadingLabel("Advanced Options");
+			HeadingLabel(Loc.MODMenuNormal_82); //Advanced Options
 
 			this.audioOptionsMenu.AdvancedOnGUI();
 		}
 
 		private static void ShowExperimentalGameplayTools()
 		{
-			Label("Experimental Gameplay Tools");
+			Label(Loc.MODMenuNormal_83); //Experimental Gameplay Tools
 			{
 				GUILayout.BeginHorizontal();
 
@@ -341,20 +305,17 @@ Sets the script censorship level
 				string gameClearButtonText;
 				if (gameClearClickCount == 0)
 				{
-					gameClearButtonText = $"{(gameClear ? "Game Clear Forced!" : "All Progress Reset!")} Please reload menu/game!";
+					string clearStateIndicator = gameClear ? Loc.MODMenuNormal_84 : Loc.MODMenuNormal_85; //Game Clear Forced! | All Progress Reset!
+					gameClearButtonText = clearStateIndicator + " " + Loc.MODMenuNormal_86; //Please reload menu/game!
 				}
 				else
 				{
-					gameClearButtonText = $"{(gameClear ? "Reset All Progress" : "Force Game Clear")} (Click {gameClearClickCount} times to confirm)";
+					string clearStateIndicator = gameClear ? Loc.MODMenuNormal_87 : Loc.MODMenuNormal_88; //Reset All Progress | Force Game Clear
+					gameClearButtonText = clearStateIndicator + "(" + Loc.MODMenuNormal_89 + $"{gameClearClickCount}" + Loc.MODMenuNormal_90 + ")"; //Click | more times
 				}
 
 				string gameClearButtonDescription =
-					"WARNING: This option will toggle your game clear status:" +
-					"\n - If you haven't finished the game, it will unlock everything." +
-					"\n - If you have already finished the game, it will reset all your progress!" +
-					"\n\nThis toggles the EXTRAS menu, including all TIPS, and all chapter jump chapters." +
-					"\n\nYou may need to reload the current menu or restart the game before you can see the changes." +
-					"\n\nSaves shouldn't be affected.";
+					Loc.MODMenuNormal_91; //WARNING: This option will toggle your game clear status:\n - If you haven't finished the game, it will unlock everything.\n - If you have already finished the game, it will reset all your progress!\n\nThis toggles the EXTRAS menu, including all TIPS, and all chapter jump chapters.\n\nYou may need to reload the current menu or restart the game before you can see the changes.\n\nSaves shouldn't be affected.
 
 				if (Button(new GUIContent(gameClearButtonText, gameClearButtonDescription)))
 				{
@@ -378,8 +339,9 @@ Sets the script censorship level
 					}
 				}
 
-				Label($"Game Cleared?: {(GetGlobal("GFlag_GameClear") == 0 ? "No" : "Yes")}" +
-					$"\nHighest Chapter: {GetGlobal("GHighestChapter")}");
+				string gameClearedYesNo = GetGlobal("GFlag_GameClear") == 0 ? Loc.MODMenuNormal_92 : Loc.MODMenuNormal_93; //No | Yes
+
+				Label(Loc.MODMenuNormal_94 + gameClearedYesNo + "\n" + Loc.MODMenuNormal_95 + $"{GetGlobal("GHighestChapter")}"); //Game Cleared?:  | Highest Chapter:
 
 				GUILayout.EndHorizontal();
 			}
@@ -391,19 +353,19 @@ Sets the script censorship level
 
 			MODMenuSupport.ShowSupportButtons(content => Button(content));
 
-			HeadingLabel("Developer Tools");
+			HeadingLabel(Loc.MODMenuNormal_96); //Developer Tools
 
 			if(showDeveloperSubmenu)
 			{
 				OnGUIRestoreSettings();
 
-				Label("Developer Debug Menu");
+				Label(Loc.MODMenuNormal_97); //Developer Debug Menu
 				GUILayout.BeginHorizontal();
-				if (Button(new GUIContent("Toggle debug menu (Shift-F9)", "Toggle the debug menu")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_98, Loc.MODMenuNormal_99))) //Toggle debug menu (Shift-F9) | Toggle the debug menu
 				{
 					modMenu.ToggleDebugMenu();
 				}
-				if (Button(new GUIContent("Toggle flag menu (Shift-F10)", "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_100, Loc.MODMenuNormal_101))) //Toggle flag menu (Shift-F10) | Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true.
 				{
 					MODActions.ToggleFlagMenu();
 				}
@@ -413,7 +375,7 @@ Sets the script censorship level
 			}
 			else
 			{
-				if (Button(new GUIContent("Show Developer Tools: Only click if asked by developers", "Show the Developer Tools.\n\nOnly click this button if you're asked to by the developers.")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_102, Loc.MODMenuNormal_103))) //Show Developer Tools: Only click if asked by developers | Show the Developer Tools.\n\nOnly click this button if you're asked to by the developers.
 				{
 					showDeveloperSubmenu = true;
 				}
@@ -422,17 +384,15 @@ Sets the script censorship level
 
 		private void OnGUIRestoreSettings()
 		{
-			Label("Flag Unlocks");
+			Label(Loc.MODMenuNormal_104); //Flag Unlocks
 			GUILayout.BeginHorizontal();
 			{
-				if (Button(new GUIContent($"Toggle GFlag_GameClear (is {GetGlobal("GFlag_GameClear")})", "Toggle the 'GFlag_GameClear' flag which is normally activated when you complete the game. Unlocks things like the All-cast review.")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_105 + $"{GetGlobal("GFlag_GameClear")}", Loc.MODMenuNormal_106))) //Toggle GFlag_GameClear is  | Toggle the 'GFlag_GameClear' flag which is normally activated when you complete the game. Unlocks things like the All-cast review.
 				{
 					SetGlobal("GFlag_GameClear", GetGlobal("GFlag_GameClear") == 0 ? 1 : 0);
 				}
 
-				if (Button(new GUIContent($"Toggle GHighestChapter 0 <-> 999 (is {GetGlobal("GHighestChapter")})", "Toggle the 'GHighestChapter' flag which indicates the highest chapter you have completed.\n\n" +
-					"When >= 1, unlocks the extras menu.\n" +
-					"Also unlocks other things like which chapters are shown on the chapter jump menu, etc.")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_107 + $"{GetGlobal("GHighestChapter")}", Loc.MODMenuNormal_108))) //Toggle GHighestChapter 0 <-> 999 | Is  | Toggle the 'GHighestChapter' flag which indicates the highest chapter you have completed.\n\nWhen >= 1, unlocks the extras menu.\nAlso unlocks other things like which chapters are shown on the chapter jump menu, etc.
 				{
 					bool isZero = GetGlobal("GHighestChapter") == 0;
 					SetGlobal("GHighestChapter", isZero ? 999 : 0);
@@ -440,30 +400,28 @@ Sets the script censorship level
 			}
 			GUILayout.EndHorizontal();
 
-			Label($"Restore Settings {(GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <Restart Pending>")}");
+			string restoreSettingsRestartPending = GetGlobal("GMOD_SETTING_LOADER") == 3 ? "" : ": <" + Loc.MODMenuNormal_109 + ">"; //Restart Pending
+			Label(Loc.MODMenuNormal_110 + restoreSettingsRestartPending); //Restore Settings
 
 			GUILayout.BeginHorizontal();
 			if (GetGlobal("GMOD_SETTING_LOADER") == 3)
 			{
-				if (Button(new GUIContent("ADV defaults", "This restores flags to the defaults for NVL mode\n" +
-					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_111, Loc.MODMenuNormal_112))) //ADV defaults | This restores flags to the defaults for NVL mode\nNOTE: Requires you to relaunch the game 2 times to come into effect
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 0);
 				}
-				else if (Button(new GUIContent("NVL defaults", "This restores flags to the defaults for NVL mode\n" +
-					"NOTE: Requires you to relaunch the game 2 times to come into effect")))
+				else if (Button(new GUIContent(Loc.MODMenuNormal_113, Loc.MODMenuNormal_114))) //NVL defaults | This restores flags to the defaults for NVL mode\nNOTE: Requires you to relaunch the game 2 times to come into effect
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 1);
 				}
-				else if (Button(new GUIContent("Vanilla Defaults", "This restores flags to the same settings as the unmodded game.\n" +
-					"NOTE: Requires a relaunch to come into effect. After this, uninstall the mod.")))
+				else if (Button(new GUIContent(Loc.MODMenuNormal_115, Loc.MODMenuNormal_116))) //Vanilla Defaults | This restores flags to the same settings as the unmodded game.\nNOTE: Requires a relaunch to come into effect. After this, uninstall the mod.
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 2);
 				}
 			}
 			else
 			{
-				if (Button(new GUIContent("Cancel Pending Restore", "Click this to stop restoring defaults on next game launch")))
+				if (Button(new GUIContent(Loc.MODMenuNormal_117, Loc.MODMenuNormal_118))) //Cancel Pending Restore | Click this to stop restoring defaults on next game launch
 				{
 					SetGlobal("GMOD_SETTING_LOADER", 3);
 				}
@@ -473,18 +431,15 @@ Sets the script censorship level
 
 		private void OnGUIComputedLipsync()
 		{
-			Label("Computed Lipsync Options");
+			Label(Loc.MODMenuNormal_119); //Computed Lipsync Options
 			GUILayout.BeginHorizontal();
-			Label(new GUIContent("LipSync Thresh 1: ", "Above this threshold, expression 1 will be used.\n\n" +
-				"Below or equal to this threshold, expression 0 will be used.\n\n" +
-				"Only saved until the game restarts"));
+			Label(new GUIContent(Loc.MODMenuNormal_120, Loc.MODMenuNormal_121)); //LipSync Thresh 1:  | Above this threshold, expression 1 will be used.\n\nBelow or equal to this threshold, expression 0 will be used.\n\nOnly saved until the game restarts
 			TextField_ComputedLipSyncThreshold1 = GUILayout.TextField(TextField_ComputedLipSyncThreshold1);
 
-			Label(new GUIContent("LipSync Thresh 2: ", "Above this thireshold, expression 2 will be used\n\n" +
-				"Only saved until the game restarts"));
+			Label(new GUIContent(Loc.MODMenuNormal_122, Loc.MODMenuNormal_123)); //LipSync Thresh 2:  | Above this thireshold, expression 2 will be used\n\nOnly saved until the game restarts
 			TextField_ComputedLipSyncThreshold2 = GUILayout.TextField(TextField_ComputedLipSyncThreshold2);
 
-			if (Button(new GUIContent("Set", "Tries to set the given lipsync thresholds\n\n")))
+			if (Button(new GUIContent(Loc.MODMenuNormal_124, Loc.MODMenuNormal_125))) //Set | Tries to set the given lipsync thresholds\n\n
 			{
 				if (float.TryParse(TextField_ComputedLipSyncThreshold1, out float threshold1) &&
 					float.TryParse(TextField_ComputedLipSyncThreshold2, out float threshold2) &&
@@ -497,7 +452,7 @@ Sets the script censorship level
 				}
 				else
 				{
-					MODToaster.Show("Invalid thresholds - each threshold should be a value between 0 and 1");
+					MODToaster.Show(Loc.MODMenuNormal_126); //Invalid thresholds - each threshold should be a value between 0 and 1
 				}
 			}
 			GUILayout.EndHorizontal();
@@ -509,37 +464,11 @@ Sets the script censorship level
 		}
 
 		public bool UserCanClose() => true;
-		public string Heading() => "Mod Options Menu";
+		public string Heading() => Loc.MODMenuNormal_127; //Mod Options Menu
 
 		public string DefaultTooltip()
 		{
-			return @"Hover over a button on the left panel for its description.
-
-[Vanilla Hotkeys]
-Enter,Return,RightArrow,PageDown : Advance Text
-LeftArrow,Pageup : See Backlog
-ESC : Open Menu
-Ctrl : Hold Skip Mode
-A : Auto Mode
-S : Toggle Skip Mode
-F, Alt-Enter : FullScreen
-Space : Hide Text
-L : Swap Language
-
-[MOD Hotkeys]
-F1 : ADV-NVL MODE
-F2 : Voice Matching Level
-F3 : Effect Level (Not Used)
-F5 : QuickSave
-F7 : QuickLoad
-F10 : Mod Menu
-M : Increase Voice Volume
-N : Decrease Voice Volume
-P : Cycle through art styles
-2 : Cycle through BGM/SE
-7 : Enable/Disable Lip-Sync
-LShift + M : Voice Volume MAX
-LShift + N : Voice Volume MIN";
+			return Loc.MODMenuNormal_129; //Hover over a button on the left panel for its description.\n\n[Vanilla Hotkeys]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF, Alt-Enter : FullScreen\nSpace : Hide Text\nL : Swap Language\n\n[MOD Hotkeys]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level (Not Used)\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Mod Menu\nM : Increase Voice Volume\nN : Decrease Voice Volume\nP : Cycle through art styles\n2 : Cycle through BGM/SE\n7 : Enable/Disable Lip-Sync\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MINN
 		}
 	}
 }

--- a/MOD.Scripts.UI/MODMenuResolution.cs
+++ b/MOD.Scripts.UI/MODMenuResolution.cs
@@ -4,16 +4,14 @@ using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 using static MOD.Scripts.UI.MODMenuCommon;
+using MOD.Scripts.Core.Localization;
 
 namespace MOD.Scripts.UI
 {
 	class MODMenuResolution
 	{
 		private string overrideFullScreenResolutionDescription =
-			"Set a custom fullscreen resolution\n\n" +
-			"Use this option only if the fullscreen resolution is detected incorrectly (such as on some Linux systems)\n" +
-			"You can manually type in a resolution to use below.\n\n" +
-			"Click 'Clear Override' to let the game automatically determine the fullscreen resolution";
+			Loc.MODMenuResolution_0; //Set a custom fullscreen resolution\n\nUse this option only if the fullscreen resolution is detected incorrectly (such as on some Linux systems)\nYou can manually type in a resolution to use below.\n\nClick 'Clear Override' to let the game automatically determine the fullscreen resolution
 
 		private string screenHeightString;
 		private string fullscreenWidthOverrideString;
@@ -44,31 +42,30 @@ namespace MOD.Scripts.UI
 
 		public void OnGUI()
 		{
-			Label("Windowed Resolution Settings");
+			Label(Loc.MODMenuResolution_1); //Windowed Resolution Settings
 			{
 				GUILayout.BeginHorizontal();
 
 				if (!GameSystem.Instance.IsFullscreen)
 				{
-					if (Button(new GUIContent("480p", "Set resolution to 853 x 480"))) { SetAndSaveResolution(480); }
-					if (Button(new GUIContent("720p", "Set resolution to 1280 x 720"))) { SetAndSaveResolution(720); }
-					if (Button(new GUIContent("1080p", "Set resolution to 1920 x 1080"))) { SetAndSaveResolution(1080); }
-					if (Button(new GUIContent("1440p", "Set resolution to 2560 x 1440"))) { SetAndSaveResolution(1440); }
+					if (Button(new GUIContent(Loc.MODMenuResolution_2, Loc.MODMenuResolution_3))) { SetAndSaveResolution(480); } //480p | Set resolution to 853 x 480
+					if (Button(new GUIContent(Loc.MODMenuResolution_4, Loc.MODMenuResolution_5))) { SetAndSaveResolution(720); } //720p | Set resolution to 1280 x 720
+					if (Button(new GUIContent(Loc.MODMenuResolution_6, Loc.MODMenuResolution_7))) { SetAndSaveResolution(1080); } //1080p | Set resolution to 1920 x 1080
+					if (Button(new GUIContent(Loc.MODMenuResolution_8, Loc.MODMenuResolution_9))) { SetAndSaveResolution(1440); } //1440p | Set resolution to 2560 x 1440
 
 					screenHeightString = GUILayout.TextField(screenHeightString);
-					if (Button(new GUIContent("Set", "Sets a custom resolution - mainly for windowed mode.\n\n" +
-						"Height set automatically to maintain 16:9 aspect ratio.")))
+					if (Button(new GUIContent(Loc.MODMenuResolution_10, Loc.MODMenuResolution_11))) //Set | Sets a custom resolution - mainly for windowed mode.\n\nHeight set automatically to maintain 16:9 aspect ratio.
 					{
 						if (int.TryParse(screenHeightString, out int new_height))
 						{
 							if (new_height < 480)
 							{
-								MODToaster.Show("Height too small - must be at least 480 pixels");
+								MODToaster.Show(Loc.MODMenuResolution_12); //Height too small - must be at least 480 pixels
 								new_height = 480;
 							}
 							else if (new_height > 15360)
 							{
-								MODToaster.Show("Height too big - must be less than 15360 pixels");
+								MODToaster.Show(Loc.MODMenuResolution_13); //Height too big - must be less than 15360 pixels
 								new_height = 15360;
 							}
 							screenHeightString = $"{new_height}";
@@ -82,14 +79,14 @@ namespace MOD.Scripts.UI
 
 				if (GameSystem.Instance.IsFullscreen)
 				{
-					if (Button(new GUIContent("Click here to go Windowed to change these settings", "Toggle Fullscreen")))
+					if (Button(new GUIContent(Loc.MODMenuResolution_14, Loc.MODMenuResolution_15))) //Click here to go Windowed to change these settings | Toggle Fullscreen
 					{
 						GameSystem.Instance.DeFullscreen(PlayerPrefs.GetInt("width"), PlayerPrefs.GetInt("height"));
 					}
 				}
 				else
 				{
-					if (Button(new GUIContent("Go Fullscreen", "Toggle Fullscreen")))
+					if (Button(new GUIContent(Loc.MODMenuResolution_16, Loc.MODMenuResolution_17))) //Go Fullscreen | Toggle Fullscreen
 					{
 						GameSystem.Instance.GoFullscreen();
 					}
@@ -102,24 +99,24 @@ namespace MOD.Scripts.UI
 
 			Resolution detectedRes = GameSystem.Instance.GetFullscreenResolution(useOverride: false, doLogging: false);
 			Resolution actualRes = GameSystem.Instance.GetFullscreenResolution(useOverride: true, doLogging: false);
-			string overrideString = FullscreenOverrideEnabled() ? $"{actualRes.width} x {actualRes.height}" : "Off";
-			Label($"Fullscreen Resolution Override (Detected: {detectedRes.width} x {detectedRes.height} Override: {overrideString})");
+			string overrideString = FullscreenOverrideEnabled() ? $"{actualRes.width} x {actualRes.height}" : Loc.MODMenuResolution_18; //Off
+			Label(Loc.MODMenuResolution_19 + $"{detectedRes.width} x {detectedRes.height}" + Loc.MODMenuResolution_20 + $"{overrideString})"); //Fullscreen Resolution Override (Detected:  |  Override:
 			{
 				GUILayout.BeginHorizontal();
 
 					GUILayout.BeginHorizontal();
-					LabelRightAlign("Width:");
+					LabelRightAlign(Loc.MODMenuResolution_21); //Width:
 					fullscreenWidthOverrideString = GUILayout.TextField(fullscreenWidthOverrideString, 5);
 					GUILayout.EndHorizontal();
 
 					GUILayout.BeginHorizontal();
-					LabelRightAlign("Height:");
+					LabelRightAlign(Loc.MODMenuResolution_22); //Height:
 					fullscreenHeightOverrideString = GUILayout.TextField(fullscreenHeightOverrideString, 5);
 					GUILayout.EndHorizontal();
 
 
 				bool shouldUpdateFullscreenResolution = false;
-				string gameClearButtonText = overrideFullResCountdown > 0 ? $"Click {overrideFullResCountdown} times to override resolution" : $"Override Fullscreen Resolution";
+				string gameClearButtonText = overrideFullResCountdown > 0 ? Loc.MODMenuResolution_23 + $" ({overrideFullResCountdown})" : Loc.MODMenuResolution_24; //Click repeatedly to override resolution | Override Fullscreen Resolution
 				if (Button(new GUIContent(gameClearButtonText, overrideFullScreenResolutionDescription)))
 				{
 					if (overrideFullResCountdown > 0)
@@ -140,17 +137,17 @@ namespace MOD.Scripts.UI
 							}
 							else
 							{
-								MODToaster.Show("Invalid Height");
+								MODToaster.Show(Loc.MODMenuResolution_25); //Invalid Height
 							}
 						}
 						else
 						{
-							MODToaster.Show("Invalid Width");
+							MODToaster.Show(Loc.MODMenuResolution_26); //Invalid Width
 						}
 					}
 				}
 
-				if (Button(new GUIContent("Clear Override", overrideFullScreenResolutionDescription)))
+				if (Button(new GUIContent(Loc.MODMenuResolution_27, overrideFullScreenResolutionDescription))) //Clear Override
 				{
 					PlayerPrefs.SetInt("fullscreen_width_override", 0);
 					PlayerPrefs.SetInt("fullscreen_height_override", 0);
@@ -172,12 +169,12 @@ namespace MOD.Scripts.UI
 		{
 			if (height < 480)
 			{
-				MODToaster.Show("Height too small - must be at least 480 pixels");
+				MODToaster.Show(Loc.MODMenuResolution_28); //Height too small - must be at least 480 pixels
 				height = 480;
 			}
 			else if (height > 15360)
 			{
-				MODToaster.Show("Height too big - must be less than 15360 pixels");
+				MODToaster.Show(Loc.MODMenuResolution_29); //Height too big - must be less than 15360 pixels
 				height = 15360;
 			}
 			screenHeightString = $"{height}";

--- a/MOD.Scripts.UI/MODMenuSupport.cs
+++ b/MOD.Scripts.UI/MODMenuSupport.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MOD.Scripts.Core.Localization;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
@@ -27,7 +28,7 @@ namespace MOD.Scripts.UI
 
 			ShowSupportButtons(content => GUILayout.Button(content));
 
-			GUILayout.Label(GUI.tooltip == "" ? "Please hover over a button for more information" : GUI.tooltip, GUI.skin.textArea, GUILayout.MinHeight(210));
+			GUILayout.Label(GUI.tooltip == "" ? Loc.MODMenuSupport_0 : GUI.tooltip, GUI.skin.textArea, GUILayout.MinHeight(210)); //Please hover over a button for more information
 
 			GUILayout.EndScrollView();
 		}
@@ -37,27 +38,16 @@ namespace MOD.Scripts.UI
 		/// </summary>
 		public static void ShowSupportButtons(Func<GUIContent, bool> buttonRenderer)
 		{
-			MODMenuCommon.Label("Save Files and Log Files");
+			MODMenuCommon.Label(Loc.MODMenuSupport_1); //Save Files and Log Files
 			{
 				GUILayout.BeginHorizontal();
-				if (buttonRenderer(new GUIContent("Show output_log.txt / Player.log",
-					"This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n" +
-					"- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n" +
-					"- This file records errors that occur during gameplay, and during game startup\n" +
-					"- This file helps when the game fails start, for example\n" +
-					"  - a corrupted save file\n" +
-					"  - the wrong UI (sharedassets0.assets) file\n" +
-					"- Note that each time the game starts up, the current log file is replaced")))
+				if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_2, //Show output_log.txt / Player.log
+					Loc.MODMenuSupport_3))) //This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n- This file records errors that occur during gameplay, and during game startup\n- This file helps when the game fails start, for example\n  - a corrupted save file\n  - the wrong UI (sharedassets0.assets) file\n- Note that each time the game starts up, the current log file is replaced
 				{
 					MODActions.ShowLogFolder();
 				}
 
-				if (buttonRenderer(new GUIContent("Show Saves", "Click to open the save folder, which includes saves, quicksaves, and global save data\n\n" +
-					"Clearing your save files can fix some issues with game startup, and resets all mod flags.\n\n" +
-					"- WARNING: Steam cloud will restore your saves if you manually delete them! Therefore, remember to disable steam cloud, otherwise your saves will magically reappear!\n" +
-					"- The 'global.dat' file stores your global unlock process and mod flags\n" +
-					"- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n" +
-					"- It's recommended to take a backup of all your saves before you modify them")))
+				if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_4, Loc.MODMenuSupport_5))) //Show Saves | Click to open the save folder, which includes saves, quicksaves, and global save data\n\nClearing your save files can fix some issues with game startup, and resets all mod flags.\n\n- WARNING: Steam cloud will restore your saves if you manually delete them! Therefore, remember to disable steam cloud, otherwise your saves will magically reappear!\n- The 'global.dat' file stores your global unlock process and mod flags\n- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n- It's recommended to take a backup of all your saves before you modify them
 				{
 					MODActions.ShowSaveFolder();
 				}
@@ -65,35 +55,27 @@ namespace MOD.Scripts.UI
 				GUILayout.EndHorizontal();
 			}
 
-			MODMenuCommon.Label("Quick Access to Game Folders");
+			MODMenuCommon.Label(Loc.MODMenuSupport_6); //Quick Access to Game Folders
 			{
 				GUILayout.BeginHorizontal();
-				if (buttonRenderer(new GUIContent("Show .assets Folder", "Click to open the game's main data folder, which contains the .assets files.\n\n" +
-					"Fonts, certain textures, and other game data is kept in the sharedassets0.assets file.")))
+				if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_7, Loc.MODMenuSupport_8))) //Show .assets Folder | Click to open the game's main data folder, which contains the .assets files.\n\nFonts, certain textures, and other game data is kept in the sharedassets0.assets file.
 				{
 					Application.OpenURL(Application.dataPath);
 				}
 
-				if (buttonRenderer(new GUIContent("Show StreamingAssets Folder", "Click to open the StreamingAssets folder, which contains most of the game assets.\n\n" +
-					"- Most Images/Textures, including Sprites, Backgrounds, Text Images, and Filter effects\n" +
-					"- Voices, Background Music, and Sound Effects\n" +
-					"- Game Scripts and Compiled Game Scripts\n" +
-					"- Movies\n" +
-					"- Other Misc Game Data")))
+				if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_9, Loc.MODMenuSupport_10))) //Show StreamingAssets Folder | Click to open the StreamingAssets folder, which contains most of the game assets.\n\n- Most Images/Textures, including Sprites, Backgrounds, Text Images, and Filter effects\n- Voices, Background Music, and Sound Effects\n- Game Scripts and Compiled Game Scripts\n- Movies\n- Other Misc Game Data
 				{
 					Application.OpenURL(Application.streamingAssetsPath);
 				}
 				GUILayout.EndHorizontal();
 
 				GUILayout.BeginHorizontal();
-				if (buttonRenderer(new GUIContent("Show DLL Folder", "Click to open the 'Managed' folder, which contains our modded 'Assembly-CSharp.dll'")))
+				if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_11, Loc.MODMenuSupport_12))) //Show DLL Folder | Click to open the 'Managed' folder, which contains our modded 'Assembly-CSharp.dll'
 				{
-					Application.OpenURL(System.IO.Path.Combine(Application.dataPath, "Managed"));
+					Application.OpenURL(System.IO.Path.Combine(Application.dataPath, Loc.MODMenuSupport_13)); //Managed
 				}
 
-				if (buttonRenderer(new GUIContent("Show Compiled Scripts", "Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\n" +
-					"You can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\n" +
-					"Please be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.")))
+				if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_14, Loc.MODMenuSupport_15))) //Show Compiled Scripts | Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\nYou can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\nPlease be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled.
 				{
 					MODActions.ShowCompiledScripts();
 				}
@@ -101,11 +83,10 @@ namespace MOD.Scripts.UI
 				GUILayout.EndHorizontal();
 			}
 
-			MODMenuCommon.Label("Support Pages");
-			if (buttonRenderer(new GUIContent("Open Support Page: 07th-mod.com/wiki/Higurashi/support", "If you have problems with the game, the information on this site may help.\n\n" +
-				"There are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly")))
+			MODMenuCommon.Label(Loc.MODMenuSupport_16); //Support Pages
+			if (buttonRenderer(new GUIContent(Loc.MODMenuSupport_17, Loc.MODMenuSupport_18))) //Open Support Page: 07th-mod.com/wiki/Higurashi/support | If you have problems with the game, the information on this site may help.\n\nThere are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly
 			{
-				Application.OpenURL("https://07th-mod.com/wiki/Higurashi/support/");
+				Application.OpenURL(Loc.MODMenuSupport_19); //https://07th-mod.com/wiki/Higurashi/support/
 			}
 		}
 	}

--- a/MOD.Scripts.UI/MODToaster.cs
+++ b/MOD.Scripts.UI/MODToaster.cs
@@ -59,9 +59,19 @@ namespace MOD.Scripts.UI
 
 			Instance.toastText = toastText;
 			Instance.toastNotificationTimer.Start(toastDuration);
-			if (maybeSound is GUISound sound)
+
+			// Try to play sound effect, if requested
+			try
 			{
-				GameSystem.Instance.AudioController.PlaySystemSound(MODSound.GetSoundPathFromEnum(sound));
+				if (maybeSound is GUISound sound)
+				{
+					GameSystem.Instance.AudioController.PlaySystemSound(MODSound.GetSoundPathFromEnum(sound));
+				}
+			}
+			catch (Exception e)
+			{
+				// If an exception occurs here, it probably means the gamesystem is not setup yet
+				// Since this only affects whether the sound is played, just ignore any errors that happen here.
 			}
 		}
 

--- a/tools/find_strings.py
+++ b/tools/find_strings.py
@@ -1,0 +1,223 @@
+from pathlib import Path
+import re
+import json
+# import csv
+
+# Try to match csharp strings
+# - try to ignore escaped characters
+# - try to ignore interpolated portions of strings
+csharp_string_regex = re.compile(r"\"(((\{[^}]*\})|([^\\\"])|(\\.))*)\"")
+
+plus_between_quotes = re.compile(r"\"\s*\+\s*\n\s*\"")
+
+exclude_list_exact = [
+    "LOCALWORK_NO_RESULT",
+    "TipsMode",
+    "SelectResult",
+    "ChapterNumber",
+    "LOnikakushiDay",
+    "LTextFade",
+    "GFlag_FirstPlay",
+    "GFlag_GameClear",
+    "GQsaveNum",
+    "GOnikakushiDay",
+    "GHighestChapter",
+    "GMessageSpeed",
+    "GAutoSpeed",
+    "GAutoAdvSpeed",
+    "GUsePrompts",
+    "GSlowSkip",
+    "GSkipUnread",
+    "GClickDuringAuto",
+    "GRightClickMenu",
+    "GWindowOpacity",
+    "GVoiceVolume",
+    "GBGMVolume",
+    "GSEVolume",
+    "GCutVoiceOnClick",
+    "GUseSystemSound",
+    "GLanguage",
+    "GVChie",
+    "GVEiji",
+    "GVKana",
+    "GVKira",
+    "GVMast",
+    "GVMura",
+    "GVRiho",
+    "GVRmn_",
+    "GVSari",
+    "GVTika",
+    "GVYayo",
+    "GVOther",
+    "GArtStyle",
+    "GHideButtons",
+    "GADVMode",
+    "GLinemodeSp",
+    "GCensor",
+    "GEffectExtend",
+    "GAltBGM",
+    "GAltSE",
+    "GAltBGMflow",
+    "GAltSEflow",
+    "GAltVoice",
+    "GAltVoicePriority",
+    "GCensorMaxNum",
+    "GEffectExtendMaxNum",
+    "GAltBGMflowMaxNum",
+    "GAltSEflowMaxNum",
+    "GMOD_SETTING_LOADER",
+    "GFlagForTest1",
+    "GFlagForTest2",
+    "GFlagForTest3",
+    "NVL_in_ADV",
+    "LFlagMonitor",
+    "DisableModHotkey",
+    "GMOD_DEBUG_MODE",
+    "GLipSync",
+    "GVideoOpening",
+    "GChoiceMode",
+    "GHideCG",
+    "GRyukishiMode",
+    "GStretchBackgrounds",
+    "GBackgroundSet",
+    "GAudioSet",
+    "GRyukishiMode43Aspect",
+    "(",
+    ")",
+    " ",
+    "\\n"
+]
+
+class LocalizedStringInfo:
+    def __init__(self, id, fullstring, filename):
+        self.id = id
+        self.fullstring = fullstring
+        self.filename = filename
+
+class StringExtractor:
+    def __init__(self, filename) -> None:
+        self.count = 0
+        self.filename = filename
+        self.database = []
+
+    def search_line(self, line):
+        # If whole line is a comment, ignore it
+        if line.strip().startswith('//'):
+            return line
+
+        newline = line
+
+        line_comment = ''
+
+        for match in csharp_string_regex.finditer(line):
+            if self.count == 94:
+                print('here')
+
+            if not match:
+                continue
+
+            found_string = match.groups()[0]
+
+            if found_string in exclude_list_exact:
+                continue
+
+            # Assume strings without any letters shouldn't be localized
+            if not re.search("[a-zA-Z]", found_string):
+                continue
+
+            # If the whole string consists of a string interpolation, just skip it
+            if '{' in found_string or '}' in found_string:
+                continue
+
+            # If "PlayerPrefs" in the line, ignore it as we probably don't want to localize it
+            if 'PlayerPrefs' in line:
+                continue
+
+            # print(found_string)
+
+            # Replace the string with a variable
+            found_string_quoted = f'"{found_string}"'
+            id = self.get_new_unique_id()
+            replacement_string = f'Loc.{id}'
+
+            newline = newline.replace(found_string_quoted, replacement_string)
+
+            # Update the database with the found match
+            self.database.append(LocalizedStringInfo(id, found_string, self.filename))
+
+            # Update the comment at the end of the line (for developer to know what text was preivously there)
+            line_comment += f"{found_string} | "
+
+
+        # print(newline)
+
+        line_comment = line_comment.strip()
+
+        if line_comment != '':
+            return f'{newline} //{line_comment.strip("| ")}'
+        else:
+            return newline
+
+
+    
+    def get_new_unique_id(self):
+        temp = f"{self.filename}_{self.count}"
+        self.count += 1
+        return temp
+
+
+# input = "MOD.Scripts.UI/MODMenuNormal.cs"
+# input = "MOD.Scripts.UI/MODMenuResolution.cs"
+# input = "MOD.Scripts.UI/MODMenuAudioOptions.cs"
+# input = "MOD.Scripts.UI/MODMenuAudioSetup.cs"
+# input = "MOD.Scripts.UI/MODMenuSupport.cs"
+input = "MOD.Scripts.UI/MODMenu.cs"
+
+
+
+filename = Path(input).stem
+output_path = Path(input).with_suffix('.out.cs')
+fragment_path = Path(input).with_suffix('.fragment.cs')
+json_path = Path(input).with_suffix('.json')
+
+with open(input, 'r', encoding='utf-8') as f:
+    text = f.read()
+
+    # Replace two strings attached by a plus
+    text = plus_between_quotes.sub("", text)
+
+    string_extractor = StringExtractor(filename)
+
+
+    lines = []
+    for line_no, line in enumerate(text.splitlines()):
+        out_line = string_extractor.search_line(line)
+        lines.append(out_line + '\n')
+
+    with open(output_path, 'w', encoding='utf-8') as out_file:
+        out_file.writelines(lines)
+
+with open(fragment_path, 'w', encoding='utf-8') as fragment_file:
+    for info in string_extractor.database:
+        # fragment_file.write(f'addFallbackEntry("{info.id}", "{info.fullstring}");\n')
+        fragment_file.write(f'public static string {info.id} => Get("{info.id}", "{info.fullstring}");\n')
+
+for info in string_extractor.database:
+    print(info.id, info.fullstring, info.filename) 
+
+# Also write out a localization.json to be merged with the existing localization.json
+all_chapters_data = {}
+json_data = {
+    "allChapters": all_chapters_data
+}
+
+for info in string_extractor.database:
+    print(info)
+    all_chapters_data[info.id] = {
+        #"comment" : "No comment"
+        "text": info.fullstring,
+    }
+
+
+with open(json_path, 'w', encoding='utf-8') as json_out:
+    json_out.write(json.dumps(json_data, indent='\t', ensure_ascii=False))

--- a/tools/localization.json
+++ b/tools/localization.json
@@ -1,0 +1,662 @@
+{
+	"allChapters": {
+		"CultureInfo": {
+			"text": null,
+			"comment": "The 'text' field sets the time format for the save file string, for example 'fr-FR' for French. See https://github.com/07th-mod/higurashi-assembly/issues/109 for more details. Leave as 'null' for the default setting (CultureInfo.CurrentCulture)."
+		},
+		"DateTimeFormat": {
+			"text": "ddd MMM dd, yyyy h:mm tt",
+			"comment": "The 'text' field sets the displayed date time format for save files, for example 'ddd MMM dd, yyyy h:mm tt'. See https://github.com/07th-mod/higurashi-assembly/issues/109 for more details."
+		},
+		"ExampleEntry": {
+			"text": "This text will displayed by default.",
+			"textJP": "This text will be displayed when the language is changed to Japanese in-game.",
+			"comment": "You can store comments here. Additionally, if any field is left empty and there is no hard-coded fallback, it will display as #NOT SET#"
+		},
+		"MODMenu_0": {
+			"comment": "The below entries are for the F10 mod menu, in the file MOD.Scripts.UI/MODMenu.cs. NOTE: some of these are the debug menu strings, wich the user will never use or see.",
+			"text": "[Audio Tracking] - indicates what would play on each BGM flow"
+		},
+		"MODMenu_1": {
+			"text": "[Audio Flags and last played audio]"
+		},
+		"MODMenu_2": {
+			"text": "Reset GAudioSet"
+		},
+		"MODMenu_3": {
+			"text": "Set GAudioSet to 0, to force the game to do audio setup on next startup"
+		},
+		"MODMenu_4": {
+			"text": "Close"
+		},
+		"MODMenu_5": {
+			"text": "Close the debug menu"
+		},
+		"MODMenu_6": {
+			"text": "Developer Debug Window (click to drag)"
+		},
+		"MODMenu_7": {
+			"text": "Mod Menu\n(Hotkey: F10)"
+		},
+		"MODMenu_8": {
+			"text": "BGM Info"
+		},
+		"MODMenu_9": {
+			"text": "Copy BGM Name"
+		},
+		"MODMenu_10": {
+			"text": "Show File"
+		},
+		"MODMenu_11": {
+			"text": "Open In Youtube"
+		},
+		"MODMenu_12": {
+			"text": "Note: If explorer freezes\nuninstall Web Media Extensions"
+		},
+		"MODMenu_13": {
+			"text": "X"
+		},
+		"MODMenu_14": {
+			"text": "Close the Mod menu"
+		},
+		"MODMenu_15": {
+			"text": "Please close the current menu and try again"
+		},
+		"MODMenu_16": {
+			"text": "It looks like there was a problem starting up\n\nPlease send the developers your log file (output_log.txt or Player.log).\n\nYou can try the following yourself to fix the issue.\n  1. Try waiting 30 seconds for the game to progress. If nothing happens, try restarting the game\n\n  2. Use the buttons under 'Troubleshooting' on the bottom left to show your save files, log files, and compiled scripts.\n\n  3. If the log indicates you have corrupt save files, you may wish to delete the offending save file (or all of them).\n\n  4. You can try to clear your compiled script files, then restart the game.\n\n  5. If the above do not fix the problem, please click the 'Open Support Page' button, which has extra troubleshooting info and links to join our Discord server for direct support."
+		},
+		"MODMenuNormal_0": {
+			"comment": "The below entries are for the F10 mod menu, in the file MOD.Scripts.UI/MODMenuNormal.cs",
+			"text": "Lip Sync for Console Sprites (Hotkey: 7)"
+		},
+		"MODMenuNormal_1": {
+			"text": "Lip Sync (NOTE: Select 'Console' sprites or preset to enable)"
+		},
+		"MODMenuNormal_2": {
+			"text": "Console"
+		},
+		"MODMenuNormal_3": {
+			"text": "Use the Console sprites"
+		},
+		"MODMenuNormal_4": {
+			"text": "MangaGamer"
+		},
+		"MODMenuNormal_5": {
+			"text": "Use Mangagamer's remake sprites"
+		},
+		"MODMenuNormal_6": {
+			"text": "Original"
+		},
+		"MODMenuNormal_7": {
+			"text": "Use Original/Ryukishi sprites"
+		},
+		"MODMenuNormal_8": {
+			"text": "Voice Matching Level (Hotkey: F2)"
+		},
+		"MODMenuNormal_9": {
+			"text": "Censorship level 0 - Equivalent to PC"
+		},
+		"MODMenuNormal_10": {
+			"text": "Censorship level 1"
+		},
+		"MODMenuNormal_11": {
+			"text": "Censorship level 2 (this is the default/recommended value)"
+		},
+		"MODMenuNormal_12": {
+			"text": "Censorship level 3"
+		},
+		"MODMenuNormal_13": {
+			"text": "Censorship level 4"
+		},
+		"MODMenuNormal_14": {
+			"text": "Censorship level 5 - Equivalent to Console"
+		},
+		"MODMenuNormal_15": {
+			"text": "Lip Sync Off"
+		},
+		"MODMenuNormal_16": {
+			"text": "Disables Lip Sync for Console Sprites"
+		},
+		"MODMenuNormal_17": {
+			"text": "Lip Sync On"
+		},
+		"MODMenuNormal_18": {
+			"text": "Enables Lip Sync for Console Sprites"
+		},
+		"MODMenuNormal_19": {
+			"text": "Lip Sync Off (Inactive)"
+		},
+		"MODMenuNormal_20": {
+			"text": "Disables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites"
+		},
+		"MODMenuNormal_21": {
+			"text": "Lip Sync On (Inactive)"
+		},
+		"MODMenuNormal_22": {
+			"text": "Enables Lip Sync for Console Sprites\n\nNOTE: Lip Sync only works with Console sprites - please select 'Console' preset or sprites"
+		},
+		"MODMenuNormal_23": {
+			"text": "Opening Movies (Hotkey: Shift-F12)"
+		},
+		"MODMenuNormal_24": {
+			"text": "Disabled"
+		},
+		"MODMenuNormal_25": {
+			"text": "Disables all opening videos"
+		},
+		"MODMenuNormal_26": {
+			"text": "Enabled"
+		},
+		"MODMenuNormal_27": {
+			"text": "Enables opening videos\n\nNOTE: Once the opening video plays the first time, will automatically switch to 'Launch + In-Game'\n\nWe have setup openings this way to avoid spoilers."
+		},
+		"MODMenuNormal_28": {
+			"text": "Launch + In-Game"
+		},
+		"MODMenuNormal_29": {
+			"text": "WARNING: There is usually no need to set this manually.\n\nIf openings are enabled, the first time you reach an opening while playing the game, this flag will be set automatically\n\nThat is, after the opening is played the first time, from then on openings will play every time the game launches"
+		},
+		"MODMenuNormal_30": {
+			"text": "Show/Hide CGs"
+		},
+		"MODMenuNormal_31": {
+			"text": "Show CGs"
+		},
+		"MODMenuNormal_32": {
+			"text": "Shows CGs (You probably want this enabled for Console ADV/NVL mode)"
+		},
+		"MODMenuNormal_33": {
+			"text": "Hide CGs"
+		},
+		"MODMenuNormal_34": {
+			"text": "Disables all CGs (mainly for use with the Original/Ryukishi preset)"
+		},
+		"MODMenuNormal_35": {
+			"text": "Background Style"
+		},
+		"MODMenuNormal_36": {
+			"text": "Console BGs"
+		},
+		"MODMenuNormal_37": {
+			"text": "Use Console backgrounds"
+		},
+		"MODMenuNormal_38": {
+			"text": "Original BGs"
+		},
+		"MODMenuNormal_39": {
+			"text": "Use Original/Ryukishi backgrounds."
+		},
+		"MODMenuNormal_40": {
+			"text": "Background Stretching"
+		},
+		"MODMenuNormal_41": {
+			"text": "BG Stretching Off"
+		},
+		"MODMenuNormal_42": {
+			"text": "Makes backgrounds as big as possible without any stretching (Keep Aspect Ratio)"
+		},
+		"MODMenuNormal_43": {
+			"text": "BG Stretching On"
+		},
+		"MODMenuNormal_44": {
+			"text": "Stretches backgrounds to fit the screen (Ignore Aspect Ratio)\n\nMainly for use with the Original BGs, which are in 4:3 aspect ratio."
+		},
+		"MODMenuNormal_45": {
+			"text": "Sprite Style"
+		},
+		"MODMenuNormal_46": {
+			"text": "Text Window Appearance"
+		},
+		"MODMenuNormal_47": {
+			"text": "ADV Mode"
+		},
+		"MODMenuNormal_48": {
+			"text": "This option:\n- Makes text show at the bottom of the screen in a textbox\n- Shows the name of the current character on the textbox\n"
+		},
+		"MODMenuNormal_49": {
+			"text": "NVL Mode"
+		},
+		"MODMenuNormal_50": {
+			"text": "This option:\n- Makes text show across the whole screen\n"
+		},
+		"MODMenuNormal_51": {
+			"text": "Original"
+		},
+		"MODMenuNormal_52": {
+			"text": "This option:\n- Darkens the whole screen to emulate the original game\n- Makes text show only in a 4:3 section of the screen (narrower than NVL mode)\n"
+		},
+		"MODMenuNormal_53": {
+			"text": "Force Computed Lipsync"
+		},
+		"MODMenuNormal_54": {
+			"text": "As Fallback"
+		},
+		"MODMenuNormal_55": {
+			"text": "Only use computed lipsync if there is no baked 'spectrum' file for a given .ogg file"
+		},
+		"MODMenuNormal_56": {
+			"text": "Computed Always"
+		},
+		"MODMenuNormal_57": {
+			"text": "Always use computed lipsync for all voices. Any 'spectrum' files will be ignored."
+		},
+		"MODMenuNormal_58": {
+			"text": "Gameplay"
+		},
+		"MODMenuNormal_59": {
+			"text": "Voice Matching and Opening Videos"
+		},
+		"MODMenuNormal_60": {
+			"text": "Graphics"
+		},
+		"MODMenuNormal_61": {
+			"text": "Sprites, Backgrounds, CGs, Resolution"
+		},
+		"MODMenuNormal_62": {
+			"text": "Audio"
+		},
+		"MODMenuNormal_63": {
+			"text": "BGM and SE options"
+		},
+		"MODMenuNormal_64": {
+			"text": "Troubleshooting"
+		},
+		"MODMenuNormal_65": {
+			"text": "Tools to help you if something goes wrong"
+		},
+		"MODMenuNormal_66": {
+			"text": "Original/Ryukishi Experimental 4:3 Aspect Ratio"
+		},
+		"MODMenuNormal_67": {
+			"text": "16:9 (default)"
+		},
+		"MODMenuNormal_68": {
+			"text": "The game's aspect ratio will be 16:9.\n\nWhen playing in OG mode, the left and right of the screen will be padded to 4:3 with black bars."
+		},
+		"MODMenuNormal_69": {
+			"text": "The game's aspect ratio will be 4:3, however this may cause some issues when playing our mod.\nOnly use this option if your monitor is 4:3 aspect ratio, like an old CRT monitor.\n\nPlease note the following:\n\n - You should enable the Original/Ryukishi preset before enabling this option. Using other settings should all work, but are not well tested.\n\n - 16:9 images will be squished to fit in 4:3 so they don't get cut off. This includes text images, and PS3 CG images if enabled.\n\n - You may see graphical artifacts just after this is enabled - they should fix after the next character transition or text clear\n\n"
+		},
+		"MODMenuNormal_70": {
+			"text": "Graphics Presets (Hotkey: F1)"
+		},
+		"MODMenuNormal_71": {
+			"text": "Console"
+		},
+		"MODMenuNormal_72": {
+			"text": "This preset:\n- Makes text show at the bottom of the screen in a textbox\n- Shows the name of the current character on the textbox\n- Uses the console sprites (with lipsync) and console backgrounds\n- Displays in 16:9 widescreen\n\nNote that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"
+		},
+		"MODMenuNormal_73": {
+			"text": "MangaGamer"
+		},
+		"MODMenuNormal_74": {
+			"text": "This preset:\n- Makes text show across the whole screen\n- Uses the Mangagamer remake sprites and Console backgrounds\n- Displays in 16:9 widescreen\n\nNote that sprites and backgrounds can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"
+		},
+		"MODMenuNormal_75": {
+			"text": "Original/Ryukishi"
+		},
+		"MODMenuNormal_76": {
+			"text": "This preset makes the game behave similarly to the unmodded game:\n- Displays backgrounds in 4:3 'standard' aspect\n- CGs are disabled (Can be re-enabled, see 'Show/Hide CGs')\n- Switches to original sprites and backgrounds\n\nNote that sprites, backgrounds, and CG hiding can be overridden by setting the 'Choose Art Set' & 'Override Art Set Backgrounds' options under 'Advanced Options', if available"
+		},
+		"MODMenuNormal_77": {
+			"text": "Custom"
+		},
+		"MODMenuNormal_78": {
+			"text": "Your own custom preset, using the options below.\n\nThis custom preset will be saved, even when you switch to the other presets."
+		},
+		"MODMenuNormal_79": {
+			"text": "Advanced Options"
+		},
+		"MODMenuNormal_80": {
+			"text": "WARNING: You have ADV mode enabled, but you are in a forced-NVL section, so the game will display in NVL mode temporarily!"
+		},
+		"MODMenuNormal_81": {
+			"text": "Resolution"
+		},
+		"MODMenuNormal_82": {
+			"text": "Advanced Options"
+		},
+		"MODMenuNormal_83": {
+			"text": "Experimental Gameplay Tools"
+		},
+		"MODMenuNormal_84": {
+			"text": "Game Clear Forced!"
+		},
+		"MODMenuNormal_85": {
+			"text": "All Progress Reset!"
+		},
+		"MODMenuNormal_86": {
+			"text": "Please reload menu/game!"
+		},
+		"MODMenuNormal_87": {
+			"text": "Reset All Progress"
+		},
+		"MODMenuNormal_88": {
+			"text": "Force Game Clear"
+		},
+		"MODMenuNormal_89": {
+			"text": "Click"
+		},
+		"MODMenuNormal_90": {
+			"text": "more times"
+		},
+		"MODMenuNormal_91": {
+			"text": "WARNING: This option will toggle your game clear status:\n - If you haven't finished the game, it will unlock everything.\n - If you have already finished the game, it will reset all your progress!\n\nThis toggles the EXTRAS menu, including all TIPS, and all chapter jump chapters.\n\nYou may need to reload the current menu or restart the game before you can see the changes.\n\nSaves shouldn't be affected."
+		},
+		"MODMenuNormal_92": {
+			"text": "No"
+		},
+		"MODMenuNormal_93": {
+			"text": "Yes"
+		},
+		"MODMenuNormal_94": {
+			"text": "Game Cleared?: "
+		},
+		"MODMenuNormal_95": {
+			"text": "Highest Chapter: "
+		},
+		"MODMenuNormal_96": {
+			"text": "Developer Tools"
+		},
+		"MODMenuNormal_97": {
+			"text": "Developer Debug Menu"
+		},
+		"MODMenuNormal_98": {
+			"text": "Toggle debug menu (Shift-F9)"
+		},
+		"MODMenuNormal_99": {
+			"text": "Toggle the debug menu"
+		},
+		"MODMenuNormal_100": {
+			"text": "Toggle flag menu (Shift-F10)"
+		},
+		"MODMenuNormal_101": {
+			"text": "Toggle the flag menu. Toggle Multiple times for more options.\n\nNote: 3rd and 4th panels are only shown if GMOD_DEBUG_MODE is true."
+		},
+		"MODMenuNormal_102": {
+			"text": "Show Developer Tools: Only click if asked by developers"
+		},
+		"MODMenuNormal_103": {
+			"text": "Show the Developer Tools.\n\nOnly click this button if you're asked to by the developers."
+		},
+		"MODMenuNormal_104": {
+			"text": "Flag Unlocks"
+		},
+		"MODMenuNormal_105": {
+			"text": "Toggle GFlag_GameClear is "
+		},
+		"MODMenuNormal_106": {
+			"text": "Toggle the 'GFlag_GameClear' flag which is normally activated when you complete the game. Unlocks things like the All-cast review."
+		},
+		"MODMenuNormal_107": {
+			"text": "Toggle GHighestChapter 0 <-> 999 | Is "
+		},
+		"MODMenuNormal_108": {
+			"text": "Toggle the 'GHighestChapter' flag which indicates the highest chapter you have completed.\n\nWhen >= 1, unlocks the extras menu.\nAlso unlocks other things like which chapters are shown on the chapter jump menu, etc."
+		},
+		"MODMenuNormal_109": {
+			"text": "Restart Pending"
+		},
+		"MODMenuNormal_110": {
+			"text": "Restore Settings"
+		},
+		"MODMenuNormal_111": {
+			"text": "ADV defaults"
+		},
+		"MODMenuNormal_112": {
+			"text": "This restores flags to the defaults for NVL mode\nNOTE: Requires you to relaunch the game 2 times to come into effect"
+		},
+		"MODMenuNormal_113": {
+			"text": "NVL defaults"
+		},
+		"MODMenuNormal_114": {
+			"text": "This restores flags to the defaults for NVL mode\nNOTE: Requires you to relaunch the game 2 times to come into effect"
+		},
+		"MODMenuNormal_115": {
+			"text": "Vanilla Defaults"
+		},
+		"MODMenuNormal_116": {
+			"text": "This restores flags to the same settings as the unmodded game.\nNOTE: Requires a relaunch to come into effect. After this, uninstall the mod."
+		},
+		"MODMenuNormal_117": {
+			"text": "Cancel Pending Restore"
+		},
+		"MODMenuNormal_118": {
+			"text": "Click this to stop restoring defaults on next game launch"
+		},
+		"MODMenuNormal_119": {
+			"text": "Computed Lipsync Options"
+		},
+		"MODMenuNormal_120": {
+			"text": "LipSync Thresh 1: "
+		},
+		"MODMenuNormal_121": {
+			"text": "Above this threshold, expression 1 will be used.\n\nBelow or equal to this threshold, expression 0 will be used.\n\nOnly saved until the game restarts"
+		},
+		"MODMenuNormal_122": {
+			"text": "LipSync Thresh 2: "
+		},
+		"MODMenuNormal_123": {
+			"text": "Above this thireshold, expression 2 will be used\n\nOnly saved until the game restarts"
+		},
+		"MODMenuNormal_124": {
+			"text": "Set"
+		},
+		"MODMenuNormal_125": {
+			"text": "Tries to set the given lipsync thresholds\n\n"
+		},
+		"MODMenuNormal_126": {
+			"text": "Invalid thresholds - each threshold should be a value between 0 and 1"
+		},
+		"MODMenuNormal_127": {
+			"text": "Mod Options Menu"
+		},
+		"MODMenuNormal_128": {
+			"text": "\n\nSets the script censorship level\n- This setting exists because the voices are taken from the censored, Console versions of the game, so no voices exist for the PC uncensored dialogue.\n- We recommend the default level (2), the most balanced option. Using this option, only copyright changes, innuendos, and a few words will be changed.\n  - 5: Use voiced lines from PS3 script as much as possible (censored at parts)\n  - 2: Default - most balanced option\n  - 0: Original PC Script with voices where it fits (fully uncensored), but uncensored scenes may be missing voices"
+		},
+		"MODMenuNormal_129": {
+			"text": "Hover over a button on the left panel for its description.\n\n[Vanilla Hotkeys]\nEnter,Return,RightArrow,PageDown : Advance Text\nLeftArrow,Pageup : See Backlog\nESC : Open Menu\nCtrl : Hold Skip Mode\nA : Auto Mode\nS : Toggle Skip Mode\nF, Alt-Enter : FullScreen\nSpace : Hide Text\nL : Swap Language\n\n[MOD Hotkeys]\nF1 : ADV-NVL MODE\nF2 : Voice Matching Level\nF3 : Effect Level (Not Used)\nF5 : QuickSave\nF7 : QuickLoad\nF10 : Mod Menu\nM : Increase Voice Volume\nN : Decrease Voice Volume\nP : Cycle through art styles\n2 : Cycle through BGM/SE\n7 : Enable/Disable Lip-Sync\nLShift + M : Voice Volume MAX\nLShift + N : Voice Volume MINN"
+		},
+		"MODMenuResolution_0": {
+			"comment": "The below entries are for Resolution part of the F10 mod menu, in the file MOD.Scripts.UI/MODMenuResolution.cs",
+			"text": "Set a custom fullscreen resolution\n\nUse this option only if the fullscreen resolution is detected incorrectly (such as on some Linux systems)\nYou can manually type in a resolution to use below.\n\nClick 'Clear Override' to let the game automatically determine the fullscreen resolution"
+		},
+		"MODMenuResolution_1": {
+			"text": "Windowed Resolution Settings"
+		},
+		"MODMenuResolution_2": {
+			"text": "480p"
+		},
+		"MODMenuResolution_3": {
+			"text": "Set resolution to 853 x 480"
+		},
+		"MODMenuResolution_4": {
+			"text": "720p"
+		},
+		"MODMenuResolution_5": {
+			"text": "Set resolution to 1280 x 720"
+		},
+		"MODMenuResolution_6": {
+			"text": "1080p"
+		},
+		"MODMenuResolution_7": {
+			"text": "Set resolution to 1920 x 1080"
+		},
+		"MODMenuResolution_8": {
+			"text": "1440p"
+		},
+		"MODMenuResolution_9": {
+			"text": "Set resolution to 2560 x 1440"
+		},
+		"MODMenuResolution_10": {
+			"text": "Set"
+		},
+		"MODMenuResolution_11": {
+			"text": "Sets a custom resolution - mainly for windowed mode.\n\nHeight set automatically to maintain 16:9 aspect ratio."
+		},
+		"MODMenuResolution_12": {
+			"text": "Height too small - must be at least 480 pixels"
+		},
+		"MODMenuResolution_13": {
+			"text": "Height too big - must be less than 15360 pixels"
+		},
+		"MODMenuResolution_14": {
+			"text": "Click here to go Windowed to change these settings"
+		},
+		"MODMenuResolution_15": {
+			"text": "Toggle Fullscreen"
+		},
+		"MODMenuResolution_16": {
+			"text": "Go Fullscreen"
+		},
+		"MODMenuResolution_17": {
+			"text": "Toggle Fullscreen"
+		},
+		"MODMenuResolution_18": {
+			"text": "Off"
+		},
+		"MODMenuResolution_19": {
+			"text": "Fullscreen Resolution Override (Detected: "
+		},
+		"MODMenuResolution_20": {
+			"text": " Override: "
+		},
+		"MODMenuResolution_21": {
+			"text": "Width:"
+		},
+		"MODMenuResolution_22": {
+			"text": "Height:"
+		},
+		"MODMenuResolution_23": {
+			"text": "Click repeatedly to override resolution"
+		},
+		"MODMenuResolution_24": {
+			"text": "Override Fullscreen Resolution"
+		},
+		"MODMenuResolution_25": {
+			"text": "Invalid Height"
+		},
+		"MODMenuResolution_26": {
+			"text": "Invalid Width"
+		},
+		"MODMenuResolution_27": {
+			"text": "Clear Override"
+		},
+		"MODMenuResolution_28": {
+			"text": "Height too small - must be at least 480 pixels"
+		},
+		"MODMenuResolution_29": {
+			"text": "Height too big - must be less than 15360 pixels"
+		},
+		"MODMenuAudioOptions_0": {
+			"comment": "The below entries are for the audio options section of the F10 mod menu, in the file MOD.Scripts.UI/MODMenuAudioOptions.cs",
+			"text": "Audio Presets (Hotkey: 2)"
+		},
+		"MODMenuAudioOptions_1": {
+			"text": "Override SE"
+		},
+		"MODMenuAudioOptions_2": {
+			"text": "Invalid BGM cascade"
+		},
+		"MODMenuAudioOptions_3": {
+			"text": "Invalid SE cascade"
+		},
+		"MODMenuAudioOptions_4": {
+			"text": " (NOT INSTALLED)"
+		},
+		"MODMenuAudioOptions_5": {
+			"text": "\n\nWARNING: This audio set is not installed! You can try to run the installer again to update your mod with this option.\nYou're missing the BGM or SE folder in the StreamingAssets folder:"
+		},
+		"MODMenuAudioOptions_6": {
+			"text": "Force enable the following sound effects (ignore preset SE): "
+		},
+		"MODMenuAudioOptions_7": {
+			"text": "The patch supports different Background Music (BGM) and Sound Effects(SE). Please click the button below for more information."
+		},
+		"MODMenuAudioOptions_8": {
+			"text": "Open BGM/SE FAQ: 07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/"
+		},
+		"MODMenuAudioOptions_9": {
+			"text": "Click here to open the  Background Music (BGM) and Sound Effects (SE) FAQ in your browser.\n\nThe BGM/SE FAQ contains information on the settings below."
+		},
+		"MODMenuAudioOptions_10": {
+			"text": "https://07th-mod.com/wiki/Higurashi/BGM-SE-FAQ/"
+		},
+		"MODMenuAudioOptions_11": {
+			"text": "To continue, please choose a BGM/SE option below (hover button for info).\nYou can change this option later via the mod menu."
+		},
+		"MODMenuAudioOptions_12": {
+			"text": "Option Not Installed!"
+		},
+		"MODMenuAudioSetup_0": {
+			"comment": "The below entries are for the audio setup optiosn which appear the first time you launch the game, in the file MOD.Scripts.UI/MODMenuAudioSetup.cs",
+			"text": "Click here when you're finished."
+		},
+		"MODMenuAudioSetup_1": {
+			"text": "First-Time Setup Menu"
+		},
+		"MODMenuAudioSetup_2": {
+			"text": "Please choose the options on the left before continuing. You can hover over a button to view its description."
+		},
+		"MODMenuSupport_0": {
+			"comment": "The below entries are for the support section of the F10 mod menu, in the file MOD.Scripts.UI/MODMenuSupport.cs",
+			"text": "Please hover over a button for more information"
+		},
+		"MODMenuSupport_1": {
+			"text": "Save Files and Log Files"
+		},
+		"MODMenuSupport_2": {
+			"text": "Show output_log.txt / Player.log"
+		},
+		"MODMenuSupport_3": {
+			"text": "This button shows the location of the 'ouput_log.txt' or 'Player.log' files\n\n- This file is called 'output_log.txt' on Windows and 'Player.log' on MacOS/Linux\n- This file records errors that occur during gameplay, and during game startup\n- This file helps when the game fails start, for example\n  - a corrupted save file\n  - the wrong UI (sharedassets0.assets) file\n- Note that each time the game starts up, the current log file is replaced"
+		},
+		"MODMenuSupport_4": {
+			"text": "Show Saves"
+		},
+		"MODMenuSupport_5": {
+			"text": "Click to open the save folder, which includes saves, quicksaves, and global save data\n\nClearing your save files can fix some issues with game startup, and resets all mod flags.\n\n- WARNING: Steam cloud will restore your saves if you manually delete them! Therefore, remember to disable steam cloud, otherwise your saves will magically reappear!\n- The 'global.dat' file stores your global unlock process and mod flags\n- The 'qsaveX.dat' and 'saveXXX.dat' files contain individual save files. Note that these becoming corrupted can break your game\n- It's recommended to take a backup of all your saves before you modify them"
+		},
+		"MODMenuSupport_6": {
+			"text": "Quick Access to Game Folders"
+		},
+		"MODMenuSupport_7": {
+			"text": "Show .assets Folder"
+		},
+		"MODMenuSupport_8": {
+			"text": "Click to open the game's main data folder, which contains the .assets files.\n\nFonts, certain textures, and other game data is kept in the sharedassets0.assets file."
+		},
+		"MODMenuSupport_9": {
+			"text": "Show StreamingAssets Folder"
+		},
+		"MODMenuSupport_10": {
+			"text": "Click to open the StreamingAssets folder, which contains most of the game assets.\n\n- Most Images/Textures, including Sprites, Backgrounds, Text Images, and Filter effects\n- Voices, Background Music, and Sound Effects\n- Game Scripts and Compiled Game Scripts\n- Movies\n- Other Misc Game Data"
+		},
+		"MODMenuSupport_11": {
+			"text": "Show DLL Folder"
+		},
+		"MODMenuSupport_12": {
+			"text": "Click to open the 'Managed' folder, which contains our modded 'Assembly-CSharp.dll'"
+		},
+		"MODMenuSupport_13": {
+			"text": "Managed"
+		},
+		"MODMenuSupport_14": {
+			"text": "Show Compiled Scripts"
+		},
+		"MODMenuSupport_15": {
+			"text": "Sometimes out-of-date scripts can cause the game to fail to start up (stuck on black screen).\n\nYou can manually clear the *.mg files (compiled scripts) in this folder to force the game to regenerate them the next time the game starts.\n\nPlease be aware that the game will freeze for a couple minutes on a white screen, while scripts are being compiled."
+		},
+		"MODMenuSupport_16": {
+			"text": "Support Pages"
+		},
+		"MODMenuSupport_17": {
+			"text": "Open Support Page: 07th-mod.com/wiki/Higurashi/support"
+		},
+		"MODMenuSupport_18": {
+			"text": "If you have problems with the game, the information on this site may help.\n\nThere are also instructions on reporting bugs, as well as a link to our Discord server to contact us directly"
+		},
+		"MODMenuSupport_19": {
+			"text": "https://07th-mod.com/wiki/Higurashi/support/"
+		}
+	}
+}


### PR DESCRIPTION
Previously, translators were not able to modify text in the mod menu, as all mod menu text were hardcoded strings in the DLL.

This PR loads the strings from a `localization.json` file which should be placed at `HigurashiEp0X_Data/localization.json` (next to the `tips.json` file).

An example `localization.json` is provided at `tools/localization.json`, which should be updated as a reference for translators.

If the `localization.json` file is missing, it uses defaults specified in the `MOD.Scripts.Core/MODLocalizationData.cs` file. This means we don't need to provide a `localization.json` file in each of our repositories at this point in time.

For more details, see https://github.com/07th-mod/higurashi-assembly/issues/109

----

There is one change which isn't directly related to mod menu localization in this file - "Fix exception if toast displayed before gamesystem started" - I think this was because I added a popup if the localization.json file is invalid, but since it was raised so early in the game startup, it would cause an exception (now fixed).