### PR TITLE
Add Standalone Script Compiler Build configuration

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -4,9 +4,7 @@
     <ProjectGuid>{0BA774AA-B2B4-468C-B002-CAA0652C466E}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
     <LangVersion>7.1</LangVersion>
-    <AssemblyName>Assembly-CSharp</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -26,7 +24,13 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
-  <ItemGroup>
+
+  <!-- These options are used when building the DLL for use in the mod-->
+  <PropertyGroup Condition="'$(Configuration)' != 'ScriptCompiler'">
+    <OutputType>Library</OutputType>
+    <AssemblyName>Assembly-CSharp</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(Configuration)' != 'ScriptCompiler'">
     <Reference Include="UnityEngine">
       <HintPath>DLLs\UnityEngine.dll</HintPath>
     </Reference>
@@ -51,8 +55,6 @@
     <Reference Include="UnityEngine.UI">
       <HintPath>DLLs\UnityEngine.UI.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="ActiveAnimation.cs" />
     <Compile Include="AnimatedAlpha.cs" />
     <Compile Include="AnimatedColor.cs" />
@@ -71,7 +73,6 @@
     <Compile Include="Assets.Scripts.Core.Audio\AudioInfo.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioLayerUnity.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioType.cs" />
-    <Compile Include="BGICompiler.Compiler\LoggerWrapper.cs" />
     <Compile Include="MOD.Scripts.AssetManager\MODAssetManager.cs" />
     <Compile Include="MOD.Scripts.Core.Audio\MODAudioSet.cs" />
     <Compile Include="MOD.Scripts.Core.Audio\MODAudioTracking.cs" />
@@ -193,6 +194,7 @@
     <Compile Include="BGICompiler.Compiler\BGIParameters.cs" />
     <Compile Include="BGICompiler.Compiler\BGItoMG.cs" />
     <Compile Include="BGICompiler.Compiler\BGIValue.cs" />
+    <Compile Include="BGICompiler.Compiler\LoggerWrapper.cs" />
     <Compile Include="BGICompiler.Compiler\OperationHandler.cs" />
     <Compile Include="BGICompiler.Compiler\OpType.cs" />
     <Compile Include="BMFont.cs" />
@@ -616,6 +618,52 @@
     <Compile Include="UIWidgetContainer.cs" />
     <Compile Include="UIWrapContent.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <!-- End normal DLL items-->
+
+  <!--
+  These options are when building a standalone "Script Compiler" executable,
+  which is used to compile the game scripts on Github Actions.
+
+  NOTE: Visual Studio doesn't properly reload settings when you switch configurations,
+  so you will need to reload the project when you are changing between "Release" and "ScriptCompiler"
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'ScriptCompiler'">
+    <OutputType>Exe</OutputType>
+    <AssemblyName>HigurashiScriptCompiler</AssemblyName>
+    <DefineConstants>STANDALONE_SCRIPT_COMPILER</DefineConstants>
+    <!-- Output and optimization options -->
+    <OutputPath>bin\ScriptCompiler\</OutputPath>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'ScriptCompiler'">
+    <Reference Include="System">
+      <HintPath>DLLs\System.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core">
+      <HintPath>DLLs\System.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Antlr3.Runtime">
+      <HintPath>DLLs\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Compile Include="AntlrTest\bgitestLexer.cs" />
+    <Compile Include="AntlrTest\bgitestParser.cs" />
+    <Compile Include="BGICompiler.Compiler\LoggerWrapper.cs" />
+    <Compile Include="Assets.Scripts.Core.Buriko\BurikoCommands.cs" />
+    <Compile Include="Assets.Scripts.Core.Buriko\BurikoMathType.cs" />
+    <Compile Include="Assets.Scripts.Core.Buriko\BurikoOperations.cs" />
+    <Compile Include="Assets.Scripts.Core.Buriko\BurikoTextModes.cs" />
+    <Compile Include="Assets.Scripts.Core.Buriko\BurikoValueType.cs" />
+    <Compile Include="BGICompiler.Compiler\BGIParameters.cs" />
+    <Compile Include="BGICompiler.Compiler\BGItoMG.cs" />
+    <Compile Include="BGICompiler.Compiler\BGIValue.cs" />
+    <Compile Include="BGICompiler.Compiler\NoUnityScriptCompiler.cs" />
+    <Compile Include="BGICompiler.Compiler\OperationHandler.cs" />
+    <Compile Include="BGICompiler.Compiler\OpType.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <!-- End standalone script compiler items -->
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Assets.Scripts.Core.Audio\AudioInfo.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioLayerUnity.cs" />
     <Compile Include="Assets.Scripts.Core.Audio\AudioType.cs" />
+    <Compile Include="BGICompiler.Compiler\LoggerWrapper.cs" />
     <Compile Include="MOD.Scripts.AssetManager\MODAssetManager.cs" />
     <Compile Include="MOD.Scripts.Core.Audio\MODAudioSet.cs" />
     <Compile Include="MOD.Scripts.Core.Audio\MODAudioTracking.cs" />

--- a/Assembly-CSharp.sln
+++ b/Assembly-CSharp.sln
@@ -9,12 +9,15 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		ScriptCompiler|Any CPU = ScriptCompiler|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0BA774AA-B2B4-468C-B002-CAA0652C466E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0BA774AA-B2B4-468C-B002-CAA0652C466E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BA774AA-B2B4-468C-B002-CAA0652C466E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BA774AA-B2B4-468C-B002-CAA0652C466E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BA774AA-B2B4-468C-B002-CAA0652C466E}.ScriptCompiler|Any CPU.ActiveCfg = ScriptCompiler|Any CPU
+		{0BA774AA-B2B4-468C-B002-CAA0652C466E}.ScriptCompiler|Any CPU.Build.0 = ScriptCompiler|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BGICompiler.Compiler/BGIParameters.cs
+++ b/BGICompiler.Compiler/BGIParameters.cs
@@ -1,7 +1,7 @@
 using Antlr.Runtime.Tree;
 using Assets.Scripts.Core.Buriko;
 using System.Collections.Generic;
-using UnityEngine;
+using BGICompiler.Compiler.Logger;
 
 namespace BGICompiler.Compiler
 {

--- a/BGICompiler.Compiler/BGItoMG.cs
+++ b/BGICompiler.Compiler/BGItoMG.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using UnityEngine;
+using BGICompiler.Compiler.Logger;
 
 namespace BGICompiler.Compiler
 {

--- a/BGICompiler.Compiler/LoggerWrapper.cs
+++ b/BGICompiler.Compiler/LoggerWrapper.cs
@@ -1,0 +1,47 @@
+// Comment out to use Console.WriteLine(...)
+// #define USE_CONSOLE_LOGGING
+
+using System;
+
+namespace BGICompiler.Compiler.Logger
+{
+	class Debug
+	{
+#if USE_CONSOLE_LOGGING
+		public static void Log(object message)
+		{
+			print($"INFO", message);
+		}
+
+		public static void LogWarning(object message)
+		{
+			print("WARN", message);
+		}
+
+		public static void LogError(object message)
+		{
+			print("ERROR", message);
+		}
+
+		private static void print(string level, object message)
+		{
+			Console.WriteLine($"[{level}] {message}", message);
+		}
+#else
+		public static void Log(object message)
+		{
+			UnityEngine.Debug.Log(message);
+		}
+
+		public static void LogWarning(object message)
+		{
+			UnityEngine.Debug.LogWarning(message);
+		}
+
+		public static void LogError(object message)
+		{
+			UnityEngine.Debug.Log(message);
+		}
+#endif
+	}
+}

--- a/BGICompiler.Compiler/LoggerWrapper.cs
+++ b/BGICompiler.Compiler/LoggerWrapper.cs
@@ -1,13 +1,10 @@
-// Comment out to use Console.WriteLine(...)
-// #define USE_CONSOLE_LOGGING
-
 using System;
 
 namespace BGICompiler.Compiler.Logger
 {
 	class Debug
 	{
-#if USE_CONSOLE_LOGGING
+#if STANDALONE_SCRIPT_COMPILER
 		public static void Log(object message)
 		{
 			print($"INFO", message);

--- a/BGICompiler.Compiler/NoUnityScriptCompiler.cs
+++ b/BGICompiler.Compiler/NoUnityScriptCompiler.cs
@@ -1,0 +1,90 @@
+﻿#if STANDALONE_SCRIPT_COMPILER
+
+using System;
+using System.IO;
+using BGICompiler.Compiler.Logger;
+
+namespace BGICompiler.Compiler
+{
+	internal class NoUnityScriptCompiler
+	{
+		private static bool SaveCompileStatus(int numTotal, int numPass, int numFail)
+		{
+			bool allCompiledOK = numPass == numTotal;
+			bool atLeastOneCompiled = numPass != 0;
+			bool pass = allCompiledOK && atLeastOneCompiled;
+
+			// Also consider compilation a failure if no scripts were compiled
+			string statusString = pass ? "Compile OK" : "FAIL";
+			statusString += $" | {numPass}/{numTotal} compiled and {numFail} failed";
+			File.WriteAllText("higu_script_compile_status.txt", statusString);
+
+			return pass;
+		}
+
+		private static bool CompileFolder(string srcDir, string destDir)
+		{
+			string[] txtPaths = Directory.GetFiles(srcDir, "*.txt");
+			int numTotal = txtPaths.Length;
+
+			int numPass = 0;
+			int numFail = 0;
+			int progress = 0;
+			foreach (string txtPath in txtPaths)
+			{
+				progress++;
+
+				try
+				{
+					string txtPathNoExt = Path.GetFileNameWithoutExtension(txtPath);
+					string mgPath = Path.Combine(destDir, txtPathNoExt) + ".mg";
+					Debug.Log($"Compiling [{progress}/{numTotal}] {txtPath} -> {mgPath}...");
+					new BGItoMG(txtPath, mgPath);
+					numPass++;
+				}
+				catch (Exception e)
+				{
+					Debug.LogWarning($"Failed to compile script {txtPath}!\r\n{e}");
+					numFail++;
+				}
+			}
+
+			return SaveCompileStatus(numTotal, numPass, numFail);
+		}
+
+		public static int Main(string[] args)
+		{
+			if(args.Length < 2)
+			{
+				Debug.LogError($"Got {args.Length} args but need at least two args:\n" +
+					$" 1. path to the 'Update' (.txt) folder\n" +
+					$" 2. path to the 'CompiledUpdateScripts' folder (.mg)\n" +
+					$"Example: [HigurashiScriptCompiler Update CompiledUpdateScripts] when called from inside the StreamingAssets folder.");
+				return -1;
+			}
+
+			Debug.Log($"Got {args.Length} args");
+
+			string txtFolderPath = args[0];
+			string mgFolderPath = args[1];
+
+			Debug.Log($"Compiling Scripts In {txtFolderPath} -> {mgFolderPath}");
+
+			if(!Directory.Exists(txtFolderPath))
+			{
+				Debug.LogError($"Source .txt script folder does not exist at [{txtFolderPath}]");
+				return -1;
+			}
+
+			if (!Directory.Exists(mgFolderPath))
+			{
+				Debug.LogError($"Destination .mg script folder does not exist at [{mgFolderPath}]");
+				return -1;
+			}
+
+			return CompileFolder(txtFolderPath, mgFolderPath) ? 0 : -1;
+		}
+	}
+}
+
+#endif

--- a/BGICompiler.Compiler/OperationHandler.cs
+++ b/BGICompiler.Compiler/OperationHandler.cs
@@ -3,7 +3,7 @@ using Assets.Scripts.Core.Buriko;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEngine;
+using BGICompiler.Compiler.Logger;
 
 namespace BGICompiler.Compiler
 {


### PR DESCRIPTION
Note: this PR was written ontop of the other window resolution fixes PR here: https://github.com/07th-mod/higurashi-assembly/pull/128 . That other PR should be merged first.

This PR adds an additional build configuration which produces a standalone "Script Compiler" executable (without Unity).

This avoids needing to run a skeleton of the game just for the purpose of building the game scripts (note: currently script compilation on Github Actions is not working for all chapters)

The PR is in Draft because I still need to:

- [x] Merge other PR https://github.com/07th-mod/higurashi-assembly/pull/128
- [x] Tidy up this PRs commit history
- [ ] Test in github actions
- [x] Verify compiled scripts are identical to ones generated by the game
- [ ] See if there will be any problems merging this with later chapters as the .csproj is slightly different on later chapters
- [ ] Merge this into every chapter 