### PR TITLE
2024 Matsuribayashi Ch.8 Crash Fixes

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoSaveManager.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoSaveManager.cs
@@ -77,10 +77,15 @@ namespace Assets.Scripts.Core.Buriko
 								throw new FileLoadException("Save file does not appear to be valid! Invalid header.");
 							}
 							int num = binaryReader.ReadInt32();
-							if (num != 1)
-							{
-								throw new FileLoadException("Save file does not appear to be valid! Invalid version number.");
-							}
+							// Note: On 01-01-2024, Ch.8 removed the save version check, so that saves with a version other than 1
+							// could be loaded. Currently, there are only two versions 1 (initial version) and 2 (priority included in save file)
+							//
+							// Please note that this means older versions of the DLL won't be able to load new saves, so you won't be able to
+							// downgrade DLL version and keep your save after this.
+							// if (num != 1)
+							// {
+							// 	throw new FileLoadException("Save file does not appear to be valid! Invalid version number.");
+							// }
 							saveEntry2.Time = DateTime.FromBinary(binaryReader.ReadInt64());
 							string textJp = binaryReader.ReadString();
 							string text = saveEntry2.Text = binaryReader.ReadString();

--- a/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
@@ -33,6 +33,8 @@ namespace Assets.Scripts.Core.Buriko
 
 		public bool FlowWasReached { get; private set; }
 
+		public static int SaveVersion = 1;
+
 		public static BurikoScriptSystem Instance
 		{
 			get;
@@ -237,7 +239,7 @@ namespace Assets.Scripts.Core.Buriko
 					using (BinaryWriter binaryWriter = new BinaryWriter(memoryStream))
 					{
 						binaryWriter.Write("MGSV".ToCharArray(0, 4));
-						binaryWriter.Write(1);
+						binaryWriter.Write(2);
 						binaryWriter.Write(DateTime.Now.ToBinary());
 						if (text == string.Empty)
 						{
@@ -358,8 +360,9 @@ namespace Assets.Scripts.Core.Buriko
 						int num = binaryReader.ReadInt32();
 						if (num != 1)
 						{
-							throw new FileLoadException("Save file does not appear to be valid! Invalid version number.");
+							SaveVersion = num;
 						}
+						Debug.Log("Loading save from version: " + num);
 						binaryReader.ReadInt64();
 						string text = binaryReader.ReadString();
 						string text2 = binaryReader.ReadString();

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -62,9 +62,17 @@ namespace Assets.Scripts.Core.Scene
 
 		public bool FadingOut;
 
-		private float startRange;
+		private float startRange
+		{
+			get;
+			set;
+		}
 
-		private float targetRange;
+		private float targetRange
+		{
+			get;
+			set;
+		}
 
 		public Vector3 targetPosition = new Vector3(0f, 0f, 0f);
 
@@ -654,8 +662,8 @@ namespace Assets.Scripts.Core.Scene
 		public void FadeTo(float alpha, float time)
 		{
 			iTween.Stop(base.gameObject);
-			startRange = targetRange;
 			targetRange = alpha;
+			targetAlpha = alpha;
 			iTween.ValueTo(base.gameObject, iTween.Hash("from", startRange, "to", targetRange, "time", time, "onupdate", "SetRange", "oncomplete", "FinishFade"));
 		}
 
@@ -772,6 +780,7 @@ namespace Assets.Scripts.Core.Scene
 
 		public void ReleaseTextures()
 		{
+			FadingOut = false;
 			if (!(primary == null))
 			{
 				ReleaseSecondaryTexture();
@@ -787,7 +796,6 @@ namespace Assets.Scripts.Core.Scene
 				Object.Destroy(mesh);
 				mesh = null;
 				meshFilter.mesh = null;
-				FadingOut = false;
 				shaderType = 0;
 				targetAngle = 0f;
 			}
@@ -869,6 +877,7 @@ namespace Assets.Scripts.Core.Scene
 			br.Write(targetAlpha);
 			br.Write((int)alignment);
 			br.Write(shaderType);
+			br.Write(Priority);
 		}
 
 		private void Awake()

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -1,3 +1,4 @@
+using Assets.Scripts.Core.Buriko;
 using Assets.Scripts.Core.AssetManagement;
 using MOD.Scripts.Core;
 using MOD.Scripts.Core.Scene;
@@ -146,20 +147,37 @@ namespace Assets.Scripts.Core.Scene
 
 		public void ControlMotionOfSprite(int layer, MtnCtrlElement[] motions, int style)
 		{
-			Layer layer2 = GetLayer(layer);
-			layer2.ControlLayerMotion(motions);
+			Layer ifInUse = GetIfInUse(layer);
+			if (ifInUse == null)
+			{
+				Debug.LogWarning("Attempting to call ControlMotionOfSprite on layer " + layer + " but it is not active in the scene.");
+			}
+			else
+			{
+				ifInUse.ControlLayerMotion(motions);
+			}
 		}
 
 		public void MoveSprite(int layer, int x, int y, int z, int angle, int easetype, float alpha, float wait, bool isblocking)
 		{
-			Layer layer2 = GetLayer(layer);
-			layer2.MoveLayer(x, y, z, alpha, easetype, wait, isblocking, adjustAlpha: true);
-			layer2.SetAngle((float)angle, wait);
+			Layer ifInUse = GetIfInUse(layer);
+			if (ifInUse == null)
+			{
+				Debug.LogWarning("Attempting to call MoveSprite on layer " + layer + " but it is not active in the scene.");
+				return;
+			}
+			ifInUse.MoveLayer(x, y, z, alpha, easetype, wait, isblocking, adjustAlpha: true);
+			ifInUse.SetAngle(angle, wait);
 		}
 
 		public void MoveSpriteEx(int layer, string filename, Vector3[] points, float alpha, float time, bool isblocking)
 		{
-			Layer i = GetLayer(layer);
+			Layer i = GetIfInUse(layer);
+			if (i == null)
+			{
+				Debug.LogWarning("Attempting to call MoveSpriteEx on layer " + layer + " but it is not active in the scene.");
+				return;
+			}
 			if (filename != string.Empty)
 			{
 				i.CrossfadeLayer(filename, time, isblocking);
@@ -182,10 +200,17 @@ namespace Assets.Scripts.Core.Scene
 			}
 
 			Layer i = GetLayer(layer);
+			int iterationCount = 0;
 			while (i.FadingOut)
 			{
 				i.HideLayer();
 				i = GetLayer(layer);
+				iterationCount++;
+				if (iterationCount > 20)
+				{
+					Debug.LogWarning("We're trying to hide bustshot " + layer + " for DrawBustshot but for some reason it's stuck in a fading out state.");
+					break;
+				}
 			}
 			if (!move)
 			{
@@ -691,6 +716,10 @@ namespace Assets.Scripts.Core.Scene
 			binaryReader.ReadSingle();
 			binaryReader.ReadInt32();
 			binaryReader.ReadInt32();
+			if (BurikoScriptSystem.SaveVersion > 1)
+			{
+				binaryReader.ReadInt32();
+			}
 			DrawScene(backgroundfilename, 0.3f);
 			if (binaryReader.ReadBoolean())
 			{
@@ -698,6 +727,7 @@ namespace Assets.Scripts.Core.Scene
 				MGHelper.ReadVector3(binaryReader);
 				string texture = binaryReader.ReadString();
 				binaryReader.ReadSingle();
+				binaryReader.ReadInt32();
 				binaryReader.ReadInt32();
 				binaryReader.ReadInt32();
 				DrawFace(texture, 0f, isblocking: false);
@@ -716,13 +746,18 @@ namespace Assets.Scripts.Core.Scene
 					float alpha = binaryReader.ReadSingle();
 					int num = binaryReader.ReadInt32();
 					int type = binaryReader.ReadInt32();
+					int priority = i;
+					if (BurikoScriptSystem.SaveVersion > 1)
+					{
+						priority = binaryReader.ReadInt32();
+					}
 					if (i != 50)
 					{
 						bool isBustshot = num != 0;
 						Layer layer = GetLayer(i);
-						UpdateLayerMask(layer, i);
+						UpdateLayerMask(layer, priority);
 						layer.DrawLayer(textureName, (int)position.x, (int)position.y, 0, null, alpha, isBustshot, type, 0f, isBlocking: false);
-						layer.SetPriority(i);
+						layer.SetPriority(priority);
 						layer.RestoreScaleAndPosition(scale, position);
 					}
 				}

--- a/MOD.Scripts.Core.Scene/MODLipsyncCache.cs
+++ b/MOD.Scripts.Core.Scene/MODLipsyncCache.cs
@@ -40,6 +40,13 @@ namespace MOD.Scripts.Core.Scene
 
             public static void SetLastDrawInformation(int character, int layer, string baseTextureName)
             {
+                // Ignore any 'null' texture and print error message
+                if(baseTextureName == null)
+                {
+                    MODLogger.Log($"WARNING: LastDrawInformationManager.SetLastDrawInformation called with baseTextureName = null (character: {character} layer: {layer})", true);
+                    return;
+                }
+
                 if (character < lastDrawInformation.Length)
                 {
                     lastDrawInformation[character] = new LastDrawInformation(layer, baseTextureName);
@@ -213,6 +220,13 @@ namespace MOD.Scripts.Core.Scene
                 DebugLog($"Texture Cache count: {cache.Keys.Count}");
 
                 if(!LastDrawInformationManager.GetLastDrawInformation(character, out LastDrawInformation info))
+                {
+                    textureGroup = null;
+                    return false;
+                }
+
+                // If the baseTextureName is null, we won't know what texture to load, so just give up
+                if(info.baseTextureName == null)
                 {
                     textureGroup = null;
                     return false;


### PR DESCRIPTION
## Change Description

Doddler pushed some fixes to Ch.8 to prevent crashing to the unmodded game on 2024-01-01. From Doddler's twitter:

> Doh, someone reported a game crash on higurashi chapter 8 and it turns out the game gets caught in an infinite loop if you save and load your game within the first 5 or so minutes.
>
> Was a fun one, if you're interested in the tech details: layers with a priority above 32 don't get removed at scene transitions. Usually layers have the same id as their priority, but that's not true in the opening. Loading a saved game incorrectly resets priority to the layer #.
>
> This causes the vignette border in the OP (layer 1 priority 35) to get incorrectly deleted, but a fade command still targets the inactive layer. Later it tries to load the layer using a loop that gets the layer and resets it if it's fading, but this fails because it's not active.
>
> The reason it's looping was for safety, if a layer somehow ended up back in the layer pool but still alive, like with our load bug, we would simply reset it, put it back, and then try again. But the reset returns early if it has no texture, which causes the fade to not clear.
 
This PR contains those changes (manually applied due to differences between our `mod` branch and Ch.8).

I'm still on the fence on applying it for previous chapters in case it somehow breaks something, as the crashes were mainly on Ch.8 (and maybe Ch.7? not sure).

## Changes made
 
 Apply unmodded fixes for Ch.8 crashing
     - This applies the changes from the unmodded  game made on 2024-01-01
     - Bump save file version to 2. Old saves can still be loaded (version check when loading saves was removed)
     - Save layer priority in save file
     - Prevent infinite loop waiting for layer to fade out
     - Check whether layer is not in use before using it in certain fns
     - Some changes to FadeTo() and ReleaseTextures() functions