### PR TITLE
Disabling playback when voice volume is set to 0

### DIFF
--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -545,6 +545,8 @@ namespace Assets.Scripts.Core.Audio
 
 		public void MODPlayVoiceLS(string filename, int channel, float volume, int character)
 		{
+			if(VoiceVolume <= 0f) return;
+			
 			MODTextController.MODCurrentVoiceLayerDetect = channel;
 			AudioLayerUnity audio = channelDictionary[GetChannelByTypeChannel(AudioType.Voice, channel)];
 			if (currentAudio[AudioType.Voice].ContainsKey(channel))

--- a/Assets.Scripts.Core.Audio/AudioController.cs
+++ b/Assets.Scripts.Core.Audio/AudioController.cs
@@ -545,8 +545,15 @@ namespace Assets.Scripts.Core.Audio
 
 		public void MODPlayVoiceLS(string filename, int channel, float volume, int character)
 		{
-			if(VoiceVolume <= 0f) return;
-			
+			// If voice volume set to 0, skip executing MODPlayVoiceLS(...) altogether.
+			// This ensures that, for users who have voices "turned off":
+			// - No unecessary delays waiting for voices to play out in Auto Mode
+			// - Lipsync is automatically disabled when voice volume is 0
+			if (VoiceVolume <= 0f)
+			{
+				return;
+			}
+
 			MODTextController.MODCurrentVoiceLayerDetect = channel;
 			AudioLayerUnity audio = channelDictionary[GetChannelByTypeChannel(AudioType.Voice, channel)];
 			if (currentAudio[AudioType.Voice].ContainsKey(channel))


### PR DESCRIPTION
Investigated this for my personal use case of at times preferring a faster auto speed but this being capped by the fact voice lines would still play out. More granular control such as a toggle asking if you'd like Auto to wait for voice lines to finish is preferable but I figured the subset of people looking for 0 voice volume and also voice timed audio were slim.
As well, this mimics functionality in Higurashi no Naku Koro ni Hou on Switch/PS4. Other console ports I do not have experience with :)