### PR TITLE
Fix black backgrounds if bgs toggled after startup

### DIFF
--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -734,7 +734,18 @@ namespace Assets.Scripts.Core.Scene
 		{
 			if (PrimaryName == string.Empty)
 			{
-				HideLayer();
+				// PrimaryName is set to string.Empty when Layer's texture is released -
+				// therefore there is no texture to reload, so do nothing here.
+				//
+				// Note: Previously there was a HideLayer() call here, which caused problems
+				// with backgrounds if ReloadTexture() was called just after the game had started
+				// running, and DrawSceneWithMask() had not yet been called. It would cause
+				// backgrounds to display for one frame(?), then turn black.
+				//
+				// I think may be a special layer is activated on startup, but has no texture set,
+				// triggering this if statement.
+				//
+				// See https://github.com/07th-mod/higurashi-assembly/issues/104 for details
 			}
 			else
 			{


### PR DESCRIPTION
This PR fixes background only displaying for one frame, then changing to black, if graphics preset changed before reaching title screen, until game restarted.

- See below, copied from https://github.com/07th-mod/higurashi-assembly/issues/104#issuecomment-1848838757)
 

> I investigated this issue today. I think it has to do with this part of the code (which only exists in our mod I think):
> 
> https://github.com/07th-mod/higurashi-assembly/blob/094444b37553b05e6d1c1bb662c53a217f60d64a/Assets.Scripts.Core.Scene/Layer.cs#L733-L740
> 
> On startup, there seems to exist a Layer which has PrimaryName set to String.Empty (normally PrimaryName is the texture name). However I think this layer disappears, or has its PrimaryName set, after the first time you call DrawSceneWithMask().
> 
> So if ReloadTexture() was called just after the game had started
> running, and DrawSceneWithMask() had not yet been called, it would cause the above HideLayer() call to run, which I assume causes this weird behavior where the background will turn black one frame after being displayed (although I'm not sure why).
> 
> I tested removing the HideLayer() call and it seems to fix the issue. I'm pretty confident it won't break anything, since ReloadAllImages() (which calls ReloadTexture()) is only ever called when you change our graphics related mod options. So if you never change any graphics mod options, ReloadAllImages() is never called. 
> 
> Worst case the user can restart their game to fix an issue (if this removal of HideLayer() causes an issue)
> 
> I have put the fix on the https://github.com/07th-mod/higurashi-assembly/compare/f-fix-corrupt-graphics branch