### PR TITLE
F priority workaround

### DIFF
--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -657,11 +657,17 @@ namespace Assets.Scripts.Core.Scene
 			{
 				if (GameSystem.Instance.SceneController.PriorityInUseByOtherLayer(this, out int layerUsingPriority, out int thisLayerNumber))
 				{
+					float originalZ = base.transform.localPosition.z;
+
+					// This should work for all possible layers (technically would work for layers between 0-999)
+					base.transform.localPosition -= new Vector3(0, 0, thisLayerNumber * .0001f);
+
 					// In-engine "Priority" is 1 higher than the priority you specify in the game script.
 					MODLogger.Log(
 						$"WARNING: Attempted to use [Layer {thisLayerNumber}] with priority {Priority - 1}, " +
-						$"but [Layer {layerUsingPriority}] is already using priority {Priority - 1}. " +
-						$"This layer may not be drawn correctly/graphical artifacts may occur.", true);
+						$"but [Layer {layerUsingPriority}] is already using priority {Priority - 1}.\n" +
+						$"Z-position has been adjusted from {originalZ} to {base.transform.localPosition.z} to try to fix it.\n" +
+						$"NOTE: This layer may not be drawn correctly/graphical artifacts may occur.", true);
 				}
 			}
 			catch (System.Exception e)

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Core.AssetManagement;
+using MOD.Scripts.Core;
 using MOD.Scripts.Core.Scene;
 using System.Collections;
 using System.IO;
@@ -651,6 +652,22 @@ namespace Assets.Scripts.Core.Scene
 			Vector3 localPosition2 = base.transform.localPosition;
 			targetPosition = new Vector3(x, localPosition2.y, (float)Priority * -0.1f);
 			base.transform.localPosition = targetPosition;
+
+			try
+			{
+				if (GameSystem.Instance.SceneController.PriorityInUseByOtherLayer(this, out int layerUsingPriority, out int thisLayerNumber))
+				{
+					// In-engine "Priority" is 1 higher than the priority you specify in the game script.
+					MODLogger.Log(
+						$"WARNING: Attempted to use [Layer {thisLayerNumber}] with priority {Priority - 1}, " +
+						$"but [Layer {layerUsingPriority}] is already using priority {Priority - 1}. " +
+						$"This layer may not be drawn correctly/graphical artifacts may occur.", true);
+				}
+			}
+			catch (System.Exception e)
+			{
+				MODLogger.Log($"Error while checking Layer Priority: {e}", true);
+			}
 		}
 
 		public void FadeInLayer(float time)

--- a/Assets.Scripts.Core.Scene/SceneController.cs
+++ b/Assets.Scripts.Core.Scene/SceneController.cs
@@ -119,6 +119,44 @@ namespace Assets.Scripts.Core.Scene
 			}
 		}
 
+		public bool PriorityInUseByOtherLayer(Layer layerToCheck, out int layerUsingPriority, out int layerToCheckNumber)
+		{
+			layerToCheckNumber = -1;
+			layerUsingPriority = -1;
+
+			for (int id = 0; id < layers.Length; id++)
+			{
+				if (layers[id] == null)
+				{
+					continue;
+				}
+
+				if (LayerPool.IsInPool(layers[id].gameObject))
+				{
+					continue;
+				}
+
+				if (!layers[id].IsInUse)
+				{
+					continue;
+				}
+
+				// Don't check layer against itself
+				if (layers[id].gameObject == layerToCheck.gameObject)
+				{
+					layerToCheckNumber = id;
+					continue;
+				}
+
+				if (layers[id].Priority == layerToCheck.Priority)
+				{
+					layerUsingPriority = id;
+				}
+			}
+
+			return layerUsingPriority != -1;
+		}
+
 		public int GetActiveLayerMask()
 		{
 			if (activeScene == 0)


### PR DESCRIPTION
# Initial Discord Report (by me)

I was investigating an issue the italian translation team reported, where lipsync didn't work in one particular scene (repeatble)

It turned out to be due to two different layers using the same priority (I think). Even without lipsync, it would cause the second sprite with the same priority to not be drawn at all.

I made the engine print a warning every time this happens, and it happens pretty rarely (about once per chapter).

In your experience, is this a known behavior with the engine? like is this something you take into account when doing the scripts?

Also it looks like the priority just sets the order of the layers when they overlap (like if two characters are drawn in the same spot, higher priority is drawn ontop). Does that seem accurate?

For example, the below code has 3 draw calls. Two calls are on layer 2, which work fine. But the third one does nothing, unless you set a priority other than `10` (priority is the 3rd last argument)

```c
FadeOutBGM( 1, 1000, TRUE );
DrawScene("background/gk1", 500 );

// Draw Layer 2 with Priority 10: me1a_def_a1_
ModDrawCharacter(2, 3, "sprite/me1a_def_a1_", "0", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 10, 200, TRUE );

OutputLine(NULL, "試験で振り落とさなきゃならないほど、人もいないし。」",
   NULL, "1 - Layer 2: me1a_def_a1_", GetGlobalFlag(GLinemodeSp));

// Draw Layer 2 with Priority 10: me1b_wink_a1_
ModDrawCharacter(2, 3, "sprite/me1b_wink_a1_", "2", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 10, 200, TRUE );

OutputLine(NULL, "「誰でも進学できるならさ、そんなにガリガリとやることもないんじゃない？」",
   NULL, "2 - Layer 2: me1b_wink_a1_", GetGlobalFlag(GLinemodeSp));

// Draw Layer 1 with Priority 10: re1a_def_a1_ (Nothing is shown during this call unless priority changed to a value other than 10)
ModDrawCharacter(1, 3, "sprite/re1a_def_a1_", "1", -160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 10, 600, TRUE );
```

# This PR

This PR both logs when the priority problems happen and fixes the Z-position when two layers have the same priority (by offsetting the Z-position proportional to the layer (higher layer = lower Z position). Note that a different (better) way to fix it, would be to make sure later layers with the same priority are drawn on-top (with a lower Z position).

However, I think in the end we won't actually fix it this way, and instead will fix it by editing the scripts, since this error does not happen very often.

I've already gone ahead and scanned the script for priority errors and orian is fixing it.

So this PR is mainly to archive/document the fix.