### PR TITLE
Fix globals not saved when game crashes or is forcibly closed

### DIFF
--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -35,6 +35,8 @@ namespace Assets.Scripts.Core.Buriko
 
 		private int scopeLevel;
 
+		private bool globalFlagsNeedSaving;
+
 		public static BurikoMemory Instance
 		{
 			get;
@@ -228,6 +230,7 @@ namespace Assets.Scripts.Core.Buriko
 
 		public void SetGlobalFlag(int key, int val)
 		{
+			globalFlagsNeedSaving = true;
 			if (!globalFlags.ContainsKey(key))
 			{
 				globalFlags.Add(key, val);
@@ -620,6 +623,15 @@ namespace Assets.Scripts.Core.Buriko
 			byte[] array = CLZF2.Compress(inputBytes);
 			MGHelper.KeyEncode(array);
 			MODUtilityNoDeps.WriteAllBytesSemiAtomic(Path.Combine(MGHelper.GetSavePath(), "global.dat"), array);
+		}
+
+		public void SaveGlobalsIfRequired()
+		{
+			if(globalFlagsNeedSaving)
+			{
+				globalFlagsNeedSaving = false;
+				SaveGlobals();
+			}
 		}
 
 		/// <summary>

--- a/Assets.Scripts.Core.Buriko/BurikoMemory.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoMemory.cs
@@ -230,13 +230,17 @@ namespace Assets.Scripts.Core.Buriko
 
 		public void SetGlobalFlag(int key, int val)
 		{
-			globalFlagsNeedSaving = true;
 			if (!globalFlags.ContainsKey(key))
 			{
 				globalFlags.Add(key, val);
 			}
 			else
 			{
+				if(globalFlags[key] != val)
+				{
+					globalFlagsNeedSaving = true;
+				}
+
 				globalFlags[key] = val;
 			}
 		}

--- a/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
+++ b/Assets.Scripts.Core.Buriko/BurikoScriptSystem.cs
@@ -80,6 +80,9 @@ namespace Assets.Scripts.Core.Buriko
 		{
 			AssetManager.Instance.OnScriptJumpOrCall();
 
+			// Save globals when jumping to a new script
+			BurikoMemory.Instance.SaveGlobalsIfRequired();
+
 			Logger.Log((currentScript == null) ? $"Starting at script {scriptname} (block {blockname})" : $"Jumping from script {currentScript.Filename} to script {scriptname} (block {blockname})");
 			callStack.Clear();
 			scriptname = scriptname.ToLower();
@@ -98,6 +101,9 @@ namespace Assets.Scripts.Core.Buriko
 		public void CallScript(string scriptname, string blockname = "main")
 		{
 			AssetManager.Instance.OnScriptJumpOrCall();
+
+			// Save globals before calling a new script
+			BurikoMemory.Instance.SaveGlobalsIfRequired();
 
 			if(scriptname == "flow")
 			{
@@ -121,6 +127,10 @@ namespace Assets.Scripts.Core.Buriko
 
 		public void Return()
 		{
+			// Save globals when returning from a script
+			// This typically happens when you finish a day of the game
+			BurikoMemory.Instance.SaveGlobalsIfRequired();
+
 			if (callStack.Count <= 0)
 			{
 				throw new Exception("Could not return from script, as the script is currently at the bottom of the call stack.");

--- a/MOD.Scripts.UI/MODMenu.cs
+++ b/MOD.Scripts.UI/MODMenu.cs
@@ -556,6 +556,14 @@ namespace MOD.Scripts.UI
 			this.visible = false;
 			gameSystem.SetMODIgnoreInputs(false);
 			gameSystem.ShowUIControls();
+
+			// Save globals if required when closing any mod menu
+			// Make sure that the game is working correctly (reached flow.txt) as we don't want to
+			// save globals if the game has a serious error.
+			if (BurikoScriptSystem.Instance != null && BurikoScriptSystem.Instance.FlowWasReached)
+			{
+				BurikoMemory.Instance.SaveGlobalsIfRequired();
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
For more details, see:
- #136 

----

This PR fixes cases where global flags are not saved, which can cause various strange issues like:
 - your preferences not being saved
 - unlocks disappearing (like tips)
 - achievements not unlocking

Previously I added saving globals when you save the game, which does fix many issues, but there are cases where you may unlock something, or change a setting, and not save the game. This particularly affects Steam Deck as it is easy to force close the game unintentionally via the SteamOS UI.

### Changes Made

The following changes were made

There is now a check to save globals **if they have changed** at the following times:
    - When Jumping to, Calling, or Returning from a script
    - When leaving any mod menu (F10 menu, but also first time setup menus like the audio setup menu)

If no globals have changed, then nothing is done (no files are written).

### Possible additional changes to make

In earlier commits 01c67aee93b0c03bc970833830ac6d8cd2bf872a and fc6c8f59da958382534c31603b741f7c70d40432, 'kind of' atomic writing of save files was added, but I didn't add logic to 'restore' the global file, in case the game or PC crashes just when the save file is being moved.

Admittedly this is unlikely, but the risk is increased after this PR is added, because global saves occur more often.