### PR TITLE
[4:3 Aspect Ryukishi Mode] Letterbox Console CGs by default rather than stretching to fill screen.

### DIFF
--- a/Assets.Scripts.Core.AssetManagement/AssetManager.cs
+++ b/Assets.Scripts.Core.AssetManagement/AssetManager.cs
@@ -177,6 +177,8 @@ namespace Assets.Scripts.Core.AssetManagement
 		public static readonly int ScreenshotWidth = 382;
 		public static readonly int ScreenshotHeight = 286;
 
+		public static readonly string MOVIE_TEXTURE_NAME = "scene/_internal_movie_texture";
+
 		/// <summary>
 		/// Get the artset at the given index
 		/// </summary>
@@ -698,6 +700,17 @@ namespace Assets.Scripts.Core.AssetManagement
 
 		public Texture2D LoadTexture(string textureName, out string texturePath)
 		{
+			if(textureName == MOVIE_TEXTURE_NAME)
+			{
+				// This is a hacky way to easily get an appropriately sized layer for movie playback.
+				// Since the texture pretends to be in the 'scene' folder, it will be treated as a CG,
+				// and scaled according to CG scaling options when in 4:3 mode.
+				// This will work appropriately for 16:9 movies, but if we ever have a movie with an odd
+				// aspect ratio it will just stretch to the size of the screen.
+				texturePath = string.Empty;
+				return new Texture2D(1920, 1080, TextureFormat.ARGB32, mipmap: false);
+			}
+
 			if (textureName == "windo_filter" && windowTexture != null)
 			{
 				texturePath = windowTexturePath;

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -117,6 +117,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GBackgroundSet", 528);
 			variableReference.Add("GAudioSet", 529);
 			variableReference.Add("GRyukishiMode43Aspect", 530);
+			variableReference.Add("GRyukishiMode43Letterbox", 531);
 
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -117,7 +117,7 @@ namespace Assets.Scripts.Core.Buriko
 			variableReference.Add("GBackgroundSet", 528);
 			variableReference.Add("GAudioSet", 529);
 			variableReference.Add("GRyukishiMode43Aspect", 530);
-			variableReference.Add("GRyukishiMode43Letterbox", 531);
+			variableReference.Add("GRyukishiMode43CGScalingMode", 531);
 
 			// 611 - 619 used for additional chapter progress info
 			SetGlobalFlag("GMessageSpeed", 60);

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -403,20 +403,36 @@ namespace Assets.Scripts.Core.Scene
 					// We could letter-box the images, but in some cases whatever is behind the image may show up? Not sure.
 					if(!isSpriteOrPortrait)
 					{
-						if ((GetGlobalFlagInt("GRyukishiMode43CGScalingMode") != 0) && textureNameFromGameScript.StartsWith("scene/"))
+						// Non-sprites handling (backgrounds, Console CG, effects etc.)
+						if(textureNameFromGameScript.StartsWith("scene/"))
 						{
-							scalingOverride = ScalingOverride.LetterboxVerticalHorizontal;
+							// Console CG handling
+							if (GetGlobalFlagInt("GRyukishiMode43CGScalingMode") == 0)
+							{
+								// Default option is to letterbox Console CGs
+								scalingOverride = ScalingOverride.LetterboxVerticalHorizontal;
+							}
+							else
+							{
+								// Option to stretch Console CGs to fill screen
+								// (this was the default behavior before 2025-10-26)
+								scalingOverride = ScalingOverride.StretchToFit;
+							}
 						}
 						else
 						{
+							// Backgrounds, effects etc. handling (non-console CGs)
+							// Everything except Console CGs stretch to fit the screen even if the aspect ratio is wrong
+							// For example, effect images or text images which have not been replaced.
 							scalingOverride = ScalingOverride.StretchToFit;
 						}
 					}
 
-					// Option to letter box CGs ('scene' folder), instead of stretching
-
 					// Do not stretch if the image is more than 5% off a 16:9 aspect ratio.
 					// Likely these are special images like credits images or effect images.
+					// Some Console CGs are funny aspect ratios because there is a panning effect,
+					// Letterboxing may intefere with the panning so for now just use the default scaling
+					// for this chapter and hopefully it works out.
 					scalingOverride = FilterStretchingBasedOnAspectRatio(scalingOverride, 16f / 9f);
 				}
 				else

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -403,7 +403,7 @@ namespace Assets.Scripts.Core.Scene
 					// We could letter-box the images, but in some cases whatever is behind the image may show up? Not sure.
 					if(!isSpriteOrPortrait)
 					{
-						if (GetGlobalFlagBool("GRyukishiMode43Letterbox") && textureNameFromGameScript.StartsWith("scene/"))
+						if ((GetGlobalFlagInt("GRyukishiMode43CGScalingMode") != 0) && textureNameFromGameScript.StartsWith("scene/"))
 						{
 							scalingOverride = ScalingOverride.LetterboxVerticalHorizontal;
 						}

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -869,7 +869,36 @@ namespace Assets.Scripts.Core.Scene
 		}
 
 		// The below two CreateMesh functions clamp the image height to 480 
-		// (the height of the screen in vertex coords) while maintaining the aspect ratio. 
+		// (the height of the screen in vertex coords) while maintaining the aspect ratio.
+		// I think the "LayerAlignment" version is ever called 99-100% of the time, and the "origin" function
+		// is rarely or never called in our game scripts.
+		//
+		//////////////////////// Regarding the "origin" version of the function ///////////////////////////////////////////////
+		// AFAIK, CreateMesh(..., Vector 2 origin, ...) is only ever called when the third last argument, "originx" of:
+		// - DrawBustshotWithFiltering(...)
+		// - DrawSprite(...)
+		// - MODDrawCharacterWithFiltering(...)
+		// is called in the game script (or possibly in some cases where a layer has its origin set non-null)
+		// However, I think we never do this in our game scripts, so I think this function is never (or rarely) called.
+		//
+		// On closer inspection, I think the function is broken, because it calculates the new scaling ratio for the width as:
+		//     scaling = newHeight / oldHeight
+		// where all three variables are integers (I think they should be floats like the "Alignment" version of the function).
+		// This means scaling is sort of a step function. For example, if the image height is 800, and it gets clamped to 480,
+		// then scaling = 800 / 480 = 0, so the width becomes 0 and the image doesn't show at all...
+		//
+		// Because I'm not really sure, I'm not going to fix it for now and try to retain the existing behavior.
+		/// Regarding differences bewteen chapters
+		/// - "Mod" branch + Ch[1, 2]: Left and right black bars only
+		///     - In other words, the image height is clamped to the window height, then the width is set to keep the same aspect
+		///       ratio. Tall images are OK, but images wider than the window will be cut-off
+		/// - Console + Ch[3, 4, 5, 7]: Both Left and right black bars, and top and bottom black bars are supported
+		/// - Ch[6, 8, 9, 10 (hou)] : In addition to both types of letterboxing, ONLY when origin is non-null, special cases are
+		///   added for specific width and heights:
+		///     - A height of 960 is converted to a height of 480
+		///     - A width of 1280 is converted to a width of 640
+		///     - I don't actually know if this does anything extra compared to normal?
+		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		private void CreateMesh(int width, int height, Vector2 origin, bool ryukishiClamp, int finalXOffset, bool stretchToFit)
 		{
 			int num = Mathf.Clamp(height, 1, 480);

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -8,6 +8,13 @@ namespace Assets.Scripts.Core.Scene
 {
 	public class Layer : MonoBehaviour
 	{
+		private enum ScalingOverride
+		{
+			Normal,
+			StretchToFit,
+			LetterboxVerticalHorizontal
+		}
+
 		private const string shaderDefaultName = "MGShader/LayerShader";
 
 		private const string shaderAlphaBlendName = "MGShader/LayerShaderAlpha";
@@ -432,13 +439,19 @@ namespace Assets.Scripts.Core.Scene
 				cachedFinalXOffset = finalXOffset;
 				cachedRyukishiClamp = ryukishiClamp;
 
+				ScalingOverride scalingOverride = ScalingOverride.Normal;
+				if (stretchToFit)
+				{
+					scalingOverride = ScalingOverride.StretchToFit;
+				}
+
 				if (origin is Vector2 nonnullOrigin)
 				{
-					CreateMesh(width, height, nonnullOrigin, ryukishiClamp, finalXOffset, stretchToFit);
+					CreateMesh(width, height, nonnullOrigin, ryukishiClamp, finalXOffset, scalingOverride);
 				}
 				else
 				{
-					CreateMesh(width, height, alignment, ryukishiClamp, finalXOffset, stretchToFit);
+					CreateMesh(width, height, alignment, ryukishiClamp, finalXOffset, scalingOverride);
 				}
 			}
 			this.origin = origin;
@@ -899,30 +912,67 @@ namespace Assets.Scripts.Core.Scene
 		///     - A width of 1280 is converted to a width of 640
 		///     - I don't actually know if this does anything extra compared to normal?
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-		private void CreateMesh(int width, int height, Vector2 origin, bool ryukishiClamp, int finalXOffset, bool stretchToFit)
+		private void CreateMesh(int width, int height, Vector2 origin, bool ryukishiClamp, int finalXOffset, ScalingOverride scalingOverride)
 		{
 			int num = Mathf.Clamp(height, 1, 480);
 			int num2 = num / height;
 			int width2 = Mathf.RoundToInt((float)Mathf.Clamp(width, 1, num2 * width));
-			if(stretchToFit)
-			{
-				width2 = Mathf.RoundToInt(num * GameSystem.Instance.AspectRatio);
-			}
+
+			ApplyScalingOverride(width, height, scalingOverride, ref width2, ref num);
+
 			mesh = MGHelper.CreateMeshWithOrigin(width2, num, origin, ryukishiClamp, finalXOffset);
 			meshFilter.mesh = mesh;
 		}
 
-		private void CreateMesh(int width, int height, LayerAlignment alignment, bool ryukishiClamp, int finalXOffset, bool stretchToFit)
+		private void CreateMesh(int width, int height, LayerAlignment alignment, bool ryukishiClamp, int finalXOffset, ScalingOverride scalingOverride)
 		{
 			int num = Mathf.Clamp(height, 1, 480);
 			float num2 = (float)num / (float)height;
 			int width2 = Mathf.RoundToInt(Mathf.Clamp((float)width, 1f, num2 * (float)width));
-			if (stretchToFit)
-			{
-				width2 = Mathf.RoundToInt(num * GameSystem.Instance.AspectRatio);
-			}
+
+			ApplyScalingOverride(width, height, scalingOverride, ref width2, ref num);
+
 			mesh = MGHelper.CreateMesh(width2, num, alignment, ryukishiClamp, finalXOffset);
 			meshFilter.mesh = mesh;
+		}
+
+		private void ApplyScalingOverride(int width, int height, ScalingOverride scalingOverride, ref int newWidth, ref int newHeight)
+		{
+			switch (scalingOverride)
+			{
+				case ScalingOverride.StretchToFit:
+					// Stretch image to fit the entire screen
+					newHeight = Mathf.Clamp(height, 1, 480);
+					newWidth = Mathf.RoundToInt(newHeight * GameSystem.Instance.AspectRatio);
+					break;
+				case ScalingOverride.LetterboxVerticalHorizontal:
+					LetterboxVerticalHorizontal(width, height, out newWidth, out newHeight);
+					break;
+				case ScalingOverride.Normal:
+				default:
+					// Don't change the existing values
+					break;
+			}
+		}
+
+		private void LetterboxVerticalHorizontal(int width, int height, out int newWidth, out int newHeight)
+		{
+			// For convenience, these variables store the window size in game coordinates.
+			// For 4:3 mode it is 640 x 480. For 16:9 it is 853 * 640.
+			float windowHeightGameCoordinates = 480;
+			float windowWidthGameCoordinates = windowHeightGameCoordinates * GameSystem.Instance.AspectRatio;
+
+			// Separately calculate the scaling required for the texture to fit on the window, for the x and y axis
+			// For example, if the image was 960 in height, then the yScalingRequired would be 0.5
+			float xScalingToFitWidth = Mathf.Clamp(width, 1, windowWidthGameCoordinates) / width;
+			float yScalingToFitHeight = Mathf.Clamp(height, 1, windowHeightGameCoordinates) / height;
+
+			// To ensure texture always fits in window, take the minimum of the two scaling factors
+			float scalingRequired = Mathf.Min(xScalingToFitWidth, yScalingToFitHeight);
+
+			// Apply this scaling to both axis to maintain the original texture's aspect ratio
+			newWidth = (int)(width * scalingRequired);
+			newHeight = (int)(height * scalingRequired);
 		}
 
 		public void Initialize()

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -10,7 +10,7 @@ namespace Assets.Scripts.Core.Scene
 	{
 		private enum ScalingOverride
 		{
-			Normal,
+			None,
 			StretchToFit,
 			LetterboxVerticalHorizontal
 		}
@@ -102,9 +102,10 @@ namespace Assets.Scripts.Core.Scene
 		private int? layerID; // The layer number in the scene controller, if it has one
 
 		private bool cachedIsBustShot;
-		private bool cachedStretchToFit;
+		private ScalingOverride cachedScalingOverride;
 		private bool cachedRyukishiClamp;
 		private int cachedFinalXOffset;
+		private bool stretchModeLetterboxing;
 
 		public int? LayerID
 		{
@@ -369,27 +370,30 @@ namespace Assets.Scripts.Core.Scene
 
 		private void EnsureCorrectlySizedMesh(int width, int height, LayerAlignment alignment, Vector2? origin, bool isBustShot, int finalXOffset, string texturePath, string textureNameFromGameScript, bool disableRyukishiClamp = false)
 		{
-			bool FilterStretchingBasedOnAspectRatio(bool inputShouldStretch, float targetAspect)
+			ScalingOverride FilterStretchingBasedOnAspectRatio(ScalingOverride inputScalingOverride, float targetAspect)
 			{
 				// Do not stretch if the image is more than 5% off the target aspect ratio.
 				// Likely these are special images like credits images or effect images.
 				float imageAspect = (float)width / (float)height;
 				if (imageAspect > targetAspect * 1.05 || imageAspect < targetAspect * .95f)
 				{
-					return false;
+					return ScalingOverride.None;
 				}
 
 				// Otherwise, leave value unchanged
-				return inputShouldStretch;
+				return inputScalingOverride;
 			}
 
-			bool ryukishiClamp = false;
-			bool stretchToFit = false;
+            int GetGlobalFlagInt(string flagname) => Buriko.BurikoMemory.Instance.GetGlobalFlag(flagname).IntValue();
+            bool GetGlobalFlagBool(string flagname) => Buriko.BurikoMemory.Instance.GetGlobalFlag(flagname).IntValue() != 0;
+
+            bool ryukishiClamp = false;
+			ScalingOverride scalingOverride = ScalingOverride.None;
 			if (texturePath != null)
 			{
 				bool isSpriteOrPortrait = AssetManager.RelativePathIsSprite(textureNameFromGameScript);
 
-				if (Buriko.BurikoMemory.Instance.GetGlobalFlag("GRyukishiMode43Aspect").IntValue() != 0)
+				if (GetGlobalFlagBool("GRyukishiMode43Aspect"))
 				{
 					// When using true 4:3 mode, we don't need to clamp the sprites, as they are automatically cut off by the viewport
 					ryukishiClamp = false;
@@ -397,26 +401,41 @@ namespace Assets.Scripts.Core.Scene
 					// When using true 4:3 aspect mode, any 16:9 images (except for sprites) should be squished to 4:3.
 					// This make sure any text or other images don't get cut off
 					// We could letter-box the images, but in some cases whatever is behind the image may show up? Not sure.
-					stretchToFit = !isSpriteOrPortrait;
+					if(!isSpriteOrPortrait)
+					{
+						if (GetGlobalFlagBool("GRyukishiMode43Letterbox") && textureNameFromGameScript.StartsWith("scene/"))
+						{
+							scalingOverride = ScalingOverride.LetterboxVerticalHorizontal;
+						}
+						else
+						{
+							scalingOverride = ScalingOverride.StretchToFit;
+						}
+					}
+
+					// Option to letter box CGs ('scene' folder), instead of stretching
 
 					// Do not stretch if the image is more than 5% off a 16:9 aspect ratio.
 					// Likely these are special images like credits images or effect images.
-					stretchToFit = FilterStretchingBasedOnAspectRatio(stretchToFit, 16f / 9f);
+					scalingOverride = FilterStretchingBasedOnAspectRatio(scalingOverride, 16f / 9f);
 				}
 				else
 				{
 					// We want to clamp sprites to 4:3 if you are using the OG backgrounds, and you are not stretching the background
 					ryukishiClamp = isBustShot &&
-						Buriko.BurikoMemory.Instance.GetGlobalFlag("GBackgroundSet").IntValue() == 1 &&      // Using OG Backgrounds AND
-						Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 0 && // Not stretching backgrounds AND
+						GetGlobalFlagInt("GBackgroundSet") == 1 &&      // Using OG Backgrounds AND
+						GetGlobalFlagInt("GStretchBackgrounds") == 0 && // Not stretching backgrounds AND
 						isSpriteOrPortrait; // Is a sprite or portrait image. I don't think we can rely only on isBustShot, as sometimes non-sprites are drawn with isBustShot
 
 					// When using old backgrounds with stretch backgrounds enabled, stretch old 4:3 backgrounds to 16:9 to fill the screen
-					stretchToFit = Buriko.BurikoMemory.Instance.GetGlobalFlag("GStretchBackgrounds").IntValue() == 1 && texturePath.Contains("OGBackgrounds");
+					if(GetGlobalFlagInt("GStretchBackgrounds") == 1 && texturePath.Contains("OGBackgrounds"))
+					{
+						scalingOverride = ScalingOverride.StretchToFit;
+					}
 
 					// Do not stretch if the image is more than 5% off a 4:3 aspect ratio.
 					// Likely these are special images like credits images or effect images.
-					stretchToFit = FilterStretchingBasedOnAspectRatio(stretchToFit, 4f / 3f);
+					scalingOverride = FilterStretchingBasedOnAspectRatio(scalingOverride, 4f / 3f);
 				}
 			}
 
@@ -434,16 +453,10 @@ namespace Assets.Scripts.Core.Scene
 				this.origin != origin ||
 				cachedRyukishiClamp != ryukishiClamp ||
 				cachedFinalXOffset != finalXOffset ||
-				cachedStretchToFit != stretchToFit)
+				cachedScalingOverride != scalingOverride)
 			{
 				cachedFinalXOffset = finalXOffset;
 				cachedRyukishiClamp = ryukishiClamp;
-
-				ScalingOverride scalingOverride = ScalingOverride.Normal;
-				if (stretchToFit)
-				{
-					scalingOverride = ScalingOverride.StretchToFit;
-				}
 
 				if (origin is Vector2 nonnullOrigin)
 				{
@@ -457,7 +470,7 @@ namespace Assets.Scripts.Core.Scene
 			this.origin = origin;
 			this.alignment = alignment;
 			this.aspectRatio = (float)width / height;
-			cachedStretchToFit = stretchToFit;
+			this.cachedScalingOverride = scalingOverride;
 
 			// Do not rotate character sprites when using 4:3 letterboxing as current method does not handle it properly
 			if (ryukishiClamp)
@@ -948,7 +961,7 @@ namespace Assets.Scripts.Core.Scene
 				case ScalingOverride.LetterboxVerticalHorizontal:
 					LetterboxVerticalHorizontal(width, height, out newWidth, out newHeight);
 					break;
-				case ScalingOverride.Normal:
+				case ScalingOverride.None:
 				default:
 					// Don't change the existing values
 					break;

--- a/Assets.Scripts.Core.Scene/Layer.cs
+++ b/Assets.Scripts.Core.Scene/Layer.cs
@@ -12,7 +12,8 @@ namespace Assets.Scripts.Core.Scene
 		{
 			None,
 			StretchToFit,
-			LetterboxVerticalHorizontal
+			LetterboxVerticalHorizontal,
+			FitHeight
 		}
 
 		private const string shaderDefaultName = "MGShader/LayerShader";
@@ -407,16 +408,23 @@ namespace Assets.Scripts.Core.Scene
 						if(textureNameFromGameScript.StartsWith("scene/"))
 						{
 							// Console CG handling
-							if (GetGlobalFlagInt("GRyukishiMode43CGScalingMode") == 0)
-							{
-								// Default option is to letterbox Console CGs
-								scalingOverride = ScalingOverride.LetterboxVerticalHorizontal;
-							}
-							else
+							if (GetGlobalFlagInt("GRyukishiMode43CGScalingMode") == 1)
 							{
 								// Option to stretch Console CGs to fill screen
 								// (this was the default behavior before 2025-10-26)
 								scalingOverride = ScalingOverride.StretchToFit;
+							}
+							else if (GetGlobalFlagInt("GRyukishiMode43CGScalingMode") == 2)
+							{
+								// Crop Console CGs to 4:3
+								// Fitting a 16:9 image to a 4:3 aspect by height effectively crops the image -
+								// the left and right side of the image will extend beyond the game window and not be seen.
+								scalingOverride = ScalingOverride.FitHeight;
+							}
+							else
+							{
+								// Default option is to letterbox Console CGs
+								scalingOverride = ScalingOverride.LetterboxVerticalHorizontal;
 							}
 						}
 						else
@@ -976,6 +984,15 @@ namespace Assets.Scripts.Core.Scene
 					break;
 				case ScalingOverride.LetterboxVerticalHorizontal:
 					LetterboxVerticalHorizontal(width, height, out newWidth, out newHeight);
+					break;
+				case ScalingOverride.FitHeight:
+					{
+						// Scale the image (preserving aspect ratio) so the new height is the height of the window
+						// Wide images will appear cropped as they will extend beyond the edge of the window
+						newHeight = Mathf.Clamp(height, 1, 480);
+						float scale = newHeight / (float)height;
+						newWidth = Mathf.RoundToInt(width * scale);
+					}
 					break;
 				case ScalingOverride.None:
 				default:

--- a/MOD.Scripts.Core.State/StateMovie.cs
+++ b/MOD.Scripts.Core.State/StateMovie.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Core;
+using Assets.Scripts.Core.AssetManagement;
 using Assets.Scripts.Core.State;
 using MOD.Scripts.Core.Movie;
 using MOD.Scripts.UI;
@@ -110,7 +111,11 @@ namespace MOD.Scripts.Core.State
 		private void SetupBackgroundLayerForVideo()
 		{
 			movieInfo.Layer.ReleaseTextures();
-			movieInfo.Layer.DrawLayer("black", 0, 0, 0, null, 1f, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
+			// Refer to function "LoadTexture(...)" in Assets.Scripts.Core.AssetManagement\AssetManager.cs
+			// for details on special texture name AssetManager.MOVIE_TEXTURE_NAME used for movie playback
+			// Chapters 1-9 only have 16:9 videos
+			// Chapter 10 has both 16:9 and 4:3 videos, but has a different way of movie playback (StateMovie/ModPlayMovie is depreciated/never used on Ch.10)
+			movieInfo.Layer.DrawLayer(AssetManager.MOVIE_TEXTURE_NAME, 0, 0, 0, null, 1f, /*isBustshot:*/ false, 0, 0f, /*isBlocking:*/ false);
 		}
 	}
 }

--- a/MOD.Scripts.Core/MODLocalizationData.cs
+++ b/MOD.Scripts.Core/MODLocalizationData.cs
@@ -241,12 +241,12 @@ namespace MOD.Scripts.Core.Localization
 		public static string MODMenuSupportCompileFailed_23 => Get("MODMenuSupportCompileFailed_23", "Continue playing anyway (NOT RECOMMENDED)");
 		public static string MODMenuSupportCompileFailed_24 => Get("MODMenuSupportCompileFailed_24", "It is NOT RECOMMENDED to continue playing despite this error. The game may seem to be OK, but once you reach the script which failed to compile, the game may restart, or you may get severe graphical glitches or skip forward in the story unexpectedly.");
 
-		public static string MODMenuChoiceModeOptionTitle => Get("MODMenuChoiceModeOptionTitle","Choice Mode");
-		public static string MODMenuChoiceModeSkipName => Get("MODMenuChoiceModeSkipName","Skip / Auto Good End");
-		public static string MODMenuChoiceModeSkipDescription => Get("MODMenuChoiceModeSkipDescription","Skip choices. Proceed toward the good ending");
-		public static string MODMenuChoiceModeNormalName => Get("MODMenuChoiceModeNormalName","Normal");
-		public static string MODMenuChoiceModeNormalDescription => Get("MODMenuChoiceModeNormalDescription","Prompt choices normally");
-		public static string MODMenuChoiceModeHighlightName => Get("MODMenuChoiceModeHighlightName","Highlight Good");
-		public static string MODMenuChoiceModeHighlightDescription => Get("MODMenuChoiceModeHighlightDescription","Prompt choices and highlight correct answers");
+		public static string MODMenuChoiceModeOptionTitle => Get("MODMenuChoiceModeOptionTitle", "Choice Mode");
+		public static string MODMenuChoiceModeSkipName => Get("MODMenuChoiceModeSkipName", "Skip / Auto Good End");
+		public static string MODMenuChoiceModeSkipDescription => Get("MODMenuChoiceModeSkipDescription", "Skip choices. Proceed toward the good ending");
+		public static string MODMenuChoiceModeNormalName => Get("MODMenuChoiceModeNormalName", "Normal");
+		public static string MODMenuChoiceModeNormalDescription => Get("MODMenuChoiceModeNormalDescription", "Prompt choices normally");
+		public static string MODMenuChoiceModeHighlightName => Get("MODMenuChoiceModeHighlightName", "Highlight Good");
+		public static string MODMenuChoiceModeHighlightDescription => Get("MODMenuChoiceModeHighlightDescription", "Prompt choices and highlight correct answers");
 	}
 }

--- a/MOD.Scripts.Core/MODLocalizationData.cs
+++ b/MOD.Scripts.Core/MODLocalizationData.cs
@@ -251,7 +251,7 @@ namespace MOD.Scripts.Core.Localization
 
 		public static string MODMenu43CGScalingModeTitle => Get("MODMenu43CGScalingModeTitle", "Original/Ryukishi 4:3 Mode CG Scaling");
 		public static string MODMenu43CGScalingModeStretchName => Get("MODMenu43CGScalingModeStretchName", "Stretch to Fit 4:3");
-		public static string MODMenu43CGScalingModeStretchDescription => Get("MODMenu43CGScalingModeStretchDescription", "Any 16:9 Console CGs will be stretched to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.");
+		public static string MODMenu43CGScalingModeStretchDescription => Get("MODMenu43CGScalingModeStretchDescription", "Any 16:9 Console CGs will be stretched to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.\n\nThis was the default behavior before 2025-10-26.");
 		public static string MODMenu43CGScalingModeLetterBoxName => Get("MODMenu43CGScalingModeLetterBoxName", "Letterbox to Fit 4:3");
 		public static string MODMenu43CGScalingModeLetterBoxDescription => Get("MODMenu43CGScalingModeLetterBoxDescription", "Any 16:9 Console CGs will be letterboxed to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.");
 	}

--- a/MOD.Scripts.Core/MODLocalizationData.cs
+++ b/MOD.Scripts.Core/MODLocalizationData.cs
@@ -248,5 +248,11 @@ namespace MOD.Scripts.Core.Localization
 		public static string MODMenuChoiceModeNormalDescription => Get("MODMenuChoiceModeNormalDescription", "Prompt choices normally");
 		public static string MODMenuChoiceModeHighlightName => Get("MODMenuChoiceModeHighlightName", "Highlight Good");
 		public static string MODMenuChoiceModeHighlightDescription => Get("MODMenuChoiceModeHighlightDescription", "Prompt choices and highlight correct answers");
+
+		public static string MODMenu43CGScalingModeTitle => Get("MODMenu43CGScalingModeTitle", "Original/Ryukishi 4:3 Mode CG Scaling");
+		public static string MODMenu43CGScalingModeStretchName => Get("MODMenu43CGScalingModeStretchName", "Stretch to Fit 4:3");
+		public static string MODMenu43CGScalingModeStretchDescription => Get("MODMenu43CGScalingModeStretchDescription", "Any 16:9 Console CGs will be stretched to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.");
+		public static string MODMenu43CGScalingModeLetterBoxName => Get("MODMenu43CGScalingModeLetterBoxName", "Letterbox to Fit 4:3");
+		public static string MODMenu43CGScalingModeLetterBoxDescription => Get("MODMenu43CGScalingModeLetterBoxDescription", "Any 16:9 Console CGs will be letterboxed to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.");
 	}
 }

--- a/MOD.Scripts.Core/MODLocalizationData.cs
+++ b/MOD.Scripts.Core/MODLocalizationData.cs
@@ -254,5 +254,7 @@ namespace MOD.Scripts.Core.Localization
 		public static string MODMenu43CGScalingModeStretchDescription => Get("MODMenu43CGScalingModeStretchDescription", "Any 16:9 Console CGs will be stretched to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.\n\nThis was the default behavior before 2025-10-26.");
 		public static string MODMenu43CGScalingModeLetterBoxName => Get("MODMenu43CGScalingModeLetterBoxName", "Letterbox to Fit 4:3");
 		public static string MODMenu43CGScalingModeLetterBoxDescription => Get("MODMenu43CGScalingModeLetterBoxDescription", "Any 16:9 Console CGs will be letterboxed to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.");
+		public static string MODMenu43CGScalingModeCropName => Get("MODMenu43CGScalingModeCropName", "Crop to Fit 4:3");
+		public static string MODMenu43CGScalingModeCropDescription => Get("MODMenu43CGScalingModeCropDescription", "Any 16:9 Console CGs will be cropped to fit the 4:3 aspect ratio. This option only has an effect if 'Show Console CGs' is enabled.\n\nWARNING: Cropping is automatic, thus some CGs may be 'cut-off' on the left and right hand sides, or be poorly framed.");
 	}
 }

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -148,9 +148,8 @@ namespace MOD.Scripts.UI
 			});
 
 			radioRyukishiExperimentalAspectScalingMode = new MODRadio(Loc.MODMenu43CGScalingModeTitle, new GUIContent[]{
-				new GUIContent(Loc.MODMenu43CGScalingModeStretchName, Loc.MODMenu43CGScalingModeStretchDescription),
-				new GUIContent(Loc.MODMenu43CGScalingModeLetterBoxName, Loc.MODMenu43CGScalingModeLetterBoxDescription
-				),
+				new GUIContent(Loc.MODMenu43CGScalingModeLetterBoxName, Loc.MODMenu43CGScalingModeLetterBoxDescription),
+				new GUIContent(Loc.MODMenu43CGScalingModeStretchName, Loc.MODMenu43CGScalingModeStretchDescription)
 			});
 
 			customFlagPreset = Assets.Scripts.Core.Buriko.BurikoMemory.Instance.GetCustomFlagPresetInstance();

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -278,10 +278,14 @@ namespace MOD.Scripts.UI
 				GameSystem.Instance.SceneController.ReloadAllImages();
 			}
 
-			if (this.radioRyukishiExperimentalAspectScalingMode.OnGUIFragment(GetGlobal("GRyukishiMode43CGScalingMode")) is int cgScalingMode)
+			// Only show this option if "Ryukishi 4:3 Mode" and "Show CGs" are both enabled
+			if(GetGlobal("GRyukishiMode43Aspect") != 0  && GetGlobal("GHideCG") == 0)
 			{
-				SetGlobal("GRyukishiMode43CGScalingMode", cgScalingMode);
-				GameSystem.Instance.SceneController.ReloadAllImages();
+				if (this.radioRyukishiExperimentalAspectScalingMode.OnGUIFragment(GetGlobal("GRyukishiMode43CGScalingMode")) is int cgScalingMode)
+				{
+					SetGlobal("GRyukishiMode43CGScalingMode", cgScalingMode);
+					GameSystem.Instance.SceneController.ReloadAllImages();
+				}
 			}
 
 			if (Assets.Scripts.Core.Buriko.BurikoMemory.Instance.GetFlag("NVL_in_ADV").IntValue() == 1)

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -149,7 +149,8 @@ namespace MOD.Scripts.UI
 
 			radioRyukishiExperimentalAspectScalingMode = new MODRadio(Loc.MODMenu43CGScalingModeTitle, new GUIContent[]{
 				new GUIContent(Loc.MODMenu43CGScalingModeLetterBoxName, Loc.MODMenu43CGScalingModeLetterBoxDescription),
-				new GUIContent(Loc.MODMenu43CGScalingModeStretchName, Loc.MODMenu43CGScalingModeStretchDescription)
+				new GUIContent(Loc.MODMenu43CGScalingModeStretchName, Loc.MODMenu43CGScalingModeStretchDescription),
+				new GUIContent(Loc.MODMenu43CGScalingModeCropName, Loc.MODMenu43CGScalingModeCropDescription)
 			});
 
 			customFlagPreset = Assets.Scripts.Core.Buriko.BurikoMemory.Instance.GetCustomFlagPresetInstance();

--- a/MOD.Scripts.UI/MODMenuNormal.cs
+++ b/MOD.Scripts.UI/MODMenuNormal.cs
@@ -35,6 +35,7 @@ namespace MOD.Scripts.UI
 		private readonly MODRadio radioTextWindowModeAndCrop;
 		private readonly MODRadio radioForceComputedLipsync;
 		private readonly MODRadio radioRyukishiExperimentalAspect;
+		private readonly MODRadio radioRyukishiExperimentalAspectScalingMode;
 
 		private readonly MODTabControl tabControl;
 
@@ -143,6 +144,12 @@ namespace MOD.Scripts.UI
 			radioRyukishiExperimentalAspect = new MODRadio(Loc.MODMenuNormal_66, new GUIContent[]{ //Original/Ryukishi Experimental 4:3 Aspect Ratio
 				new GUIContent(Loc.MODMenuNormal_67, Loc.MODMenuNormal_68), //16:9 (default) | The game's aspect ratio will be 16:9.\n\nWhen playing in OG mode, the left and right of the screen will be padded to 4:3 with black bars.
 				new GUIContent("4:3", Loc.MODMenuNormal_69 //The game's aspect ratio will be 4:3, however this may cause some issues when playing our mod.\nOnly use this option if your monitor is 4:3 aspect ratio, like an old CRT monitor.\n\nPlease note the following:\n\n - You should enable the Original/Ryukishi preset before enabling this option. Using other settings should all work, but are not well tested.\n\n - 16:9 images will be squished to fit in 4:3 so they don't get cut off. This includes text images, and PS3 CG images if enabled.\n\n - You may see graphical artifacts just after this is enabled - they should fix after the next character transition or text clear\n\n
+				),
+			});
+
+			radioRyukishiExperimentalAspectScalingMode = new MODRadio(Loc.MODMenu43CGScalingModeTitle, new GUIContent[]{
+				new GUIContent(Loc.MODMenu43CGScalingModeStretchName, Loc.MODMenu43CGScalingModeStretchDescription),
+				new GUIContent(Loc.MODMenu43CGScalingModeLetterBoxName, Loc.MODMenu43CGScalingModeLetterBoxDescription
 				),
 			});
 
@@ -268,6 +275,12 @@ namespace MOD.Scripts.UI
 			{
 				SetGlobal("GRyukishiMode43Aspect", experimentalAspect);
 				GameSystem.Instance.UpdateAspectRatio();
+				GameSystem.Instance.SceneController.ReloadAllImages();
+			}
+
+			if (this.radioRyukishiExperimentalAspectScalingMode.OnGUIFragment(GetGlobal("GRyukishiMode43CGScalingMode")) is int cgScalingMode)
+			{
+				SetGlobal("GRyukishiMode43CGScalingMode", cgScalingMode);
 				GameSystem.Instance.SceneController.ReloadAllImages();
 			}
 


### PR DESCRIPTION
## PR Description

Previously, when using 4:3 Aspect ratio option, and when Console CGs are enabled, Console CGs would be displayed by stretching to fill the entire screen.

It was discussed on discord whether it could be letter boxed instead, which is added by this PR.

Now, letterboxing is the default, but it can be reverted to stretch via an option. To avoid having too many option, the option is only shown when you have 4:3 aspect + console CGs.

Also of note is what is NOT letterboxed - currently, everything else is not letterboxed. The main thing I'm thinking might also be letterboxed are text images. Here is a list of folders:

- `scene` - Console CGs are currently LETTERBOXED
- `text` - Text is currently STRETCHED
- `tips` - Tips are currently STRETCHED 


I've added a separate function to do the letterboxing, which is partially because of this issue:
https://github.com/07th-mod/higurashi-assembly/issues/141 , to ensure the behavior is consistent across chapters.

## TODO

- [x] Request user playtest one chapter with this enabled
- [x] Check whether other images should also be letterboxed:
    - [x]  `text` folder
    - [x] `tips` folder
    - Report from playtester: "the "text" images, as in the poem at the beggining of the chapter and the like, are pretty much unnoticable in terms of stretching, because it's just text so it's generally harder to tell if it's stretched or actually supposed to be like that, same goes for the tips." - given this, perhaps don't need to fix?
- [x] Check whether videos are properly letterboxed in this mode
    - Report from playtester "the opening videos aren't letterboxed and still stretched, but otherwise work fine." - really should fix this, I think videos should always maintain aspect ratio. 
- [x] Add "crop to fit" option, with disclaimer that cropping is automatic (just takes the center part of the CG), thus important parts of the CG might be cut-off
