### PR TITLE
Fix 'return to main menu', 'quit', and 'load' not working in choices

### DIFF
--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -492,8 +492,17 @@ namespace Assets.Scripts.Core
 		{
 			if (ChoiceController != null)
 			{
-				ChoiceController.Destroy();
-				ChoiceController = null;
+				if (GameSystem.Instance.GameState == GameState.ChoiceScreen)
+				{
+					// If you're currently on the choice screen, then cleanly leave the choices state and delete the choice controller
+					LeaveChoices();
+				}
+				else
+				{
+					// If you're on another screen layered ontop of the choice screen (eg the load screen), just delete the choice controller and hope for the best.
+					ChoiceController.Destroy();
+					ChoiceController = null;
+				}
 			}
 		}
 

--- a/Assets.Scripts.UI.Menu/MenuUIButton.cs
+++ b/Assets.Scripts.UI.Menu/MenuUIButton.cs
@@ -51,6 +51,7 @@ namespace Assets.Scripts.UI.Menu
 					gameSystem.PopStateStack();
 					GameSystem.Instance.PushStateObject(new StateDialogPrompt(PromptType.DialogTitle, delegate
 					{
+						gameSystem.CloseChoiceIfExists();
 						gameSystem.ClearActions();
 						gameSystem.ClearAllWaits();
 						gameSystem.TextController.ClearText();
@@ -74,6 +75,7 @@ namespace Assets.Scripts.UI.Menu
 					gameSystem.PopStateStack();
 					GameSystem.Instance.PushStateObject(new StateDialogPrompt(PromptType.DialogExit, delegate
 					{
+						gameSystem.CloseChoiceIfExists();
 						gameSystem.CanExit = true;
 						Application.Quit();
 					}, delegate


### PR DESCRIPTION
Fix 'return to main menu', 'quit', and 'load' not working in choices 
 - Not all chapters are broken in the same way
 - See https://github.com/07th-mod/higurashi-assembly/issues/106
 - See https://github.com/07th-mod/higurashi-rei/issues/2#issue-1320921974
 - This was semi-applied in Rei (5796215), but it did not fix loading during a choice, and had some issues, so I'm going to revert that in Rei