### PR TITLE
F bgm loop

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -225,6 +225,7 @@
     <Compile Include="LTSpline.cs" />
     <Compile Include="MenuUIController.cs" />
     <Compile Include="MOD.Scripts.Core.Audio\MODBGMInfo.cs" />
+    <Compile Include="MOD.Scripts.Core.Audio\MODPreLoopAudio.cs" />
     <Compile Include="MOD.Scripts.Core.Config\MODConfig.cs" />
     <Compile Include="MOD.Scripts.Core.Config\MODConfigManager.cs" />
     <Compile Include="MOD.Scripts.Core.Movie\AVProMovieRenderer.cs" />

--- a/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
+++ b/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
@@ -1,5 +1,6 @@
 using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.Audio;
+using MOD.Scripts.Core.Audio;
 using System;
 using System.Collections;
 using UnityEngine;
@@ -13,6 +14,8 @@ namespace Assets.Scripts.Core.Audio
 		private AudioSource audioSource;
 
 		private AudioClip audioClip;
+
+		private MODPreLoopAudio preLoopAudio = new MODPreLoopAudio();
 
 		private AudioFinishCallback finishCallback;
 
@@ -102,6 +105,7 @@ namespace Assets.Scripts.Core.Audio
 			{
 				Destroy(audioClip);
 			}
+			preLoopAudio.StopAudio();
 			loadedName = string.Empty;
 			audioClip = null;
 			iTween.Stop(base.gameObject);
@@ -118,7 +122,7 @@ namespace Assets.Scripts.Core.Audio
 			{
 				return false;
 			}
-			return audioSource.isPlaying;
+			return preLoopAudio.IsPlaying() || audioSource.isPlaying;
 		}
 
 		public float GetRemainingPlayTime()
@@ -127,10 +131,10 @@ namespace Assets.Scripts.Core.Audio
 			{
 				return -1f;
 			}
-			return audioSource.clip.length - audioSource.time;
+			return preLoopAudio.GetRemainingPlayTime() + audioSource.clip.length - audioSource.time;
 		}
 
-		public int GetPlayTimeSamples() => audioSource.timeSamples;
+		public int GetPlayTimeSamples() => preLoopAudio.GetPlayTimeSamples() + audioSource.timeSamples;
 
 		private IEnumerator WaitForLoad(string filename, AudioType type, Action<string, AudioType, AudioClip> onAudioDataLoaded = null)
 		{
@@ -138,6 +142,12 @@ namespace Assets.Scripts.Core.Audio
 			string path = AssetManager.Instance.GetAudioFilePath(filename, type);
 			WWW audioLoader = new WWW("file://" + path);
 			yield return audioLoader;
+
+			if(isLoop)
+			{
+				yield return StartCoroutine(preLoopAudio.LoadAudioClips(filename, type));
+			}
+
 			loadedName = filename;
 			audioClip = audioLoader.audioClip;
 
@@ -199,8 +209,12 @@ namespace Assets.Scripts.Core.Audio
 			audioSource.loop = isLoop;
 			audioSource.priority = audioController.GetPriorityByType(audioType);
 			volume = audioController.GetVolumeByType(audioType) * subVolume;
+
+			LoopPlaybackInformation info = preLoopAudio.OnFinishLoad(base.gameObject, audioSource.priority);
+
 			audioSource.volume = volume;
-			audioSource.Play();
+			audioSource.time = info.loopFirstStartTime;
+			audioSource.PlayDelayed(info.loopStartDelay);
 			isReady = true;
 			if (onFinishLoad != null)
 			{
@@ -234,7 +248,8 @@ namespace Assets.Scripts.Core.Audio
 				}
 				volume = audioController.GetVolumeByType(audioType);
 				audioSource.volume = volume * subVolume;
-				if (!audioSource.isPlaying && !isLoop && !isLoading && isReady && isLoaded)
+				preLoopAudio.Update(audioSource.volume);
+				if (!preLoopAudio.IsPlaying() && !audioSource.isPlaying && !isLoop && !isLoading && isReady && isLoaded)
 				{
 					OnAudioEnd();
 				}

--- a/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
+++ b/Assets.Scripts.Core.Audio/AudioLayerUnity.cs
@@ -199,6 +199,7 @@ namespace Assets.Scripts.Core.Audio
 			audioSource.loop = isLoop;
 			audioSource.priority = audioController.GetPriorityByType(audioType);
 			volume = audioController.GetVolumeByType(audioType) * subVolume;
+			audioSource.volume = volume;
 			audioSource.Play();
 			isReady = true;
 			if (onFinishLoad != null)

--- a/MOD.Scripts.Core.Audio/MODPreLoopAudio.cs
+++ b/MOD.Scripts.Core.Audio/MODPreLoopAudio.cs
@@ -1,0 +1,183 @@
+﻿using Assets.Scripts.Core.AssetManagement;
+using Assets.Scripts.Core.Audio;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEngine;
+
+namespace MOD.Scripts.Core.Audio
+{
+	public class LoopPlaybackInformation
+	{
+		public float loopStartDelay;
+		public float loopFirstStartTime;
+
+		public LoopPlaybackInformation(float loopStartDelay, float loopInitialTime)
+		{
+			this.loopStartDelay = loopStartDelay;
+			this.loopFirstStartTime = loopInitialTime;
+		}
+	}
+
+	public class MODPreLoopAudio
+	{
+		List<AudioClip> AudioClips = new List<AudioClip>();
+		List<AudioSource> AudioSources = new List<AudioSource>();
+		bool LastTrackOverlaps = true;
+		LoopPlaybackInformation playbackInformation = null;
+
+		public IEnumerator LoadAudioClips(string filename, Assets.Scripts.Core.Audio.AudioType type)
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				string preLoopFilename = Path.GetFileNameWithoutExtension(filename) + $"_{i}" + Path.GetExtension(filename);
+				string preLoopPath = AssetManager.Instance.GetAudioFilePath(preLoopFilename, type);
+
+				bool fileExists = false;
+
+				if (File.Exists(preLoopPath))
+				{
+					fileExists = true;
+				}
+				else
+				{
+					// If file not found, try checking same path suffixed with 'f' - this means that the audio
+					// file is a 'full audio' and should not overlap with the main audio loop
+					preLoopFilename = Path.GetFileNameWithoutExtension(filename) + $"_{i}f" + Path.GetExtension(filename);
+					preLoopPath = AssetManager.Instance.GetAudioFilePath(preLoopFilename, type);
+
+					if (File.Exists(preLoopPath))
+					{
+						LastTrackOverlaps = false;
+						fileExists = true;
+					}
+				}
+
+				if (fileExists)
+				{
+					WWW audioLoaderIntro = new WWW("file://" + preLoopPath);
+					yield return audioLoaderIntro;
+					AudioClips.Add(audioLoaderIntro.audioClip);
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+		public LoopPlaybackInformation OnFinishLoad(GameObject gameObjectToAttach, int priority)
+		{
+			// Probably unnecessary, but there was a guard here in the original code to prevent creating extra AudioSource objects unecessarily
+			if (playbackInformation != null)
+			{
+				return playbackInformation;
+			}
+
+			// First, generate an audio source for each audio clip
+			foreach (AudioClip audioClip in AudioClips)
+			{
+				AudioSource audioSource = gameObjectToAttach.AddComponent<AudioSource>();
+
+				audioSource.clip = audioClip;
+				audioSource.loop = false;
+				audioSource.priority = priority;
+
+				AudioSources.Add(audioSource);
+			}
+
+			// Then, determine when each audio should start playing
+			float overlapAmount = 0;
+			float playHead = 0;
+			foreach(AudioSource audioSource in AudioSources)
+			{
+				// Handle overlap by moving playhead back slightly (but never less than 0)
+				playHead = Math.Max(0, playHead - overlapAmount);
+
+				audioSource.PlayDelayed(playHead);
+
+				// Increment playhead equal to length of played track
+				playHead += audioSource.clip.length;
+			}
+
+			playbackInformation = new LoopPlaybackInformation(playHead, GetLoopInitialStartTime());
+			return playbackInformation;
+		}
+
+		private float GetLoopInitialStartTime()
+		{
+			// Return the length of the last audio, if the last audio track overlaps the main loop
+			if(LastTrackOverlaps && AudioClips.Count > 0)
+			{
+				return AudioClips[AudioClips.Count - 1].length;
+			}
+
+			// Otherwise, the main loop plays from the start
+			return 0;
+		}
+
+		public void StopAudio()
+		{
+			foreach (AudioSource audioSource in AudioSources)
+			{
+				audioSource.Stop();
+			}
+
+			foreach(AudioClip audioClip in AudioClips)
+			{
+				UnityEngine.Object.Destroy(audioClip);
+			}
+		}
+
+		public bool IsPlaying()
+		{
+			foreach(AudioSource audioSource in AudioSources)
+			{
+				if(audioSource.isPlaying)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public float GetRemainingPlayTime()
+		{
+			float remainingPlayTime = 0;
+
+			foreach (AudioSource audioSource in AudioSources)
+			{
+				if(audioSource.time != audioSource.clip.length)
+				{
+					remainingPlayTime = audioSource.clip.length - audioSource.time;
+				}
+			}
+
+			return remainingPlayTime;
+		}
+
+		public int GetPlayTimeSamples()
+		{
+			int playTimeSamples = 0;
+
+			foreach (AudioSource audioSource in AudioSources)
+			{
+				playTimeSamples += audioSource.timeSamples;
+			}
+
+			return playTimeSamples;
+		}
+
+		// To be called from AudioLayerUnity.cs's Update() function
+		public void Update(float volume)
+		{
+			foreach (AudioSource audioSource in AudioSources)
+			{
+				audioSource.volume = volume;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This branch implements "properly" looping BGM/SFX (well, the engine side of it. Each file needs to be prepared for looping if it doesn't already loop seamlessly.). 

## Background

brotherelric on discord approached me last year, basically saying they wanted to implement proper looping for Higurashi, and asked if I could do the engine side of things, and they could do the BGM/SFX processing side of things.

Work stopped for a long time while they were busy, but now we're back into it. I decided to make this PR to keep track of the branch where I had added the BGM/SFX looping function.

## Overview (to be completed)

Each BGM has:

Below to be filled in properly later...

- Zero or more introduction sections, which are only played once (?)
- At least one looping section, which is looped after the introductions play
- All transitions are seamless (at least enough that you shouldn't be able to hear the seams between sections)

Below is my comment from discord. But it's not finalized, may have other changes

## Notes

Insert google sheets we're using to keep track of BGM/SE here

## Details

Ok so I've tested what we discussed, and everything seems to work, however I would like to use a slightly different naming scheme:

- The main looping BGM should just be the filename with no suffix at all. Eg `msys02.ogg`
- The intro files will be played in numeric order starting from `0`, according to the suffix. Eg `msys02_0.ogg`, `msys02_1.ogg` will play in that order one after another, then it will play `msys02.ogg` (no suffix) forever.
- For intro files which 'play fully', I decided to use the suffix `f` rather than `y`, eg `f` stands for full
- Numbering starts at 0 always

To make it clear, the two files you sent me should be renamed:

`msys02_0.ogg` (intro)
`msys02.ogg` (loop, starts with offset = len(intro) the first time only)

`msys04_0.ogg` (intro)
`msys04.ogg` (loop, starts with offset = len(intro) the first time only)

And some more hypothetical examples:

`msys99_0.ogg` (intro 1, played first)
`msys99_1.ogg` (intro 2, played second)
`msys99.ogg` (loop, starts with offset = len(intro 2) the first time only)

And for doing 'full' playback with the `f` suffix:

`msys99_0f.ogg` (intro 1)
`msys99.ogg` (loop, starts with offset = 0)