### PR TITLE
Fix various volume issues

### DIFF
--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -1,3 +1,4 @@
+using Assets.Scripts.Core.Buriko;
 using MOD.Scripts.Core;
 using MOD.Scripts.Core.Audio;
 using MOD.Scripts.Core.TextWindow;
@@ -510,8 +511,30 @@ namespace Assets.Scripts.Core.Audio
 			}
 		}
 
+		public static bool GlobalFlagAffectsAudio(string globalFlagName)
+		{
+			switch(globalFlagName)
+			{
+				case "GVoiceVolume":
+				case "GBGMVolume":
+				case "GSEVolume":
+					return true;
+			}
+
+			return false;
+		}
+
 		public void RefreshLayerVolumes()
 		{
+			if(BurikoMemory.Instance != null)
+			{
+				BurikoMemory memory = BurikoMemory.Instance;
+				VoiceVolume = (float)memory.GetGlobalFlag("GVoiceVolume").IntValue() / 100f;
+				BGMVolume = (float)memory.GetGlobalFlag("GBGMVolume").IntValue() / 100f;
+				SoundVolume = (float)memory.GetGlobalFlag("GSEVolume").IntValue() / 100f;
+				SystemVolume = (float)memory.GetGlobalFlag("GSEVolume").IntValue() / 100f;
+			}
+
 			for (int i = 0; i < 6; i++)
 			{
 				AudioLayerUnity audioLayerUnity = channelDictionary[GetChannelByTypeChannel(AudioType.BGM, i)];

--- a/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
+++ b/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
@@ -198,7 +198,8 @@ namespace Assets.Scripts.Core.Audio
 			audioSource.clip = audioClip;
 			audioSource.loop = isLoop;
 			audioSource.priority = audioController.GetPriorityByType(audioType);
-			volume = audioController.GetVolumeByType(audioType) * subVolume;
+			volume = audioController.GetVolumeByType(audioType);
+			audioSource.volume = volume * subVolume;
 			audioSource.Play();
 			isReady = true;
 			if (onFinishLoad != null)

--- a/Assets.Scripts.Core/GameSystem.cs
+++ b/Assets.Scripts.Core/GameSystem.cs
@@ -335,6 +335,9 @@ namespace Assets.Scripts.Core
 		public void PostLoading()
 		{
 			StartScriptSystem();
+
+			// At this point in the startup, BurikoMemory is intialized
+			GameSystem.Instance.AudioController.RefreshLayerVolumes();
 			MainUIController.InitializeModMenu(this);
 		}
 

--- a/Assets.Scripts.UI.Config/ConfigSlider.cs
+++ b/Assets.Scripts.UI.Config/ConfigSlider.cs
@@ -72,19 +72,12 @@ namespace Assets.Scripts.UI.Config
 					BurikoMemory.Instance.SetGlobalFlag("GWindowOpacity", num);
 					break;
 				case "1-AutoSpeed": // Voice Volume
-					GameSystem.Instance.AudioController.VoiceVolume = laststep;
-					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GVoiceVolume", num);
 					break;
 				case "2-AutoPageSpeed": // BGM Volume
-					GameSystem.Instance.AudioController.BGMVolume = laststep;
-					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GBGMVolume", num);
 					break;
 				case "3-WindowOpacity": // SE Volume
-					GameSystem.Instance.AudioController.SoundVolume = laststep;
-					GameSystem.Instance.AudioController.SystemVolume = laststep;
-					GameSystem.Instance.AudioController.RefreshLayerVolumes();
 					BurikoMemory.Instance.SetGlobalFlag("GSEVolume", num);
 					break;
 				case "4-BGMVolume": // Text / Auto text Speed


### PR DESCRIPTION
There are two audio issues which I noticed
- Sometimes, the audio volume will glitch to maximum for one frame (as if you had your BGM volume slider set to max, for example). I haven't confirmed that my change fixes this issue, however, since I couldn't reproduce it easily.
- The first time you launch the game, the actual volume level, and the volume slides on the config menu were out of sync. When you rebooted the game, it would fix. I've tested my changes to fix this (which should prevent any possible desync of the volume sliders/volume flag variables to the actual volume), but am not sure if these fixes break anything else in the engine.